### PR TITLE
Fix TypeError: unusable in doubleKnock redirect handling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,13 @@ Version 1.6.6
 
 To be released.
 
+ -  Fixed `TypeError: unusable` error that occurred when `doubleKnock()`
+    encountered redirects during HTTP signature retry attempts.
+    [[#294], [#295]]
+
+[#294]: https://github.com/fedify-dev/fedify/issues/294
+[#295]: https://github.com/fedify-dev/fedify/pull/295
+
 
 Version 1.6.5
 -------------

--- a/fedify/sig/http.ts
+++ b/fedify/sig/http.ts
@@ -1222,6 +1222,33 @@ export interface DoubleKnockOptions {
 }
 
 /**
+ * Helper function to create a new Request for redirect handling.
+ * @param request The original request.
+ * @param location The redirect location.
+ * @param body The request body as ArrayBuffer or undefined.
+ * @returns A new Request object for the redirect.
+ */
+function createRedirectRequest(
+  request: Request,
+  location: string,
+  body: ArrayBuffer | undefined,
+): Request {
+  return new Request(location, {
+    method: request.method,
+    headers: request.headers,
+    body,
+    redirect: "manual",
+    signal: request.signal,
+    mode: request.mode,
+    credentials: request.credentials,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    integrity: request.integrity,
+    keepalive: request.keepalive,
+  });
+}
+
+/**
  * Performs a double-knock request to the given URL.  For the details of
  * double-knocking, see
  * <https://swicg.github.io/activitypub-http-signature/#how-to-upgrade-supported-versions>.
@@ -1264,19 +1291,7 @@ export async function doubleKnock(
       ? await request.clone().arrayBuffer()
       : undefined;
     return doubleKnock(
-      new Request(location, {
-        method: request.method,
-        headers: request.headers,
-        body,
-        redirect: "manual",
-        signal: request.signal,
-        mode: request.mode,
-        credentials: request.credentials,
-        referrer: request.referrer,
-        referrerPolicy: request.referrerPolicy,
-        integrity: request.integrity,
-        keepalive: request.keepalive,
-      }),
+      createRedirectRequest(request, location, body),
       identity,
       options,
     );
@@ -1330,21 +1345,7 @@ export async function doubleKnock(
         ? await request.clone().arrayBuffer()
         : undefined;
       return doubleKnock(
-        new Request(location, {
-          // Explicitly copy all Request properties instead of using destructuring
-          // to ensure proper Request constructor behavior and preserve all properties
-          method: request.method,
-          headers: request.headers,
-          body,
-          redirect: "manual",
-          signal: request.signal,
-          mode: request.mode,
-          credentials: request.credentials,
-          referrer: request.referrer,
-          referrerPolicy: request.referrerPolicy,
-          integrity: request.integrity,
-          keepalive: request.keepalive,
-        }),
+        createRedirectRequest(request, location, body),
         identity,
         options,
       );

--- a/fedify/sig/http.ts
+++ b/fedify/sig/http.ts
@@ -1245,6 +1245,7 @@ function createRedirectRequest(
     referrerPolicy: request.referrerPolicy,
     integrity: request.integrity,
     keepalive: request.keepalive,
+    cache: request.cache,
   });
 }
 


### PR DESCRIPTION
This PR fixes a critical bug in the `doubleKnock()` function where inconsistent request body handling in redirect scenarios caused `TypeError: unusable` errors during HTTP signature retry attempts. The issue occurred when the second redirect path used `request.clone().body` instead of `await request.clone().arrayBuffer()`, leading to body consumption issues that prevented subsequent clone operations from succeeding.

The fix standardizes both redirect handling paths to use `await request.clone().arrayBuffer()` consistently and replaces destructuring with explicit property copying to ensure proper `Request` constructor behavior. This resolves the runtime errors that were being frequently reported in production environments when ActivityPub federation encountered redirects during signature verification retries. A comprehensive regression test has been added to prevent future occurrences of this issue.

Closes #294