### PR TITLE
Update docs/README.md to reflect Node.js + pnpm setup

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,17 +4,17 @@ Fedify docs
 This directory contains the source files of the Fedify docs.  The docs are
 written in Markdown format and are built with [VitePress].
 
-In order to build the docs locally, you need to install [Bun]
+In order to build the docs locally, you need to install [pnpm]
 first.  Then you can run the following commands (assuming you are in
 the *docs/* directory):
 
 ~~~~ bash
-bun install
-bun run dev
+npm install
+npm dev
 ~~~~
 
 Once the development server is running, you can open your browser and navigate
 to *http://localhost:5173/* to view the docs.
 
 [VitePress]: https://vitepress.dev/
-[Bun]: https://bun.sh/
+[pnpm]: https://pnpm.io/


### PR DESCRIPTION
Closes #289

This pull request updates the `docs/README.md` file to reflect a change in the package manager used for building the Fedify documentation locally. The instructions now specify using `pnpm` instead of `Bun`.

Documentation updates:

- Updated the build instructions in `docs/README.md` to use `pnpm` (`npm install` and `npm dev`) instead of `Bun` (`bun install` and `bun run dev`)
- Also replaced the reference to the Bun website with a reference to the pnpm website.