### PR TITLE
feat(cli): add --actor-name and --actor-summary options to 'fedify inbox' command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,13 @@ To be released.
      -  Added optional `KvStore.cas()` method.
      -  Added `MemoryKvStore.cas()` method.
      -  Added `DenoKvStore.cas()` method.
+  
+ -  Added options to customize the temporary actor information when running
+    `fedify inbox` command.  [[#262] by Hasang Cho]
+
+     -  Added `--actor-name` option to customize the actor display name.
+     -  Added `--actor-summary` option to customize the actor description.
+     -  Both options provide sensible defaults when not specified.
 
  -  Added useful functions for fediverse handles at `@fedify/fedify/vocab`.
     This functions simplify working with fediverse handles and URLs.
@@ -63,6 +70,7 @@ To be released.
 [#168]: https://github.com/fedify-dev/fedify/issues/168
 [#248]: https://github.com/fedify-dev/fedify/issues/248
 [#260]: https://github.com/fedify-dev/fedify/issues/260
+[#262]: https://github.com/fedify-dev/fedify/issues/262
 [#278]: https://github.com/fedify-dev/fedify/pull/278
 [#281]: https://github.com/fedify-dev/fedify/pull/281
 [#282]: https://github.com/fedify-dev/fedify/pull/282

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,7 +32,7 @@ To be released.
      -  Added `DenoKvStore.cas()` method.
   
  -  Added options to customize the temporary actor information when running
-    `fedify inbox` command.  [[#262] by Hasang Cho]
+    `fedify inbox` command.  [[#262], [#285] by Hasang Cho]
 
      -  Added `--actor-name` option to customize the actor display name.
      -  Added `--actor-summary` option to customize the actor description.
@@ -74,6 +74,7 @@ To be released.
 [#278]: https://github.com/fedify-dev/fedify/pull/278
 [#281]: https://github.com/fedify-dev/fedify/pull/281
 [#282]: https://github.com/fedify-dev/fedify/pull/282
+[#285]: https://github.com/fedify-dev/fedify/pull/285
 
 
 Version 1.7.4

--- a/cli/inbox.tsx
+++ b/cli/inbox.tsx
@@ -53,6 +53,11 @@ export const TunnelConfig = {
   },
 } as const;
 
+const actorOptions = {
+  name: "Fedify Ephemeral Inbox",
+  summary: "An ephemeral ActivityPub inbox for testing purposes.",
+};
+
 export const command = new Command()
   .description(
     "Spins up an ephemeral server that serves the ActivityPub inbox with " +
@@ -87,7 +92,10 @@ export const command = new Command()
     "Customize the actor description.",
     { default: "An ephemeral ActivityPub inbox for testing purposes." },
   )
-  .action(async (options: InboxOptions) => {
+  .action(async (options) => {
+    actorOptions.name = options.actorName;
+    actorOptions.summary = options.actorSummary;
+
     const spinner = ora({
       text: "Spinning up an ephemeral ActivityPub server...",
       discardStdin: false,
@@ -168,8 +176,8 @@ federation
     return new Application({
       id: ctx.getActorUri(identifier),
       preferredUsername: identifier,
-      name: "Fedify Ephemeral Inbox",
-      summary: "An ephemeral ActivityPub inbox for testing purposes.",
+      name: actorOptions.name,
+      summary: actorOptions.summary,
       inbox: ctx.getInboxUri(identifier),
       endpoints: new Endpoints({
         sharedInbox: ctx.getInboxUri(),

--- a/cli/inbox.tsx
+++ b/cli/inbox.tsx
@@ -77,6 +77,16 @@ export const command = new Command()
     "-T, --no-tunnel",
     "Do not tunnel the ephemeral ActivityPub server to the public Internet.",
   )
+  .option(
+    "--actor-name=<name:string>",
+    "Customize the actor display name.",
+    { default: "Fedify Ephemeral Inbox" },
+  )
+  .option(
+    "--actor-summary=<summary:string>",
+    "Customize the actor description.",
+    { default: "An ephemeral ActivityPub inbox for testing purposes." },
+  )
   .action(async (options: InboxOptions) => {
     const spinner = ora({
       text: "Spinning up an ephemeral ActivityPub server...",


### PR DESCRIPTION
## Description
closes #262 

## Changes
- Use --actor-name and --actor-summary values in Application object

  - `--actor-name <name>`: Customize actor display name
    - Default: `"Fedify Ephemeral Inbox"`


  - `--actor-summary <summary>`: Customize actor description  
    - Default: `"An ephemeral ActivityPub inbox for testing purposes."`
   

~~- Add actorOptions global object to store custom values~~
- eliminate global state and implement function factory (updated)
- Replace hardcoded actor name and summary with dynamic values


## Checklist
- [X] Add --actor-name <name> option to customize actor display name
- [X] Add --actor-summary <summary> option to customize actor description
- [X] Update the Application object creation to use these custom values
- [X] Provide appropriate default values when options are not specified
- [X] Update command help text to document the new options

## Tests

- Ran `deno task check-all` — all checks passed.
- Executed `deno fmt` — no formatting changes were needed.
- Confirmed that the `--actor-name` and `--actor-summary` options appear in the help output (`deno task cli inbox --help`).  
  ![CLI help screenshot](https://github.com/user-attachments/assets/0bc9b2e2-5201-4165-9806-32e602dae18e)
- Manually tested the new CLI options:
    - Ran:  
      ```
      deno task cli inbox --actor-name "My Test Actor" --actor-summary "A temporary actor for testing"
      ```
    - Accessed the site and verified that the custom actor name and summary are displayed correctly.
    - See screenshot for confirmation:  
      ![Custom actor test screenshot](https://github.com/user-attachments/assets/e3a4a824-43d2-4e48-b80b-ee19a3b1a654)
- Ran `deno task test` and encountered an error.  
  Based on the error message, it appears unrelated to the changes introduced in this PR.  
  ![Test error screenshot](https://github.com/user-attachments/assets/c68073b3-c001-4c11-969c-a445e2220be9)

## Additional Notes
- During testing, I attempted to connect using both lhr.life and serveo.net:
    - The connection was successful with lhr.life.
    - However, I was unable to establish a connection using serveo.net.
    
  
## Update(KST 20250713 1628)
-  Refactored implementation to eliminate global state using function factory pattern for improved code maintainability and following Builder Pattern established in the codebase.

- Ran `deno task check-all` — all checks passed.
- Executed `deno fmt` — no formatting changes were needed.

- Ran `deno task cli inbox`
<img width="1106" height="1206" alt="image" src="https://github.com/user-attachments/assets/c73ad266-ebd8-477c-8402-415dde3ceccb" />

- Ran
      ```
      deno task cli inbox --actor-name "My Test Actor" --actor-summary "A temporary actor for testing"
      ```

<img width="1064" height="1066" alt="image" src="https://github.com/user-attachments/assets/14347f63-2987-48a7-ac28-fb52f4659fa8" />

## Update(KST 20250713 1058)
- Rebased the feature branch onto the latest main to resolve merge conflicts
- Remove hardcoded actorOptions
- Extract ActorOptions interface to reduce inline type duplication in factory functions
- Change action handler to use InboxOptions & ActorOptions intersection type
- Update ContextData and ActorOptions annotation