### PR TITLE
fix(bug, test): ASCII art tests fail in PR #299

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -78,11 +78,7 @@ To be released.
 
   -  Fixed a bug where the `fedify node` command had failed to correctly
      render the favicon in terminal emulators that do not support 24-bit
-     colors.  [[#168], [#282] by Hyeonseo Kim]
-
-  - Fixed a bug where the getAsciiArt tests failed on terminal emulators with 
-    different color support capabilities. Enhanced color detection to support true 
-    color, 256-color, and non-color environments with appropriate test coverage. [[#304] by Hyeonseo Kim]
+     colors.  [[#168], [#282], [#304] by Hyeonseo Kim]
 
 [#168]: https://github.com/fedify-dev/fedify/issues/168
 [#248]: https://github.com/fedify-dev/fedify/issues/248

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -80,11 +80,16 @@ To be released.
      render the favicon in terminal emulators that do not support 24-bit
      colors.  [[#168], [#282] by Hyeonseo Kim]
 
+  - Fixed a bug where the getAsciiArt tests failed on terminal emulators with 
+    different color support capabilities. Enhanced color detection to support true 
+    color, 256-color, and non-color environments with appropriate test coverage. [[#304] by contributor]
+
 [#168]: https://github.com/fedify-dev/fedify/issues/168
 [#248]: https://github.com/fedify-dev/fedify/issues/248
 [#260]: https://github.com/fedify-dev/fedify/issues/260
 [#262]: https://github.com/fedify-dev/fedify/issues/262
 [#263]: https://github.com/fedify-dev/fedify/issues/263
+[#304]: https://github.com/fedify-dev/fedify/issues/304
 [#278]: https://github.com/fedify-dev/fedify/pull/278
 [#281]: https://github.com/fedify-dev/fedify/pull/281
 [#282]: https://github.com/fedify-dev/fedify/pull/282

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -82,7 +82,7 @@ To be released.
 
   - Fixed a bug where the getAsciiArt tests failed on terminal emulators with 
     different color support capabilities. Enhanced color detection to support true 
-    color, 256-color, and non-color environments with appropriate test coverage. [[#304] by contributor]
+    color, 256-color, and non-color environments with appropriate test coverage. [[#304] by Hyeonseo Kim]
 
 [#168]: https://github.com/fedify-dev/fedify/issues/168
 [#248]: https://github.com/fedify-dev/fedify/issues/248

--- a/cli/node.test.ts
+++ b/cli/node.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "@std/assert";
 import fetchMock from "fetch-mock";
-import { checkTerminalColorSupport, getAsciiArt, getFaviconUrl, Jimp, rgbTo256Color } from "./node.ts";
+import { getAsciiArt, getFaviconUrl, Jimp, rgbTo256Color } from "./node.ts";
 
 const HTML_WITH_SMALL_ICON = `
 <!DOCTYPE html>

--- a/cli/node.test.ts
+++ b/cli/node.test.ts
@@ -1,6 +1,6 @@
 import { assertEquals } from "@std/assert";
 import fetchMock from "fetch-mock";
-import { getAsciiArt, getFaviconUrl, Jimp, rgbTo256Color } from "./node.ts";
+import { checkTerminalColorSupport, getAsciiArt, getFaviconUrl, Jimp, rgbTo256Color } from "./node.ts";
 
 const HTML_WITH_SMALL_ICON = `
 <!DOCTYPE html>
@@ -152,7 +152,7 @@ Deno.test("rgbTo256Color - check grayscale", () => {
   assertEquals(results, expected_gray_idx);
 });
 
-Deno.test("getAsciiArt - Darkest Letter", async () => {
+Deno.test("getAsciiArt - Darkest Letter without color support", async () => {
   // Create black and white 1x1 images using Jimp constructor
   const blackImage = new Jimp({ width: 1, height: 1, color: 0x000000ff });
   const blackImageBuffer = await blackImage.getBuffer("image/webp");
@@ -160,13 +160,13 @@ Deno.test("getAsciiArt - Darkest Letter", async () => {
   const blackResult = getAsciiArt(
     await Jimp.read(blackImageBuffer),
     1,
-    true,
+    "none",
   );
 
   assertEquals(blackResult, "█");
 });
 
-Deno.test("getAsciiArt - Brightest Letter", async () => {
+Deno.test("getAsciiArt - Brightest Letter without color support", async () => {
   // Create black and white 1x1 images using Jimp constructor
   const whiteImage = new Jimp({ width: 1, height: 1, color: 0xffffffff });
   const whiteImageBuffer = await whiteImage.getBuffer("image/webp");
@@ -174,8 +174,64 @@ Deno.test("getAsciiArt - Brightest Letter", async () => {
   const whiteResult = getAsciiArt(
     await Jimp.read(whiteImageBuffer),
     1,
-    true,
+    "none",
   );
 
   assertEquals(whiteResult, " ");
+});
+
+Deno.test("getAsciiArt - Darkest Letter with 256 color support", async () => {
+  // Create black and white 1x1 images using Jimp constructor
+  const blackImage = new Jimp({ width: 1, height: 1, color: 0x000000ff });
+  const blackImageBuffer = await blackImage.getBuffer("image/webp");
+  
+  const blackResult = getAsciiArt(
+    await Jimp.read(blackImageBuffer),
+    1,
+    "256color",
+  );
+
+  assertEquals(blackResult, "\u001b[38;5;16m█\u001b[39m");
+});
+
+Deno.test("getAsciiArt - Brightest Letter with 256 color support", async () => {
+  // Create black and white 1x1 images using Jimp constructor
+  const whiteImage = new Jimp({ width: 1, height: 1, color: 0xffffffff });
+  const whiteImageBuffer = await whiteImage.getBuffer("image/webp");
+
+  const whiteResult = getAsciiArt(
+    await Jimp.read(whiteImageBuffer),
+    1,
+    "256color",
+  );
+
+  assertEquals(whiteResult, "\u001b[38;5;231m \u001b[39m");
+});
+
+Deno.test("getAsciiArt - Darkest Letter with true color support", async () => {
+  // Create black and white 1x1 images using Jimp constructor
+  const blackImage = new Jimp({ width: 1, height: 1, color: 0x000000ff });
+  const blackImageBuffer = await blackImage.getBuffer("image/webp");
+  
+  const blackResult = getAsciiArt(
+    await Jimp.read(blackImageBuffer),
+    1,
+    "truecolor",
+  );
+
+  assertEquals(blackResult, "\u001b[38;2;0;0;0m█\u001b[39m");
+});
+
+Deno.test("getAsciiArt - Brightest Letter with true color support", async () => {
+  // Create black and white 1x1 images using Jimp constructor
+  const whiteImage = new Jimp({ width: 1, height: 1, color: 0xffffffff });
+  const whiteImageBuffer = await whiteImage.getBuffer("image/webp");
+
+  const whiteResult = getAsciiArt(
+    await Jimp.read(whiteImageBuffer),
+    1,
+    "truecolor",
+  );
+
+  assertEquals(whiteResult, "\u001b[38;2;255;255;255m \u001b[39m");
 });

--- a/cli/node.test.ts
+++ b/cli/node.test.ts
@@ -152,13 +152,15 @@ Deno.test("rgbTo256Color - check grayscale", () => {
   assertEquals(results, expected_gray_idx);
 });
 
-Deno.test("getAsciiArt - Darkest Letter without color support", async () => {
-  // Create black and white 1x1 images using Jimp constructor
-  const blackImage = new Jimp({ width: 1, height: 1, color: 0x000000ff });
-  const blackImageBuffer = await blackImage.getBuffer("image/webp");
+async function createTestImage(color: number): Promise<Awaited<ReturnType<typeof Jimp.read>>> {
+  const image = new Jimp({ width: 1, height: 1, color });
+  const imageBuffer = await image.getBuffer("image/webp");
+  return Jimp.read(imageBuffer);
+}
 
+Deno.test("getAsciiArt - Darkest Letter without color support", async () => {
   const blackResult = getAsciiArt(
-    await Jimp.read(blackImageBuffer),
+    await createTestImage(0x000000ff),
     1,
     "none",
   );
@@ -167,12 +169,8 @@ Deno.test("getAsciiArt - Darkest Letter without color support", async () => {
 });
 
 Deno.test("getAsciiArt - Brightest Letter without color support", async () => {
-  // Create black and white 1x1 images using Jimp constructor
-  const whiteImage = new Jimp({ width: 1, height: 1, color: 0xffffffff });
-  const whiteImageBuffer = await whiteImage.getBuffer("image/webp");
-
   const whiteResult = getAsciiArt(
-    await Jimp.read(whiteImageBuffer),
+    await createTestImage(0xffffffff),
     1,
     "none",
   );
@@ -181,56 +179,40 @@ Deno.test("getAsciiArt - Brightest Letter without color support", async () => {
 });
 
 Deno.test("getAsciiArt - Darkest Letter with 256 color support", async () => {
-  // Create black and white 1x1 images using Jimp constructor
-  const blackImage = new Jimp({ width: 1, height: 1, color: 0x000000ff });
-  const blackImageBuffer = await blackImage.getBuffer("image/webp");
-
   const blackResult = getAsciiArt(
-    await Jimp.read(blackImageBuffer),
+    await createTestImage(0x000000ff),
     1,
-    "256color",
+    "none",
   );
 
   assertEquals(blackResult, "\u001b[38;5;16m█\u001b[39m");
 });
 
 Deno.test("getAsciiArt - Brightest Letter with 256 color support", async () => {
-  // Create black and white 1x1 images using Jimp constructor
-  const whiteImage = new Jimp({ width: 1, height: 1, color: 0xffffffff });
-  const whiteImageBuffer = await whiteImage.getBuffer("image/webp");
-
   const whiteResult = getAsciiArt(
-    await Jimp.read(whiteImageBuffer),
+    await createTestImage(0xffffffff),
     1,
-    "256color",
+    "none",
   );
 
   assertEquals(whiteResult, "\u001b[38;5;231m \u001b[39m");
 });
 
 Deno.test("getAsciiArt - Darkest Letter with true color support", async () => {
-  // Create black and white 1x1 images using Jimp constructor
-  const blackImage = new Jimp({ width: 1, height: 1, color: 0x000000ff });
-  const blackImageBuffer = await blackImage.getBuffer("image/webp");
-
   const blackResult = getAsciiArt(
-    await Jimp.read(blackImageBuffer),
+    await createTestImage(0x000000ff),
     1,
-    "truecolor",
+    "none",
   );
 
   assertEquals(blackResult, "\u001b[38;2;0;0;0m█\u001b[39m");
 });
 
 Deno.test("getAsciiArt - Brightest Letter with true color support", async () => {
-  // Create black and white 1x1 images using Jimp constructor
-  const whiteImage = new Jimp({ width: 1, height: 1, color: 0xffffffff });
-  const whiteImageBuffer = await whiteImage.getBuffer("image/webp");
-
   const whiteResult = getAsciiArt(
-    await Jimp.read(whiteImageBuffer),
+    await createTestImage(0xffffffff),
     1,
-    "truecolor",
+    "none",
   );
 
   assertEquals(whiteResult, "\u001b[38;2;255;255;255m \u001b[39m");

--- a/cli/node.test.ts
+++ b/cli/node.test.ts
@@ -184,7 +184,7 @@ Deno.test("getAsciiArt - Darkest Letter with 256 color support", async () => {
   // Create black and white 1x1 images using Jimp constructor
   const blackImage = new Jimp({ width: 1, height: 1, color: 0x000000ff });
   const blackImageBuffer = await blackImage.getBuffer("image/webp");
-  
+
   const blackResult = getAsciiArt(
     await Jimp.read(blackImageBuffer),
     1,
@@ -212,7 +212,7 @@ Deno.test("getAsciiArt - Darkest Letter with true color support", async () => {
   // Create black and white 1x1 images using Jimp constructor
   const blackImage = new Jimp({ width: 1, height: 1, color: 0x000000ff });
   const blackImageBuffer = await blackImage.getBuffer("image/webp");
-  
+
   const blackResult = getAsciiArt(
     await Jimp.read(blackImageBuffer),
     1,

--- a/cli/node.test.ts
+++ b/cli/node.test.ts
@@ -184,7 +184,7 @@ Deno.test("getAsciiArt - Darkest Letter with 256 color support", async () => {
   const blackResult = getAsciiArt(
     await createTestImage(0x000000ff),
     1,
-    "none",
+    "256color",
   );
 
   assertEquals(blackResult, "\u001b[38;5;16m█\u001b[39m");
@@ -194,7 +194,7 @@ Deno.test("getAsciiArt - Brightest Letter with 256 color support", async () => {
   const whiteResult = getAsciiArt(
     await createTestImage(0xffffffff),
     1,
-    "none",
+    "256color",
   );
 
   assertEquals(whiteResult, "\u001b[38;5;231m \u001b[39m");
@@ -204,7 +204,7 @@ Deno.test("getAsciiArt - Darkest Letter with true color support", async () => {
   const blackResult = getAsciiArt(
     await createTestImage(0x000000ff),
     1,
-    "none",
+    "truecolor",
   );
 
   assertEquals(blackResult, "\u001b[38;2;0;0;0m█\u001b[39m");
@@ -214,7 +214,7 @@ Deno.test("getAsciiArt - Brightest Letter with true color support", async () => 
   const whiteResult = getAsciiArt(
     await createTestImage(0xffffffff),
     1,
-    "none",
+    "truecolor",
   );
 
   assertEquals(whiteResult, "\u001b[38;2;255;255;255m \u001b[39m");

--- a/cli/node.test.ts
+++ b/cli/node.test.ts
@@ -152,7 +152,9 @@ Deno.test("rgbTo256Color - check grayscale", () => {
   assertEquals(results, expected_gray_idx);
 });
 
-async function createTestImage(color: number): Promise<Awaited<ReturnType<typeof Jimp.read>>> {
+async function createTestImage(
+  color: number,
+): Promise<Awaited<ReturnType<typeof Jimp.read>>> {
   const image = new Jimp({ width: 1, height: 1, color });
   const imageBuffer = await image.getBuffer("image/webp");
   return Jimp.read(imageBuffer);

--- a/cli/node.ts
+++ b/cli/node.ts
@@ -259,10 +259,14 @@ export const Jimp = createJimp({
 });
 
 function checkTerminalColorSupport(): "truecolor" | "256color" | "none" {
-  const colorTerm = Deno.env.get("COLORTERM");
-  const term = Deno.env.get("TERM");
+  // Check if colors are explicitly disabled
+  const noColor = Deno.env.get("NO_COLOR");
+  if (noColor != null && noColor !== "") {
+    return "none";
+  }
 
   // Check for true color (24-bit) support
+  const colorTerm = Deno.env.get("COLORTERM");
   if (
     colorTerm != null &&
     (colorTerm.includes("24bit") || colorTerm.includes("truecolor"))
@@ -271,6 +275,7 @@ function checkTerminalColorSupport(): "truecolor" | "256color" | "none" {
   }
 
   // Check for xterm 256-color support
+  const term = Deno.env.get("TERM");
   if (
     term != null &&
     (term.includes("256color") ||
@@ -279,12 +284,6 @@ function checkTerminalColorSupport(): "truecolor" | "256color" | "none" {
       term === "tmux")
   ) {
     return "256color";
-  }
-
-  // Check if colors are explicitly disabled
-  const noColor = Deno.env.get("NO_COLOR");
-  if (noColor != null && noColor !== "") {
-    return "none";
   }
 
   // Fallback: assume basic color support if TERM is set

--- a/cli/node.ts
+++ b/cli/node.ts
@@ -98,8 +98,8 @@ export const command = new Command()
             buffer = images[0].buffer;
           }
           const image = await Jimp.read(buffer);
-          const trueColorSupport = checkTerminalTrueColorSupport();
-          layout = getAsciiArt(image, DEFAULT_IMAGE_WIDTH, trueColorSupport)
+          const colorSupport = checkTerminalColorSupport();
+          layout = getAsciiArt(image, DEFAULT_IMAGE_WIDTH, colorSupport)
             .split("\n").map((line) => ` ${line}  `);
           defaultWidth = 41;
         } else {
@@ -258,16 +258,41 @@ export const Jimp = createJimp({
   plugins: defaultPlugins,
 });
 
-function checkTerminalTrueColorSupport() {
+function checkTerminalColorSupport(): "truecolor" | "256color" | "none" {
   const colorTerm = Deno.env.get("COLORTERM");
+  const term = Deno.env.get("TERM");
 
+  // Check for true color (24-bit) support
   if (
-    colorTerm == null ||
-    !(colorTerm.includes("24bit") || colorTerm.includes("truecolor"))
+    colorTerm != null &&
+    (colorTerm.includes("24bit") || colorTerm.includes("truecolor"))
   ) {
-    return false;
+    return "truecolor";
   }
-  return true;
+
+  // Check for xterm 256-color support
+  if (
+    term != null &&
+    (term.includes("256color") ||
+      term.includes("xterm") ||
+      term === "screen" ||
+      term === "tmux")
+  ) {
+    return "256color";
+  }
+
+  // Check if colors are explicitly disabled
+  const noColor = Deno.env.get("NO_COLOR");
+  if (noColor != null && noColor !== "") {
+    return "none";
+  }
+
+  // Fallback: assume basic color support if TERM is set
+  if (term != null && term !== "dumb") {
+    return "256color";
+  }
+
+  return "none";
 }
 
 const DEFAULT_IMAGE_WIDTH = 38;
@@ -326,7 +351,7 @@ export function rgbTo256Color(r: number, g: number, b: number): number {
 export function getAsciiArt(
   image: Awaited<ReturnType<typeof Jimp.read>>,
   width = DEFAULT_IMAGE_WIDTH,
-  trueColorSupport: boolean,
+  colorSupport: "truecolor" | "256color" | "none",
 ): string {
   const ratio = image.width / image.height;
   const height = Math.round(
@@ -348,11 +373,13 @@ export function getAsciiArt(
       );
       const char = ASCII_CHARS[charIndex];
 
-      if (trueColorSupport) {
+      if (colorSupport === "truecolor") {
         art += colors.rgb24(char, color);
-      } else {
+      } else if (colorSupport === "256color") {
         const colorIndex = rgbTo256Color(color.r, color.g, color.b);
         art += colors.rgb8(char, colorIndex);
+      } else {
+        art += char;
       }
     }
     if (y < height - 1) art += "\n";


### PR DESCRIPTION
# Summary
Fix the issue that `getAsciiArt` tests failed according to the terminal emulator, add support for the non-color environment, and add test cases for color support. 

# Related Issue
- close #304 

# Problem / Motivation
Test added by #299 has failed according to the color support of the terminal emulator.

# Changes
- Refactor `trueColorSupport(): boolean` to `colorSupport(): 'truecolor'| '256color' | 'none'`.
- Add support for non-color environments.
- Add test case for color support.

# Benefits
- Add support for non-color terminals.
- Add more suitable test cases.

# Checklist
- [x] Did you add a changelog entry to the *CHANGES.md*?
- [ ] Did you write some relevant docs about this change (if it's a new feature)?
- [x] Did you write a regression test to reproduce the bug (if it's a bug fix)?
- [x] Did you write some tests for this change (if it's a new feature)?
- [x] Did you run `deno task test-all` on your machine?