### PR TITLE
Migrate tests from deno-mock-fetch to fetch-mock

### DIFF
--- a/fedify/deno.json
+++ b/fedify/deno.json
@@ -21,7 +21,6 @@
     "@cfworker/json-schema": "npm:@cfworker/json-schema@^4.1.1",
     "@cloudflare/workers-types": "npm:@cloudflare/workers-types@^4.20250529.0",
     "@es-toolkit/es-toolkit": "jsr:@es-toolkit/es-toolkit@^1.38.0",
-    "@hongminhee/deno-mock-fetch": "jsr:@hongminhee/deno-mock-fetch@^0.3.2",
     "@hugoalh/http-header-link": "jsr:@hugoalh/http-header-link@^1.0.2",
     "@multiformats/base-x": "npm:@multiformats/base-x@^4.0.1",
     "@opentelemetry/api": "npm:@opentelemetry/api@^1.9.0",

--- a/fedify/package.json
+++ b/fedify/package.json
@@ -104,7 +104,6 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250529.0",
-    "@hongminhee/deno-mock-fetch": "jsr:^0.3.2",
     "@std/assert": "jsr:^0.226.0",
     "@std/path": "jsr:^1.0.9",
     "@std/url": "jsr:1.0.0-rc.3",


### PR DESCRIPTION
Replace *@hongminhee/deno-mock-fetch* with *fetch-mock* across test files for improved compatibility and standardization. Updates test mocking patterns in nodeinfo, runtime, sig, vocab, and webfinger modules.