### PR TITLE
Support configuring default HTTP signature spec

### DIFF
--- a/fedify/federation/federation.ts
+++ b/fedify/federation/federation.ts
@@ -6,6 +6,7 @@ import type {
   DocumentLoaderFactory,
   GetUserAgentOptions,
 } from "../runtime/docloader.ts";
+import type { HttpMessageSignaturesSpec } from "../sig/http.ts";
 import type { Actor, Recipient } from "../vocab/actor.ts";
 import type { Activity, Hashtag, Object } from "../vocab/vocab.ts";
 import type {
@@ -677,6 +678,8 @@ export interface FederationOptions<TContextData> {
    * @since 0.13.0
    */
   skipSignatureVerification?: boolean;
+
+  defaultHttpMessageSignaturesSpec?: HttpMessageSignaturesSpec;
 
   /**
    * The retry policy for sending activities to recipients' inboxes.

--- a/fedify/federation/middleware.ts
+++ b/fedify/federation/middleware.ts
@@ -400,7 +400,8 @@ export class FederationImpl<TContextData>
     this.activityTransformers = options.activityTransformers ??
       getDefaultActivityTransformers<TContextData>();
     this.tracerProvider = options.tracerProvider ?? trace.getTracerProvider();
-    this.defaultHttpMessageSignaturesSpec = options.defaultHttpMessageSignaturesSpec;
+    this.defaultHttpMessageSignaturesSpec =
+      options.defaultHttpMessageSignaturesSpec;
   }
 
   _initializeRouter() {

--- a/fedify/federation/middleware.ts
+++ b/fedify/federation/middleware.ts
@@ -231,6 +231,7 @@ export class FederationImpl<TContextData>
   inboxRetryPolicy: RetryPolicy;
   activityTransformers: readonly ActivityTransformer<TContextData>[];
   tracerProvider: TracerProvider;
+  defaultHttpMessageSignaturesSpec?: HttpMessageSignaturesSpec;
 
   constructor(options: FederationOptions<TContextData>) {
     super();
@@ -384,6 +385,7 @@ export class FederationImpl<TContextData>
             specDeterminer: new KvSpecDeterminer(
               this.kv,
               this.kvPrefixes.httpMessageSignaturesSpec,
+              options.defaultHttpMessageSignaturesSpec,
             ),
             tracerProvider: this.tracerProvider,
           }));
@@ -398,6 +400,7 @@ export class FederationImpl<TContextData>
     this.activityTransformers = options.activityTransformers ??
       getDefaultActivityTransformers<TContextData>();
     this.tracerProvider = options.tracerProvider ?? trace.getTracerProvider();
+    this.defaultHttpMessageSignaturesSpec = options.defaultHttpMessageSignaturesSpec;
   }
 
   _initializeRouter() {
@@ -643,6 +646,7 @@ export class FederationImpl<TContextData>
         specDeterminer: new KvSpecDeterminer(
           this.kv,
           this.kvPrefixes.httpMessageSignaturesSpec,
+          this.defaultHttpMessageSignaturesSpec,
         ),
         tracerProvider: this.tracerProvider,
       });
@@ -1097,6 +1101,7 @@ export class FederationImpl<TContextData>
             specDeterminer: new KvSpecDeterminer(
               this.kv,
               this.kvPrefixes.httpMessageSignaturesSpec,
+              this.defaultHttpMessageSignaturesSpec,
             ),
             tracerProvider: this.tracerProvider,
           }),
@@ -2839,6 +2844,7 @@ export class InboxContextImpl<TContextData> extends ContextImpl<TContextData>
             specDeterminer: new KvSpecDeterminer(
               this.federation.kv,
               this.federation.kvPrefixes.httpMessageSignaturesSpec,
+              this.federation.defaultHttpMessageSignaturesSpec,
             ),
           }),
         );


### PR DESCRIPTION
no-issue

We're currently running into problems with other servers implementation of the new RFC 9421 signatures, which breaks interacting with them. This change allows us to default to the original cavage signatures to maintain compatibility.