### PR TITLE
fix(cli): Fix `--no-tunnel` option being ignored in fedify inbox command

### DIFF
--- a/cli/inbox.test.ts
+++ b/cli/inbox.test.ts
@@ -1,0 +1,84 @@
+import { assertEquals } from "@std/assert";
+import type { InboxOptions } from "./inbox.tsx";
+
+// mock of the tunnel disabling logic
+function shouldDisableTunnel(options: InboxOptions): boolean {
+  return options.tunnel === false || options.noTunnel === true;
+}
+
+Deno.test("handles --no-tunnel flag correctly", () => {
+  const optionsWithNoTunnel: InboxOptions = {
+    tunnel: false,
+    follow: undefined,
+    acceptFollow: undefined,
+  };
+  assertEquals(
+    shouldDisableTunnel(optionsWithNoTunnel),
+    true,
+    "--no-tunnel flag should disable tunnel",
+  );
+});
+
+Deno.test("set noTunnel true, should handles -T flag correctly", () => {
+  const optionsWithT: InboxOptions = {
+    tunnel: true,
+    noTunnel: true,
+    follow: undefined,
+    acceptFollow: undefined,
+  };
+  assertEquals(
+    shouldDisableTunnel(optionsWithT),
+    true,
+    "-T flag should disable tunnel",
+  );
+});
+
+Deno.test("handles default behavior (no flags)", () => {
+  const optionsDefault: InboxOptions = {
+    tunnel: true,
+    follow: undefined,
+    acceptFollow: undefined,
+  };
+  assertEquals(
+    shouldDisableTunnel(optionsDefault),
+    false,
+    "Default behavior should enable tunnel",
+  );
+});
+
+Deno.test("handles both flags together", () => {
+  const optionsBothFlags: InboxOptions = {
+    tunnel: false,
+    noTunnel: true,
+    follow: undefined,
+    acceptFollow: undefined,
+  };
+  assertEquals(
+    shouldDisableTunnel(optionsBothFlags),
+    true,
+    "Both flags should disable tunnel",
+  );
+});
+
+Deno.test("Various InboxOptions combinations", () => {
+  // Valid option combinations
+  const validOptions: InboxOptions[] = [
+    { tunnel: true },
+    { tunnel: false },
+    { tunnel: true, noTunnel: true },
+    { tunnel: false, noTunnel: false },
+    { tunnel: true, follow: ["@user@example.com"] },
+    { tunnel: true, acceptFollow: ["*"] },
+    { tunnel: true, follow: [], acceptFollow: [] },
+  ];
+
+  // Test that all valid options work with shouldDisableTunnel
+  for (const options of validOptions) {
+    const result = shouldDisableTunnel(options);
+    assertEquals(
+      typeof result,
+      "boolean",
+      "shouldDisableTunnel must return boolean",
+    );
+  }
+});

--- a/cli/inbox.tsx
+++ b/cli/inbox.tsx
@@ -37,6 +37,22 @@ import { spawnTemporaryServer, type TemporaryServer } from "./tempserver.ts";
 
 const logger = getLogger(["fedify", "cli", "inbox"]);
 
+/**
+ * Options for the inbox command.
+ */
+export interface InboxOptions {
+  follow?: string[];
+  acceptFollow?: string[];
+  tunnel: boolean;
+  noTunnel?: boolean; // for -T shorthand support
+}
+
+export const TunnelConfig = {
+  shouldDisableTunnel: (opts: InboxOptions): boolean => {
+    return opts.tunnel === false || opts.noTunnel === true;
+  }
+} as const;
+
 export const command = new Command()
   .description(
     "Spins up an ephemeral server that serves the ActivityPub inbox with " +
@@ -61,13 +77,13 @@ export const command = new Command()
     "-T, --no-tunnel",
     "Do not tunnel the ephemeral ActivityPub server to the public Internet.",
   )
-  .action(async (options) => {
+  .action(async (options: InboxOptions) => {
     const spinner = ora({
       text: "Spinning up an ephemeral ActivityPub server...",
       discardStdin: false,
     }).start();
     const server = await spawnTemporaryServer(fetch, {
-      noTunnel: !options.tunnel,
+      noTunnel: TunnelConfig.shouldDisableTunnel(options),
     });
     spinner.succeed(
       `The ephemeral ActivityPub server is up and running: ${


### PR DESCRIPTION
# Description

This PR fixes issue #243 where the `--no-tunnel` option in the `fedify inbox` command was being ignored, causing the server to always create a public tunnel regardless of the flag.

## Changes

1. Fixed the option checking logic from `!options.tunnel` to `options.tunnel === false || options.noTunnel === true`
2. Added an `InboxOptions` interface
3. Added inbox related tests in `inbox.test.ts` file

## Problem

The `fedify inbox` command spin up an ephemeral ActivityPub server that can either be exposed to the public internet via a tunnel (default behavior) or run locally without tunneling when the `--no-tunnel` (or `-T`) flag is provided. However, as described in original issue, even when using the `--no-tunnel` flag, the server would still create a public HTTPS tunnel and be accessible from the outside.

The problem was the option handling logic of `inbox.tsx`. This was checking `!options.tunnel` to determine whether to disable tunneling.
https://github.com/fedify-dev/fedify/blob/62db879971116fa4fbf71d15dadcdd2335a4f33b/cli/inbox.tsx#L69-L71
However, due to how the [`Cliffy`](https://cliffy.io/) framework handles negated boolean options, this logic was incorrect. When no flag is provided, `options.tunnel` is `undefined`, and `!undefined` evaluates to `true`, which incorrectly disabled tunneling by default. This meant the server would never create a tunnel unless the logic was inverted.

After fix, We can see the `fedify inbox` creates local server as expected:


**With `--no-tunnel` option**

```bash
$ deno task cli inbox --no-tunnel
```

<img width="613" height="278" alt="스크린샷 2025-07-12 오후 10 57 12" src="https://github.com/user-attachments/assets/b0f840c9-9e54-40a6-8c85-bee49bf05ce4" />

**Without `--no-tunnel` option**
<img width="741" height="278" alt="스크린샷 2025-07-12 오후 10 59 46" src="https://github.com/user-attachments/assets/a5377191-2da7-4ac7-83e6-21a610f703d7" />