### PR TITLE
Update fedify CLI init to use @fedify/express ^0.2.1

### DIFF
--- a/cli/init.ts
+++ b/cli/init.ts
@@ -306,7 +306,7 @@ Then, try look up an actor from your server:
     init: (projectName, runtime, pm) => ({
       dependencies: {
         express: "^4.19.2",
-        "@fedify/express": "^0.1.3",
+        "@fedify/express": "^0.2.1",
         ...(runtime === "node"
           ? {
             "@dotenvx/dotenvx": "^1.14.1",


### PR DESCRIPTION
This is necessary for fixing #230 as the new version exceeds the semver range of ^0.1.3

https://jubianchi.github.io/semver-check/#/^0.1.3/0.2.1

So 0.2.1 isn't being automatically installed.