### PR TITLE
Fix broken links

### DIFF
--- a/docs/manual/federation.md
+++ b/docs/manual/federation.md
@@ -410,7 +410,7 @@ to use the default tracer provider (i.e., [`trace.getTracerProvider()`]).
 
 For more information, see the [*OpenTelemetry* section](./opentelemetry.md).
 
-[`trace.getTracerProvider()`]: https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_api.TraceAPI.html#getTracerProvider
+[`trace.getTracerProvider()`]: https://open-telemetry.github.io/opentelemetry-js/classes/_opentelemetry_api._opentelemetry_api.TraceAPI.html#gettracerprovider
 
 
 Builder pattern for structuring

--- a/docs/manual/opentelemetry.md
+++ b/docs/manual/opentelemetry.md
@@ -138,7 +138,7 @@ const federation = createFederation<void>({
 > For more information about the Sentry SDK's OpenTelemetry integration, please
 > refer to the [*OpenTelemetry Support* section] in the Sentry SDK docs.
 
-[`TracerProvider`]: https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api.TracerProvider.html
+[`TracerProvider`]: https://open-telemetry.github.io/opentelemetry-js/interfaces/_opentelemetry_api._opentelemetry_api.TracerProvider.html
 [Sentry]: https://sentry.io/
 [@sentry/node]: https://npmjs.com/package/@sentry/node
 [@sentry/deno]: https://npmjs.com/package/@sentry/deno

--- a/docs/tutorial/basics.md
+++ b/docs/tutorial/basics.md
@@ -1299,7 +1299,7 @@ You can extend the server by adding more features, such as sending other
 activities, handling other types of activities, and implementing other callback
 functions.  The Fedify framework provides a wide range of features to build
 a federated server, and you can explore them by reading
-the [manual](./manual.md) and the [API reference].
+the [manual](../manual/federation.md) and the [API reference].
 
 If you have any questions or feedback, feel free to ask in
 the [Fedify community] on Matrix or the [Discord server] or
@@ -1326,7 +1326,7 @@ Exercises
     Instead, you can use a web framework like [Hono] or [Fresh] to utilize
     the proper routing system and [JSX] templates to produce HTML.
 
-    See also the [*Integration* section](./manual/integration.md) in
+    See also the [*Integration* section](../manual/integration.md) in
     the manual for more details.
 
 [Hono]: https://hono.dev/

--- a/fedify/README.md
+++ b/fedify/README.md
@@ -105,7 +105,7 @@ Here is the list of packages:
 [jsr:@fedify/amqp]: https://jsr.io/@fedify/amqp
 [npm:@fedify/amqp]: https://www.npmjs.com/package/@fedify/amqp
 [jsr:@fedify/express]: https://jsr.io/@fedify/express
-[npm:@fedify/express]: https://www.npmjs.com/package/@fedify
+[npm:@fedify/express]: https://www.npmjs.com/package/@fedify/express
 [jsr:@fedify/h3]: https://jsr.io/@fedify/h3
 [npm:@fedify/h3]: https://www.npmjs.com/package/@fedify/h3
 [jsr:@fedify/postgres]: https://jsr.io/@fedify/postgres

--- a/postgres/README.md
+++ b/postgres/README.md
@@ -32,8 +32,8 @@ const federation = createFederation({
 [Fedify]: https://fedify.dev/
 [`KvStore`]: https://jsr.io/@fedify/fedify/doc/federation/~/KvStore
 [`MessageQueue`]: https://jsr.io/@fedify/fedify/doc/federation/~/MessageQueue
-[`PostgresKvStore`]: https://jsr.io/@fedify/postgres/doc/federation/~/PostgresKvStore
-[`PostgresMessageQueue`]: https://jsr.io/@fedify/postgres/doc/federation/~/PostgresMessageQueue
+[`PostgresKvStore`]: https://jsr.io/@fedify/postgres/doc/~/PostgresKvStore
+[`PostgresMessageQueue`]: https://jsr.io/@fedify/postgres/doc/~/PostgresMessageQueue
 
 
 Installation


### PR DESCRIPTION
When I run the [`lychee`][lychee] command, I found some several broken links. This pull request fixes them.

But there are some points to hope you check and to let you know:

 - I changed `./manual.md` to `../manual/federation.md` because `manual.md` used to show the list of pages under `manual` when the lines were written. However, since there is no longer a corresponding file in `manual.md`, I have changed the path to the first page, `manual/federation.md`.
   - https://github.com/fedify-dev/fedify/blob/cffe7f44bf0e66fc11d19379e1694c240d58580a/docs/manual.md
 - I've modified the links regarding whether something was changed during the OpenTelemetry documentation generation process. cc https://github.com/open-telemetry/opentelemetry-js/pull/5613
 
[lychee]: https://lychee.cli.rs/

------

<details><summary>`lychee` command I used</summary>
<code>
lychee --max-retries 5 -H "Accept: text/html" --root-dir=`pwd` --exclude='https://fedify-blog.deno.dev/' --exclude='https://[^.]*\.?serveo\.net/' --exclude="amqp.org" --exclude-loopback */**/*.md --exclude=`pwd`/fedify/logo.svg
</code>
</details> 