### PR TITLE
fix(docLoader): handle exception from kvstore and log error message

### DIFF
--- a/src/runtime/docloader.ts
+++ b/src/runtime/docloader.ts
@@ -495,10 +495,25 @@ export function kvCache(
     const match = matchRule(url);
     if (match == null) return await loader(url);
     const key: KvKey = [...keyPrefix, url];
-    const cache = await kv.get<RemoteDocument>(key);
+    let cache: RemoteDocument | undefined = undefined;
+    try {
+      cache = await kv.get<RemoteDocument>(key);
+    } catch (err) {
+      if (err instanceof Error) {
+        logger.warn(`Failed to get value from kv cache.`);
+        logger.error(err.message);
+      }
+    }
     if (cache == null) {
       const remoteDoc = await loader(url);
-      await kv.set(key, remoteDoc, { ttl: match });
+      try {
+        await kv.set(key, remoteDoc, { ttl: match });
+      } catch (err) {
+        if (err instanceof Error) {
+          logger.warn(`Failed to get value from kv cache.`);
+          logger.error(err.message);
+        }
+      }
       return remoteDoc;
     }
     return cache;


### PR DESCRIPTION
In case of an exception when writing or reading from kvStore, fedify logs the below error, which is confusing and not helpful for the developers.

```
jsonld.InvalidUrl: Dereferencing a URL did not result in a valid JSON-LD
object. Possible causes are a
n inaccessible URL perhaps due to a same-origin policy (ensure the
server uses CORS if you are using client-side JavaScript), too many
redirects, a non-JSON response, or more than one HTTP Link Header was
provided for a remote context.
URL: "https://w3id.org/security/multikey/v1".
```

So, this patch tries to handle the exception from kvStore and log the error message.

### Steps to reproduce the problem

* Use `@fedify/postgres` as kvStore.
* Configure invalid database url.
* Try `curl  -H"Accept: application/activity+json" http://localhost:3000/users/demo`

Sample logs after the handling the exception.

![image](https://github.com/user-attachments/assets/dcd8f449-e54f-40ed-bace-62054ce93c10)

