### PR TITLE
`MessageQueue.nativeRetrial` property

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,20 @@ Version 1.7.0
 
 To be released.
 
+ -  Added optional `MessageQueue.nativeRetrial` property to indicate whether
+    the message queue backend provides native retry mechanisms.  When `true`,
+    Fedify will skip its own retry logic and rely on the backend to handle
+    retries.  When `false` or omitted, Fedify will handle retries using its
+    own retry policies.  [[#250], [#251]]
+
+     -  `DenoKvMessageQueue.nativeRetrial` is `true`.
+     -  `WorkersMessageQueue.nativeRetrial` is `true`.
+     -  `InProcessMessageQueue.nativeRetrial` is `false`.
+     -  `ParallelMessageQueue.nativeRetrial` inherits from the wrapped queue.
+
+[#250]: https://github.com/fedify-dev/fedify/issues/250
+[#251]: https://github.com/fedify-dev/fedify/pull/251
+
 
 Version 1.6.1
 -------------

--- a/docs/manual/federation.md
+++ b/docs/manual/federation.md
@@ -324,6 +324,11 @@ satisfies the `RetryPolicy` type.  Or you can adjust the parameters of
 the `createExponentialBackoffRetryPolicy()` function, which is a default
 implementation of the retry policy.
 
+> [!NOTE]
+> This policy is ignored when using message queue backends that provide native
+> retry mechanisms (`MessageQueue.nativeRetrial` is `true`).  In such cases,
+> the backend's native retry logic takes precedence.
+
 ### `inboxRetryPolicy`
 
 *This API is available since Fedify 0.12.0.*
@@ -337,6 +342,11 @@ In the same way as the `outboxRetryPolicy` option, you can fully customize
 the retry policy by providing a custom function that satisfies the `RetryPolicy`
 type.  Or you can adjust the parameters of the built-in
 `createExponentialBackoffRetryPolicy()` function.
+
+> [!NOTE]
+> This policy is ignored when using message queue backends that provide native
+> retry mechanisms (`MessageQueue.nativeRetrial` is `true`).  In such cases,
+> the backend's native retry logic takes precedence.
 
 ### `activityTransformers`
 

--- a/docs/manual/inbox.md
+++ b/docs/manual/inbox.md
@@ -355,10 +355,15 @@ in production environments to prevent the server from being overwhelmed by
 incoming activities.
 
 With the `queue` enabled, the failed activities are automatically retried
-after a certain period of time.  The default retry strategy is exponential
-backoff with a maximum of 10 retries, but you can customize it by providing
-an [`inboxRetryPolicy`](./federation.md#inboxretrypolicy) option to
-the `createFederation()` function.
+after a certain period of time.  By default, Fedify handles retries using
+exponential backoff with a maximum of 10 retries, but you can customize it
+by providing an [`inboxRetryPolicy`](./federation.md#inboxretrypolicy) option
+to the `createFederation()` function.
+
+However, if your message queue backend provides native retry mechanisms
+(indicated by `MessageQueue.nativeRetrial` being `true`), Fedify will skip
+its own retry logic and rely on the backend to handle retries.  This avoids
+duplicate retry mechanisms and leverages the backend's optimized retry features.
 
 > [!NOTE]
 > Activities with invalid signatures/proofs are silently ignored and not queued.

--- a/docs/manual/send.md
+++ b/docs/manual/send.md
@@ -393,10 +393,15 @@ const federation = createFederation({
 > For further information, see the [*Message queue* section](./mq.md).
 
 The failed activities are automatically retried after a certain period of time.
-The default retry strategy is exponential backoff with a maximum of 10 retries,
-but you can customize it by providing
+By default, Fedify handles retries using exponential backoff with a maximum of
+10 retries, but you can customize it by providing
 an [`outboxRetryPolicy`](./federation.md#outboxretrypolicy) option to
 the `createFederation()` function.
+
+However, if your message queue backend provides native retry mechanisms
+(indicated by `MessageQueue.nativeRetrial` being `true`), Fedify will skip
+its own retry logic and rely on the backend to handle retries.  This avoids
+duplicate retry mechanisms and leverages the backend's optimized retry features.
 
 If the `queue` is not set, the `~Context.sendActivity()` method immediately
 sends the activity to the recipient's inbox.  If the delivery fails, it throws

--- a/docs/package.json
+++ b/docs/package.json
@@ -4,7 +4,7 @@
     "@cloudflare/workers-types": "4.20250529.0",
     "@deno/kv": "^0.8.4",
     "@fedify/amqp": "^0.2.0",
-    "@fedify/fedify": "1.6.1-pr.242.863",
+    "@fedify/fedify": "1.7.0-pr.251.885",
     "@fedify/postgres": "^0.3.0",
     "@fedify/redis": "^0.4.0",
     "@hono/node-server": "^1.13.7",

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -21,8 +21,8 @@ importers:
         specifier: ^0.2.0
         version: 0.2.0(web-streams-polyfill@3.3.3)
       '@fedify/fedify':
-        specifier: 1.6.1-pr.242.863
-        version: 1.6.1-pr.242.863(web-streams-polyfill@3.3.3)
+        specifier: 1.7.0-pr.251.885
+        version: 1.7.0-pr.251.885(web-streams-polyfill@3.3.3)
       '@fedify/postgres':
         specifier: ^0.3.0
         version: 0.3.0(web-streams-polyfill@3.3.3)
@@ -460,8 +460,8 @@ packages:
     resolution: {integrity: sha512-s4ev+HMu6TNH1/RMNvIGvyn17D2dahq8Fpn/aDuBBngi0rHuOodZsoOnQMvEl9MoU0isv9GhPq5BP8oPYSmGaw==}
     engines: {bun: '>=1.1.0', deno: '>=2.0.0', node: '>=20.0.0'}
 
-  '@fedify/fedify@1.6.1-pr.242.863':
-    resolution: {integrity: sha512-NyjF5dUSLPiCXqe6yHMf9cdrNRv/LiWkB7mYtophRWfkHNoawSi2TsPfbBruvxH03+CyApOO22S0l7bSAgZPDg==}
+  '@fedify/fedify@1.7.0-pr.251.885':
+    resolution: {integrity: sha512-GAUJfNmgsSuMO1d9HvgtwxcdEFBHtC9B7jqDavssqUjzvrlyWvIRUePjq2VLHtuDsjl5WIETIQo+gztdUT4YTg==}
     engines: {bun: '>=1.1.0', deno: '>=2.0.0', node: '>=22.0.0'}
 
   '@fedify/postgres@0.3.0':
@@ -534,6 +534,9 @@ packages:
 
   '@logtape/logtape@0.10.0':
     resolution: {integrity: sha512-zk8YILUU7TACEDPaI7sPO6Jyxj6+gwXeS82/ANAtIs3oyLqbUp1kzi5RWUjRj7yu8R7Hd0C4cX4fmfOo9S7COA==}
+
+  '@logtape/logtape@0.11.0':
+    resolution: {integrity: sha512-CV14Jf+gXCdgICvMZbkUOrVPJ2eBuLFaacEYJ3vI6ohv6n2mVepakxTfuZNhtWYVeIB1EblRRQNkFs/n5vFYqA==}
 
   '@logtape/logtape@0.8.2':
     resolution: {integrity: sha512-KikaMHi64p0BHYrYOE2Lom4dOE3R8PGT+21QJ5Ql/SWy0CNOp69dkAlG9RXzENQ6PAMWtiU+4kelJYNvfUvHOQ==}
@@ -3009,13 +3012,13 @@ snapshots:
     transitivePeerDependencies:
       - web-streams-polyfill
 
-  '@fedify/fedify@1.6.1-pr.242.863(web-streams-polyfill@3.3.3)':
+  '@fedify/fedify@1.7.0-pr.251.885(web-streams-polyfill@3.3.3)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
       '@es-toolkit/es-toolkit': es-toolkit@1.38.0
       '@hugoalh/http-header-link': 1.0.3
       '@js-temporal/polyfill': 0.5.1
-      '@logtape/logtape': 0.10.0
+      '@logtape/logtape': 0.11.0
       '@multiformats/base-x': 4.0.1
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/semantic-conventions': 1.34.0
@@ -3128,6 +3131,8 @@ snapshots:
       '@logtape/logtape': 0.10.0
 
   '@logtape/logtape@0.10.0': {}
+
+  '@logtape/logtape@0.11.0': {}
 
   '@logtape/logtape@0.8.2': {}
 

--- a/fedify/federation/mq.ts
+++ b/fedify/federation/mq.ts
@@ -33,6 +33,17 @@ export interface MessageQueueListenOptions {
  */
 export interface MessageQueue {
   /**
+   * Whether the message queue backend provides native retry mechanisms.
+   * When `true`, Fedify will skip its own retry logic and rely on the backend
+   * to handle retries. When `false` or omitted, Fedify will handle retries
+   * using its own retry policies.
+   *
+   * @default `false`
+   * @since 1.7.0
+   */
+  readonly nativeRetrial?: boolean;
+
+  /**
    * Enqueues a message in the queue.
    * @param message The message to enqueue.
    * @param options Additional options for enqueuing the message.
@@ -89,6 +100,12 @@ export class InProcessMessageQueue implements MessageQueue {
   #messages: any[];
   #monitors: Record<ReturnType<typeof crypto.randomUUID>, () => void>;
   #pollIntervalMs: number;
+
+  /**
+   * In-process message queue does not provide native retry mechanisms.
+   * @since 1.7.0
+   */
+  readonly nativeRetrial = false;
 
   /**
    * Constructs a new {@link InProcessMessageQueue} with the given options.
@@ -198,6 +215,12 @@ export class ParallelMessageQueue implements MessageQueue {
   readonly workers: number;
 
   /**
+   * Inherits the native retry capability from the wrapped queue.
+   * @since 1.7.0
+   */
+  readonly nativeRetrial?: boolean;
+
+  /**
    * Constructs a new {@link ParallelMessageQueue} with the given queue and
    * number of workers.
    * @param queue The message queue to use under the hood.  Note that
@@ -212,6 +235,7 @@ export class ParallelMessageQueue implements MessageQueue {
     }
     this.queue = queue;
     this.workers = workers;
+    this.nativeRetrial = queue.nativeRetrial;
   }
 
   enqueue(message: any, options?: MessageQueueEnqueueOptions): Promise<void> {

--- a/fedify/x/cfworkers.ts
+++ b/fedify/x/cfworkers.ts
@@ -93,6 +93,13 @@ export class WorkersKvStore implements KvStore {
 export class WorkersMessageQueue implements MessageQueue {
   #queue: Queue;
 
+  /**
+   * Cloudflare Queues provide automatic retry with exponential backoff
+   * and Dead Letter Queues.
+   * @since 1.7.0
+   */
+  readonly nativeRetrial = true;
+
   constructor(queue: Queue) {
     this.#queue = queue;
   }

--- a/fedify/x/denokv.ts
+++ b/fedify/x/denokv.ts
@@ -71,6 +71,12 @@ export class DenoKvMessageQueue implements MessageQueue, Disposable {
   #kv: Deno.Kv;
 
   /**
+   * Deno KV queues provide automatic retry with exponential backoff.
+   * @since 1.7.0
+   */
+  readonly nativeRetrial = true;
+
+  /**
    * Constructs a new {@link DenoKvMessageQueue} adapter with the given Deno KV
    * store.
    * @param kv The Deno KV store to use.


### PR DESCRIPTION
## Summary

Adds optional `MessageQueue.nativeRetrial` property to indicate whether the message queue backend provides native retry mechanisms. When `true`, Fedify skips its own retry logic and relies on the backend to handle retries.

## Changes

- `DenoKvMessageQueue.nativeRetrial` is `true`
- `WorkersMessageQueue.nativeRetrial` is `true`  
- `InProcessMessageQueue.nativeRetrial` is `false`
- `ParallelMessageQueue.nativeRetrial` inherits from wrapped queue

## Test plan

- [x] Unit tests for all queue implementations
- [x] Integration tests for middleware behavior
- [x] All existing tests pass

Fixes #250