### PR TITLE
Create `fedify webfinger` command for isolated WebFinger lookups

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,12 +34,25 @@ To be released.
  -  Added `fedify webfinger` command. This command allows users to look up
     WebFinger information for a given resource.
 
-    -  The input can be a handle (e.g., `@user@server`, `user@server`) or
-       a URL (e.g., `https://server/users/path`).
-    -  The `--user-agent` or `-a` option used as `User-Agent` header value
-       in the WebFinger request.
-    -  The `--allow-private-address` or `-p` option allows looking up
-       WebFinger information for private addresses (e.g., `localhost`).
+     -  The input can be a handle (e.g., `@user@server`, `user@server`) or
+        a URL (e.g., `https://server/users/path`).
+     -  The `--user-agent` or `-a` option used as `User-Agent` header value
+        in the WebFinger request.
+     -  The `--allow-private-address` or `-p` option allows looking up
+        WebFinger information for private addresses (e.g., `localhost`).
+
+ -  Added useful functions for Fediverse handles at `@fedify/fedify/vocab`.
+    This functions simplify working with Fediverse handles and URLs.
+    - `FediverseHandle`: An interface representing a Fediverse handle.
+         - `username`: The username part of the handle.
+         - `host`: The host part of the handle.
+    - `parseFediverseHandle`: A function to parse a Fediverse handle into its components.
+         - If the input is a valid Fediverse handle, it returns a `FediverseHandle` object.
+         - Else, it returns `null`.
+     - `isFediverseHandle`: A function to check if a string is a valid Fediverse handle.
+     - `convertFediverseHandle`: A function to convert a Fediverse handle to a URL.
+         - If the input is a valid Fediverse handle, it returns a `URL` object.
+         - Else, it returns `null`.
 
 Version 1.7.2
 -------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,15 @@ To be released.
      -  Added `MemoryKvStore.cas()` method.
      -  Added `DenoKvStore.cas()` method.
 
+ -  Added `fedify webfinger` command. This command allows users to look up
+    WebFinger information for a given resource.
+
+    -  The input can be a handle (e.g., `@user@server`, `user@server`) or
+       a URL (e.g., `https://server/users/path`).
+    -  The `--user-agent` or `-a` option used as `User-Agent` header value
+       in the WebFinger request.
+    -  The `--allow-private-address` or `-p` option allows looking up
+       WebFinger information for private addresses (e.g., `localhost`).
 
 Version 1.7.2
 -------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,18 +41,13 @@ To be released.
      -  The `--allow-private-address` or `-p` option allows looking up
         WebFinger information for private addresses (e.g., `localhost`).
 
- -  Added useful functions for Fediverse handles at `@fedify/fedify/vocab`.
-    This functions simplify working with Fediverse handles and URLs.
-    - `FediverseHandle`: An interface representing a Fediverse handle.
-         - `username`: The username part of the handle.
-         - `host`: The host part of the handle.
-    - `parseFediverseHandle`: A function to parse a Fediverse handle into its components.
-         - If the input is a valid Fediverse handle, it returns a `FediverseHandle` object.
-         - Else, it returns `null`.
-     - `isFediverseHandle`: A function to check if a string is a valid Fediverse handle.
-     - `convertFediverseHandle`: A function to convert a Fediverse handle to a URL.
-         - If the input is a valid Fediverse handle, it returns a `URL` object.
-         - Else, it returns `null`.
+ -  Added useful functions for fediverse handles at `@fedify/fedify/vocab`.  
+    This functions simplify working with fediverse handles and URLs.  
+
+     -  `FediverseHandle`: An interface representing a fediverse handle.  
+     -  `parseFediverseHandle()`: A function to parse a fediverse handle into its components.  
+     - `isFediverseHandle()`: A function to check if a string is a valid fediverse handle.  
+     - `toAcctUrl()`: A function to convert a fediverse handle to a `URL`.  
 
 Version 1.7.2
 -------------

--- a/cli/mod.ts
+++ b/cli/mod.ts
@@ -10,6 +10,7 @@ import { logFile, recordingSink } from "./log.ts";
 import { command as lookup } from "./lookup.ts";
 import { command as node } from "./node.ts";
 import { command as tunnel } from "./tunnel.ts";
+import { command as webfinger } from "./webfinger.ts";
 
 const command = new Command()
   .name("fedify")
@@ -65,7 +66,8 @@ const command = new Command()
   .command("node", node)
   .command("tunnel", tunnel)
   .command("completions", new CompletionsCommand())
-  .command("help", new HelpCommand().global());
+  .command("help", new HelpCommand().global())
+  .command("webfinger", webfinger);
 
 if (import.meta.main) {
   await command.parse(Deno.args);

--- a/cli/mod.ts
+++ b/cli/mod.ts
@@ -66,8 +66,8 @@ const command = new Command()
   .command("node", node)
   .command("tunnel", tunnel)
   .command("completions", new CompletionsCommand())
-  .command("help", new HelpCommand().global())
-  .command("webfinger", webfinger);
+  .command("webfinger", webfinger)
+  .command("help", new HelpCommand().global());
 
 if (import.meta.main) {
   await command.parse(Deno.args);

--- a/cli/webfinger.ts
+++ b/cli/webfinger.ts
@@ -25,10 +25,8 @@ export const command = new Command()
       }).start();
       try {
         const url = convertUrlIfHandle(resource); // Convert resource to URL
-        const webFinger = await lookupWebFinger(url, options); // Look up WebFinger
-        if (webFinger == null) { // If no WebFinger found,
-          throw new NotFoundError(resource); // throw NotFoundError
-        }
+        const webFinger = await lookupWebFinger(url, options) ?? // Look up WebFinger
+          new NotFoundError(resource).throw(); // throw NotFoundError if not found
 
         spinner.succeed(`WebFinger found for ${resource}:`); // Succeed the spinner
         printJson(webFinger); // Print the WebFinger
@@ -71,6 +69,9 @@ class InvalidHandleError extends Error {
     super(`Invalid handle format: ${handle}`);
     this.name = "InvalidHandleError";
   }
+  throw(): never {
+    throw this;
+  }
 }
 
 /**
@@ -82,6 +83,9 @@ class NotFoundError extends Error {
   constructor(public resource: string) {
     super(`Resource not found: ${resource}`);
     this.name = "NotFoundError";
+  }
+  throw(): never {
+    throw this;
   }
 }
 
@@ -98,9 +102,6 @@ class NotFoundError extends Error {
  * ```
  */
 function convertHandleToUrl(handle: string): URL {
-  const url = convertFediverseHandle(handle); // Convert the handle to a URL
-  if (!url) {
-    throw new InvalidHandleError(handle);
-  }
-  return url;
+  return convertFediverseHandle(handle) ??
+    new InvalidHandleError(handle).throw(); // Convert the handle to a URL or throw an error if invalid
 }

--- a/cli/webfinger.ts
+++ b/cli/webfinger.ts
@@ -27,7 +27,7 @@ export const command = new Command()
         const url = convertUrlIfHandle(resource); // Convert resource to URL
         const webFinger = await lookupWebFinger(url, options); // Look up WebFinger
         if (webFinger == null) { // If no WebFinger found,
-          throw new Error(`No WebFinger found for ${resource}`); // throw an error
+          throw new NotFoundError(resource); // throw NotFoundError
         }
 
         spinner.succeed(`WebFinger found for ${resource}:`); // Succeed the spinner
@@ -35,7 +35,9 @@ export const command = new Command()
       } catch (error) {
         if (error instanceof InvalidHandleError) { // If the handle format is invalid,
           spinner.fail(`Invalid handle format: ${error.handle}`); // log error message with handle
-        } else {
+        } else if (error instanceof NotFoundError) { // If the resource is not found,
+          spinner.fail(`Resource not found: ${error.resource}`); // log not found message
+        } else if (error instanceof Error) {
           spinner.fail( // For other errors, log the error message
             `Error looking up WebFinger for ${resource}: ${error}`,
           );
@@ -68,6 +70,18 @@ class InvalidHandleError extends Error {
   constructor(public handle: string) {
     super(`Invalid handle format: ${handle}`);
     this.name = "InvalidHandleError";
+  }
+}
+
+/**
+ * Custom error class for not found resources.
+ * @param resource The resource that was not found.
+ * @extends {Error}
+ */
+class NotFoundError extends Error {
+  constructor(public resource: string) {
+    super(`Resource not found: ${resource}`);
+    this.name = "NotFoundError";
   }
 }
 

--- a/cli/webfinger.ts
+++ b/cli/webfinger.ts
@@ -73,16 +73,12 @@ class InvalidHandleError extends Error {
  * console.log(url.toString()); // "https://domain.com/@username"
  * ```
  */
-function convertHandleToUrl(handle: string): URL {
+function convertHandleToUrl(handle: string): string {
   const match = handle.match(HANDLE_REGEX); // Match the handle format
   if (!match) { // If the handle does not match,
     throw new InvalidHandleError(handle); // throw `Invalid handle format` error
   }
 
   const [, username, domain] = match; // Extract username and domain from the match
-  if (!username || !domain) { // If username or domain is empty,
-    throw new InvalidHandleError(handle); // throw `Invalid handle format` error
-  }
-
-  return new URL(`https://${domain}/@${username}`); // Create a URL object with the domain and username
+  return `acct:${username}@${domain}`;
 }

--- a/cli/webfinger.ts
+++ b/cli/webfinger.ts
@@ -1,5 +1,5 @@
 import { Command } from "@cliffy/command";
-import { handleRegexp } from "@fedify/fedify/vocab";
+import { convertFediverseHandle } from "@fedify/fedify/vocab";
 import { lookupWebFinger } from "@fedify/fedify/webfinger";
 import ora from "ora";
 import { printJson } from "./utils.ts";
@@ -82,12 +82,9 @@ class InvalidHandleError extends Error {
  * ```
  */
 function convertHandleToUrl(handle: string): URL {
-  const match = handle.match(handleRegexp);
-  if (!match) {
+  const url = convertFediverseHandle(handle); // Convert the handle to a URL
+  if (!url) {
     throw new InvalidHandleError(handle);
   }
-
-  const [, username, domain] = match;
-  // Builds a URL like "https://domain.com/@username"
-  return new URL(`https://${domain}/@${username}`);
+  return url;
 }

--- a/cli/webfinger.ts
+++ b/cli/webfinger.ts
@@ -1,5 +1,5 @@
 import { Command } from "@cliffy/command";
-import { convertFediverseHandle } from "@fedify/fedify/vocab";
+import { toAcctUrl } from "@fedify/fedify/vocab";
 import { lookupWebFinger } from "@fedify/fedify/webfinger";
 import ora from "ora";
 import { printJson } from "./utils.ts";
@@ -102,6 +102,6 @@ class NotFoundError extends Error {
  * ```
  */
 function convertHandleToUrl(handle: string): URL {
-  return convertFediverseHandle(handle) ?? // Convert the handle to a URL
+  return toAcctUrl(handle) ?? // Convert the handle to a URL
     new InvalidHandleError(handle).throw(); // or throw an error if invalid
 }

--- a/cli/webfinger.ts
+++ b/cli/webfinger.ts
@@ -1,4 +1,5 @@
 import { Command } from "@cliffy/command";
+import { handleRegexp } from "@fedify/fedify/vocab";
 import { lookupWebFinger } from "@fedify/fedify/webfinger";
 import ora from "ora";
 import { printJson } from "./utils.ts";
@@ -57,14 +58,6 @@ function convertUrlIfHandle(handleOrUrl: string): URL {
 }
 
 /**
- * Regular expression to match a handle in the format `@username@domain`.
- * The username can contain any characters except `@`.
- * The domain must be match with `[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}`.
- */
-const HANDLE_REGEX =
-  /^@?([^@]+)@([-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6})$/;
-
-/**
  * Custom error class for invalid handle formats.
  * @param handle The invalid handle that caused the error.
  * @extends {Error}
@@ -89,7 +82,7 @@ class InvalidHandleError extends Error {
  * ```
  */
 function convertHandleToUrl(handle: string): URL {
-  const match = handle.match(HANDLE_REGEX);
+  const match = handle.match(handleRegexp);
   if (!match) {
     throw new InvalidHandleError(handle);
   }

--- a/cli/webfinger.ts
+++ b/cli/webfinger.ts
@@ -17,26 +17,25 @@ export const command = new Command()
     "Allow private IP addresses in the URL.",
   )
   .action(async (options, handle: string) => {
+    const spinner = ora({ // Create a spinner for the lookup process
+      text: `Looking up WebFinger for ${handle}`,
+      discardStdin: false,
+    }).start();
     try {
       const url = convertHandleToUrl(handle); // Convert handle to URL
-      const spinner = ora({ // Create a spinner for the lookup process
-        text: `Looking up WebFinger for ${handle}`,
-        discardStdin: false,
-      }).start();
       const webFinger = await lookupWebFinger(url, options); // Look up WebFinger
       if (webFinger == null) { // If no WebFinger found,
-        spinner.fail(`No WebFinger found for ${handle}`); // fail the spinner
+        throw new Error(`No WebFinger found for ${handle}`); // throw an error
       }
 
       spinner.succeed(`WebFinger found for ${handle}:`); // Succeed the spinner
       printJson(webFinger); // Print the WebFinger
     } catch (error) {
       if (error instanceof InvalidHandleError) { // If the handle format is invalid,
-        console.error(`Invalid handle format: ${error.handle}`); // log error message with handle
+        spinner.fail(`Invalid handle format: ${error.handle}`); // log error message with handle
       } else {
-        console.error( // For other errors, log the error message
-          `Error looking up WebFinger for ${handle}:`,
-          error,
+        spinner.fail( // For other errors, log the error message
+          `Error looking up WebFinger for ${handle}: ${error}`,
         );
       }
     }

--- a/cli/webfinger.ts
+++ b/cli/webfinger.ts
@@ -61,7 +61,7 @@ function convertUrlIfHandle(handleOrUrl: string): URL {
 
 /**
  * Custom error class for invalid handle formats.
- * @param handle The invalid handle that caused the error.
+ * @param {string} handle The invalid handle that caused the error.
  * @extends {Error}
  */
 class InvalidHandleError extends Error {
@@ -76,7 +76,7 @@ class InvalidHandleError extends Error {
 
 /**
  * Custom error class for not found resources.
- * @param resource The resource that was not found.
+ * @param {string} resource The resource that was not found.
  * @extends {Error}
  */
 class NotFoundError extends Error {
@@ -102,6 +102,6 @@ class NotFoundError extends Error {
  * ```
  */
 function convertHandleToUrl(handle: string): URL {
-  return convertFediverseHandle(handle) ??
-    new InvalidHandleError(handle).throw(); // Convert the handle to a URL or throw an error if invalid
+  return convertFediverseHandle(handle) ?? // Convert the handle to a URL
+    new InvalidHandleError(handle).throw(); // or throw an error if invalid
 }

--- a/cli/webfinger.ts
+++ b/cli/webfinger.ts
@@ -6,7 +6,7 @@ import { printJson } from "./utils.ts";
 export const command = new Command()
   .arguments("<handle:string>")
   .description(
-    "Lookup a WebFinger resource by handle. The argument can be multiple.",
+    "Look up a WebFinger resource by handle. The argument can be multiple.",
   )
   .option(
     "-a, --user-agent <userAgent:string>",
@@ -73,12 +73,13 @@ class InvalidHandleError extends Error {
  * console.log(url.toString()); // "https://domain.com/@username"
  * ```
  */
-function convertHandleToUrl(handle: string): string {
-  const match = handle.match(HANDLE_REGEX); // Match the handle format
-  if (!match) { // If the handle does not match,
-    throw new InvalidHandleError(handle); // throw `Invalid handle format` error
+function convertHandleToUrl(handle: string): URL {
+  const match = handle.match(HANDLE_REGEX);
+  if (!match) {
+    throw new InvalidHandleError(handle);
   }
 
-  const [, username, domain] = match; // Extract username and domain from the match
-  return `acct:${username}@${domain}`;
+  const [, username, domain] = match;
+  // Builds a URL like "https://domain.com/@username"
+  return new URL(`https://${domain}/@${username}`);
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1010,6 +1010,90 @@ command.  For example, to use the serveo.net, run the below command:
 fedify tunnel --service serveo.net 3000
 ~~~~
 
+`fedify webfinger`: Looking up a WebFinger resource
+-----------------------------------------------------
+
+*This command is available since Fedify 1.8.0.*
+
+The `fedify webfinger` command is used to look up a WebFinger resource by
+resource URI or handle.  [WebFinger] is a protocol that allows discovery of
+information about people and other entities on the Internet using simple web
+requests.  This command is useful for debugging and testing WebFinger
+implementations.
+
+To look up a WebFinger resource, for example, for a user handle, run the
+below command:
+
+~~~~ sh
+fedify webfinger @username@domain.com
+~~~~
+
+The output will be like the below:
+
+~~~~ json
+{
+  "subject": "acct:username@domain.com",
+  "aliases": [
+    "https://domain.com/@username",
+    "https://domain.com/users/username"
+  ],
+  "links": [
+    {
+      "rel": "http://webfinger.net/rel/profile-page",
+      "type": "text/html",
+      "href": "https://domain.com/@username"
+    },
+    {
+      "rel": "self",
+      "type": "application/activity+json",
+      "href": "https://domain.com/users/username"
+    }
+  ]
+}
+~~~~
+
+[WebFinger]: https://tools.ietf.org/html/rfc7033
+
+You can also look up a WebFinger resource by its URL.  For example, the below
+command looks up a WebFinger resource by http or acct URL:
+
+~~~~ sh
+fedify webfinger https://domain.com/@username
+fedify webfinger acct:username@domain.com
+~~~~
+
+Or, you can also look up multiple WebFinger resources at once.  For example,
+the below command looks up multiple WebFinger resources:
+
+~~~~ sh
+fedify webfinger @user1@domain.com https://domain.com/@username acct:username@domain.com
+~~~~
+
+The outputs will be displayed sequentially, each preceded by a success message
+indicating which resource was found.
+
+### `-a`/`--user-agent`: Custom `User-Agent` header
+
+By default, the `fedify webfinger` command sends the `User-Agent` header with
+the value `Fedify/1.8.0 (Deno/2.4.0)` (version numbers may vary).  You can
+specify a custom `User-Agent` header by using the `-a`/`--user-agent` option.
+For example, to send the `User-Agent` header with the value `MyApp/1.0`, run
+the below command:
+
+~~~~ sh
+fedify webfinger --user-agent MyApp/1.0 @username@domain.com
+~~~~
+
+### `-p`/`--allow-private-address`: Allow private IP addresses
+
+The `-p`/`--allow-private-address` option is used to allow private IP addresses.
+If you want to allow private IP addresses, run the below command:
+
+~~~~ sh
+fedify webfinger --allow-private-address @username@localhost
+~~~~
+
+Mostly useful for testing purposes.  *Do not use this in production.*
 
 Shell completions
 -----------------

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1011,7 +1011,7 @@ fedify tunnel --service serveo.net 3000
 ~~~~
 
 `fedify webfinger`: Looking up a WebFinger resource
------------------------------------------------------
+---------------------------------------------------
 
 *This command is available since Fedify 1.8.0.*
 

--- a/fedify/vocab/handle.ts
+++ b/fedify/vocab/handle.ts
@@ -10,6 +10,7 @@ const handleRegexp =
  * Represents a fediverse handle, which consists of a username and a host.
  * The username can be alphanumeric and may include special characters,
  * while the host is typically a domain name.
+ * @since 1.8.0
  */
 export interface FediverseHandle {
   /**

--- a/fedify/vocab/handle.ts
+++ b/fedify/vocab/handle.ts
@@ -83,7 +83,7 @@ export function isFediverseHandle(
  * @since 1.8.0
  * @example
  * ```typescript
- * const identifier = convertFediverseHandle("@username@example.com");
+ * const identifier = toAcctUrl("@username@example.com");
  * console.log(identifier?.href); // "acct:username@example.com"
  * ```
  */

--- a/fedify/vocab/handle.ts
+++ b/fedify/vocab/handle.ts
@@ -86,7 +86,7 @@ export function isFediverseHandle(
  * console.log(identifier?.href); // "acct:username@example.com"
  * ```
  */
-export function convertFediverseHandle(handle: string): URL | null {
+export function toAcctUrl(handle: string): URL | null {
   const parsed = parseFediverseHandle(handle);
   if (!parsed) return null;
   const identifier = new URL(`acct:${parsed.username}@${parsed.host}`);

--- a/fedify/vocab/handle.ts
+++ b/fedify/vocab/handle.ts
@@ -1,0 +1,94 @@
+/**
+ * Regular expression to match a fediverse handle in the format `@user@server` or `user@server`.
+ * The `user` part can contain alphanumeric characters and some special characters except `@`.
+ * The `server` part is all characters after the `@` symbol in the middle.
+ */
+const handleRegexp =
+  /^@?((?:[-A-Za-z0-9._~!$&'()*+,;=]|%[A-Fa-f0-9]{2})+)@([^@]+)$/;
+
+/**
+ * Represents a fediverse handle, which consists of a username and a host.
+ * The username can be alphanumeric and may include special characters,
+ * while the host is typically a domain name.
+ */
+export interface FediverseHandle {
+  /**
+   * The username part of the fediverse handle.
+   * It can include alphanumeric characters and some special characters.
+   */
+  readonly username: string;
+  /**
+   * The host part of the fediverse handle, typically a domain name.
+   * It is the part after the `@` symbol in the handle.
+   */
+  readonly host: string;
+}
+
+/**
+ * Parses a fediverse handle in the format `@user@server` or `user@server`.
+ * The `user` part can contain alphanumeric characters and some special characters except `@`.
+ * The `server` part is all characters after the `@` symbol in the middle.
+ *
+ * @param handle - The fediverse handle string to parse.
+ * @returns A {@link FediverseHandle} object with `username` and `host` if the input is valid; otherwise `null`.
+ * @since 1.8.0
+ * @example
+ * ```typescript
+ * const handle = parseFediverseHandle("@username@example.com");
+ * console.log(handle?.username); // "username"
+ * console.log(handle?.host);     // "example.com"
+ * ```
+ */
+export function parseFediverseHandle(
+  handle: string,
+): FediverseHandle | null {
+  const match = handleRegexp.exec(handle);
+  if (match) {
+    return {
+      username: match[1],
+      host: match[2],
+    };
+  }
+  return null;
+}
+
+/**
+ * Checks if a string is a valid fediverse handle in the format `@user@server` or `user@server`.
+ * The `user` part can contain alphanumeric characters and some special characters except `@`.
+ * The `server` part is all characters after the `@` symbol in the middle.
+ *
+ * @param handle - The string to test as a fediverse handle.
+ * @returns `true` if the string matches the fediverse handle pattern; otherwise `false`.
+ * @since 1.8.0
+ * @example
+ * ```typescript
+ * console.log(isFediverseHandle("@username@example.com")); // true
+ * console.log(isFediverseHandle("username@example.com"));  // true
+ * console.log(isFediverseHandle("@username@"));            // false
+ * ```
+ */
+export function isFediverseHandle(
+  handle: string,
+): handle is `${string}@${string}` {
+  return handleRegexp.test(handle);
+}
+
+/**
+ * Converts a fediverse handle in the format `@user@server` or `user@server`
+ * to an `acct:` URI, which is a URL-like identifier for ActivityPub actors.
+ *
+ * @param handle - The fediverse handle string to convert.
+ * @returns A `URL` object representing the `acct:` URI if conversion succeeds; otherwise `null`.
+ * @since 1.8.0
+ * @example
+ * ```typescript
+ * const identifier = convertFediverseHandle("@username@example.com");
+ * console.log(identifier?.href); // "acct:username@example.com"
+ * ```
+ */
+export function convertFediverseHandle(handle: string): URL | null {
+  const parsed = parseFediverseHandle(handle);
+  if (!parsed) return null;
+  const identifier = new URL(`acct:${parsed.username}@${parsed.host}`);
+  return identifier;
+}

--- a/fedify/vocab/lookup.ts
+++ b/fedify/vocab/lookup.ts
@@ -8,7 +8,7 @@ import {
   type GetUserAgentOptions,
 } from "../runtime/docloader.ts";
 import { lookupWebFinger } from "../webfinger/lookup.ts";
-import { convertFediverseHandle } from "./handle.ts";
+import { toAcctUrl } from "./handle.ts";
 import { getTypeId } from "./type.ts";
 import { type Collection, type Link, Object } from "./vocab.ts";
 
@@ -128,7 +128,7 @@ async function lookupObjectInternal(
   const documentLoader = options.documentLoader ??
     getDocumentLoader({ userAgent: options.userAgent });
   if (typeof identifier === "string") {
-    identifier = convertFediverseHandle(identifier) ?? new URL(identifier);
+    identifier = toAcctUrl(identifier) ?? new URL(identifier);
   }
   let document: unknown | null = null;
   if (identifier.protocol === "http:" || identifier.protocol === "https:") {

--- a/fedify/vocab/lookup.ts
+++ b/fedify/vocab/lookup.ts
@@ -52,8 +52,86 @@ export interface LookupObjectOptions {
  * The `user` part can contain alphanumeric characters and some special characters except `@`.
  * The `server` part is all characters after the `@` symbol in the middle.
  */
-export const handleRegexp =
+const handleRegexp =
   /^@?((?:[-A-Za-z0-9._~!$&'()*+,;=]|%[A-Fa-f0-9]{2})+)@([^@]+)$/;
+
+/**
+ * Represents a fediverse handle, which consists of a username and a host.
+ * The username can be alphanumeric and may include special characters,
+ * while the host is typically a domain name.
+ */
+export interface FediverseHandle {
+  /**
+   * The username part of the fediverse handle.
+   * It can include alphanumeric characters and some special characters.
+   */
+  readonly username: string;
+  /**
+   * The host part of the fediverse handle, typically a domain name.
+   * It is the part after the `@` symbol in the handle.
+   */
+  readonly host: string;
+}
+
+/**
+ * Parses a fediverse handle in the format `@user@server` or `user@server`.
+ * The `user` part can contain alphanumeric characters and some special characters except `@`.
+ * The `server` part is all characters after the `@` symbol in the middle.
+ *
+ * @example
+ * ```typescript
+ * const handle = parseFediverseHandle("@username@example.com");
+ * console.log(handle?.username); // "username"
+ * console.log(handle?.host);     // "example.com"
+ * ```
+ */
+export function parseFediverseHandle(
+  handle: string,
+): FediverseHandle | undefined {
+  const match = handleRegexp.exec(handle);
+  if (match) {
+    return {
+      username: match[1],
+      host: match[2],
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Checks if a string is a valid fediverse handle in the format `@user@server` or `user@server`.
+ * The `user` part can contain alphanumeric characters and some special characters except `@`.
+ * The `server` part is all characters after the `@` symbol in the middle.
+ *
+ * @example
+ * ```typescript
+ * console.log(isFediverseHandle("@username@example.com")); // true
+ * console.log(isFediverseHandle("username@example.com"));  // true
+ * console.log(isFediverseHandle("@username@"));             // false
+ * ```
+ */
+export function isFediverseHandle(
+  handle: string,
+): handle is `${string}@${string}` {
+  return handleRegexp.test(handle);
+}
+
+/**
+ * Converts a fediverse handle in the format `@user@server` or `user@server`
+ * to an `acct:` URI, which is a URL-like identifier for ActivityPub actors.
+ *
+ * @example
+ * ```typescript
+ * const identifier = convertFediverseHandle("@username@example.com");
+ * console.log(identifier?.href); // "acct:username@example.com"
+ * ```
+ */
+export function convertFediverseHandle(handle: string): URL | undefined {
+  const parsed = parseFediverseHandle(handle);
+  if (!parsed) return undefined;
+  const identifier = new URL(`acct:${parsed.username}@${parsed.host}`);
+  return identifier;
+}
 
 /**
  * Looks up an ActivityStreams object by its URI (including `acct:` URIs)

--- a/fedify/vocab/lookup.ts
+++ b/fedify/vocab/lookup.ts
@@ -47,7 +47,12 @@ export interface LookupObjectOptions {
   tracerProvider?: TracerProvider;
 }
 
-const handleRegexp =
+/**
+ * Regular expression to match a fediverse handle in the format `@user@server` or `user@server`.
+ * The `user` part can contain alphanumeric characters and some special characters except `@`.
+ * The `server` part is all characters after the `@` symbol in the middle.
+ */
+export const handleRegexp =
   /^@?((?:[-A-Za-z0-9._~!$&'()*+,;=]|%[A-Fa-f0-9]{2})+)@([^@]+)$/;
 
 /**

--- a/fedify/vocab/mod.ts
+++ b/fedify/vocab/mod.ts
@@ -51,6 +51,7 @@
  */
 export * from "./actor.ts";
 export * from "./constants.ts";
+export * from "./handle.ts";
 export * from "./lookup.ts";
 export * from "./type.ts";
 export * from "./vocab.ts";


### PR DESCRIPTION
Implement a new `fedify webfinger <handle>` command to perform isolated WebFinger lookups. This command accepts a `@user@domain` format handle and outputs the WebFinger result in JSON format. It utilizes the existing `lookupWebFinger()` function and handles errors related to invalid handles and lookup failures gracefully. The command is registered in the CLI module system with appropriate help text and usage examples.

- [x]  Create `fedify webfinger <handle>` command
- [x]  Accept `@user@domain` format handles as input
- [x]  Output WebFinger JRD results in JSON format
- [x]  Handle invalid handles and WebFinger lookup failures gracefully
- [x]  Register the command in the CLI module system
- [x]  Add appropriate help text and usage examples