### PR TITLE
Add AbortSignal to `fedify lookup`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -97,7 +97,8 @@ the versioning.
       -  The `DocumentLoader` type became able to optionally take
          the second parameter.
       -  Added `LookupObjectOptions.signal` option.
-      -  Added `LookupWebFingerOptions.signal` option.   
+      -  Added `LookupWebFingerOptions.signal` option.
+      -  Added `DoubleKnockOptions.signal` option.
 
 
  -  Added `SqliteKvStore`, implementing `KvStore` using SQLite with the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -90,6 +90,10 @@ the versioning.
 
      -  Added `@fedify/nestjs` package.
      -  Added `FedifyModule` for integrating Fedify into NestJS applications.
+     
+  -  `lookupWebFinger()` now supports request cancellation via `AbortSignal`.
+     [[#51] by Hyunchae Kim]
+
 
  -  Added `SqliteKvStore`, implementing `KvStore` using SQLite with the
     `@fedify/sqlite` package. Compatible with Bun, Deno, and Node.js.
@@ -165,6 +169,7 @@ the versioning.
 [#341]: https://github.com/fedify-dev/fedify/pull/341
 [#342]: https://github.com/fedify-dev/fedify/pull/342
 [#348]: https://github.com/fedify-dev/fedify/pull/348
+[#51]: https://github.com/fedify-dev/fedify/issues/51
 [Kitty]: https://sw.kovidgoyal.net/kitty/
 [WezTerm]: https://wezterm.org/
 [Konsole]: https://konsole.kde.org/
@@ -172,7 +177,6 @@ the versioning.
 [Wayst]: https://github.com/91861/wayst
 [st]: https://st.suckless.org/
 [iTerm]: https://iterm2.com/
-
 
 Version 1.7.7
 -------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -91,8 +91,13 @@ the versioning.
      -  Added `@fedify/nestjs` package.
      -  Added `FedifyModule` for integrating Fedify into NestJS applications.
      
-  -  `lookupWebFinger()` now supports request cancellation via `AbortSignal`.
-     [[#51] by Hyunchae Kim]
+    -  APIs making HTTP requests became able to optionally take `AbortSignal`.
+     [[#51], [#315] by Hyunchae Kim]
+      -  Added `DocumentLoaderOptions` interface.
+      -  The `DocumentLoader` type became able to optionally take
+         the second parameter.
+      -  Added `LookupObjectOptions.signal` option.
+      -  Added `LookupWebFingerOptions.signal` option.   
 
 
  -  Added `SqliteKvStore`, implementing `KvStore` using SQLite with the
@@ -170,6 +175,7 @@ the versioning.
 [#342]: https://github.com/fedify-dev/fedify/pull/342
 [#348]: https://github.com/fedify-dev/fedify/pull/348
 [#51]: https://github.com/fedify-dev/fedify/issues/51
+[#315]: https://github.com/fedify-dev/fedify/pull/315
 [Kitty]: https://sw.kovidgoyal.net/kitty/
 [WezTerm]: https://wezterm.org/
 [Konsole]: https://konsole.kde.org/

--- a/packages/fedify/src/runtime/authdocloader.ts
+++ b/packages/fedify/src/runtime/authdocloader.ts
@@ -61,7 +61,7 @@ export function getAuthenticatedDocumentLoader(
   validateCryptoKey(identity.privateKey);
   async function load(
     url: string,
-    _options?: DocumentLoaderOptions,
+    options?: DocumentLoaderOptions,
   ): Promise<RemoteDocument> {
     if (!allowPrivateAddress) {
       try {
@@ -77,7 +77,12 @@ export function getAuthenticatedDocumentLoader(
     const response = await doubleKnock(
       originalRequest,
       identity,
-      { specDeterminer, log: logRequest, tracerProvider },
+      {
+        specDeterminer,
+        log: logRequest,
+        tracerProvider,
+        signal: options?.signal,
+      },
     );
     return getRemoteDocument(url, response, load);
   }

--- a/packages/fedify/src/runtime/authdocloader.ts
+++ b/packages/fedify/src/runtime/authdocloader.ts
@@ -9,6 +9,7 @@ import {
   createRequest,
   type DocumentLoader,
   type DocumentLoaderFactoryOptions,
+  type DocumentLoaderOptions,
   getRemoteDocument,
   logRequest,
   type RemoteDocument,
@@ -58,7 +59,10 @@ export function getAuthenticatedDocumentLoader(
     GetAuthenticatedDocumentLoaderOptions = {},
 ): DocumentLoader {
   validateCryptoKey(identity.privateKey);
-  async function load(url: string): Promise<RemoteDocument> {
+  async function load(
+    url: string,
+    _options?: DocumentLoaderOptions,
+  ): Promise<RemoteDocument> {
     if (!allowPrivateAddress) {
       try {
         await validatePublicUrl(url);

--- a/packages/fedify/src/runtime/docloader.ts
+++ b/packages/fedify/src/runtime/docloader.ts
@@ -36,6 +36,7 @@ export interface RemoteDocument {
 export interface DocumentLoaderOptions {
   /**
    * An `AbortSignal` for cancellation.
+   * @since 1.8.0
    */
   signal?: AbortSignal;
 }

--- a/packages/fedify/src/sig/http.ts
+++ b/packages/fedify/src/sig/http.ts
@@ -1240,6 +1240,7 @@ export interface DoubleKnockOptions {
 
   /**
    * An `AbortSignal` for cancellation.
+   * @since 1.8.0
    */
   signal?: AbortSignal;
 }

--- a/packages/fedify/src/sig/http.ts
+++ b/packages/fedify/src/sig/http.ts
@@ -1237,6 +1237,11 @@ export interface DoubleKnockOptions {
    * is used.
    */
   tracerProvider?: TracerProvider;
+
+  /**
+   * An `AbortSignal` for cancellation.
+   */
+  signal?: AbortSignal;
 }
 
 /**
@@ -1283,7 +1288,7 @@ export async function doubleKnock(
   identity: { keyId: URL; privateKey: CryptoKey },
   options: DoubleKnockOptions = {},
 ): Promise<Response> {
-  const { specDeterminer, log, tracerProvider } = options;
+  const { specDeterminer, log, tracerProvider, signal } = options;
   const origin = new URL(request.url).origin;
   const firstTrySpec: HttpMessageSignaturesSpec = specDeterminer == null
     ? "rfc9421"
@@ -1308,6 +1313,7 @@ export async function doubleKnock(
     // to work around it we specify `redirect: "manual"` here too:
     // https://github.com/oven-sh/bun/issues/10754
     redirect: "manual",
+    signal,
   });
   // Follow redirects manually to get the final URL:
   if (
@@ -1355,6 +1361,7 @@ export async function doubleKnock(
       // to work around it we specify `redirect: "manual"` here too:
       // https://github.com/oven-sh/bun/issues/10754
       redirect: "manual",
+      signal,
     });
     // Follow redirects manually to get the final URL:
     if (

--- a/packages/fedify/src/testing/docloader.ts
+++ b/packages/fedify/src/testing/docloader.ts
@@ -1,5 +1,8 @@
 import { getLogger } from "@logtape/logtape";
-import type { RemoteDocument } from "../runtime/docloader.ts";
+import type {
+  DocumentLoaderOptions,
+  RemoteDocument,
+} from "../runtime/docloader.ts";
 
 const logger = getLogger(["fedify", "testing", "docloader"]);
 
@@ -13,6 +16,7 @@ const logger = getLogger(["fedify", "testing", "docloader"]);
  */
 export async function mockDocumentLoader(
   resource: string,
+  _options?: DocumentLoaderOptions,
 ): Promise<RemoteDocument> {
   const url = new URL(resource);
   if (

--- a/packages/fedify/src/vocab/lookup.test.ts
+++ b/packages/fedify/src/vocab/lookup.test.ts
@@ -182,7 +182,10 @@ test("lookupObject()", {
   fetchMock.hardReset();
 });
 
-test("traverseCollection()", async () => {
+test("traverseCollection()", {
+  sanitizeResources: false,
+  sanitizeOps: false,
+}, async () => {
   const options = {
     documentLoader: mockDocumentLoader,
     contextLoader: mockDocumentLoader,

--- a/packages/fedify/src/vocab/lookup.test.ts
+++ b/packages/fedify/src/vocab/lookup.test.ts
@@ -5,7 +5,10 @@ import { test } from "../testing/mod.ts";
 import { lookupObject, traverseCollection } from "./lookup.ts";
 import { Collection, Note, Object, Person } from "./vocab.ts";
 
-test("lookupObject()", async (t) => {
+test("lookupObject()", {
+  sanitizeResources: false,
+  sanitizeOps: false,
+}, async (t) => {
   fetchMock.spyGlobal();
 
   fetchMock.get(
@@ -87,6 +90,93 @@ test("lookupObject()", async (t) => {
   await t.step("not found", async () => {
     assertEquals(await lookupObject("janedoe@example.com", options), null);
     assertEquals(await lookupObject("https://example.com/404", options), null);
+  });
+
+  fetchMock.removeRoutes();
+  fetchMock.get(
+    "begin:https://example.com/.well-known/webfinger",
+    () =>
+      new Promise((resolve) => {
+        setTimeout(() => {
+          resolve({
+            subject: "acct:johndoe@example.com",
+            links: [
+              {
+                rel: "self",
+                href: "https://example.com/person",
+                type: "application/activity+json",
+              },
+            ],
+          });
+        }, 1000);
+      }),
+  );
+
+  await t.step("request cancellation", async () => {
+    const controller = new AbortController();
+    const promise = lookupObject("johndoe@example.com", {
+      ...options,
+      signal: controller.signal,
+    });
+
+    controller.abort();
+    assertEquals(await promise, null);
+  });
+
+  fetchMock.removeRoutes();
+  fetchMock.get(
+    "begin:https://example.com/.well-known/webfinger",
+    {
+      subject: "acct:johndoe@example.com",
+      links: [
+        {
+          rel: "self",
+          href: "https://example.com/person",
+          type: "application/activity+json",
+        },
+      ],
+    },
+  );
+
+  await t.step("successful request with signal", async () => {
+    const controller = new AbortController();
+    const person = await lookupObject("johndoe@example.com", {
+      ...options,
+      signal: controller.signal,
+    });
+    assertInstanceOf(person, Person);
+    assertEquals(person.id, new URL("https://example.com/person"));
+  });
+
+  fetchMock.removeRoutes();
+  fetchMock.get(
+    "begin:https://example.com/.well-known/webfinger",
+    () =>
+      new Promise((resolve) => {
+        setTimeout(() => {
+          resolve({
+            subject: "acct:johndoe@example.com",
+            links: [
+              {
+                rel: "self",
+                href: "https://example.com/person",
+                type: "application/activity+json",
+              },
+            ],
+          });
+        }, 500);
+      }),
+  );
+
+  await t.step("cancellation with immediate abort", async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await lookupObject("johndoe@example.com", {
+      ...options,
+      signal: controller.signal,
+    });
+    assertEquals(result, null);
   });
 
   fetchMock.hardReset();

--- a/packages/fedify/src/vocab/lookup.ts
+++ b/packages/fedify/src/vocab/lookup.ts
@@ -46,6 +46,11 @@ export interface LookupObjectOptions {
    * @since 1.3.0
    */
   tracerProvider?: TracerProvider;
+
+  /**
+   * AbortSignal for cancelling the request.
+   */
+  signal?: AbortSignal;
 }
 
 /**
@@ -145,6 +150,7 @@ async function lookupObjectInternal(
       tracerProvider: options.tracerProvider,
       allowPrivateAddress: "allowPrivateAddress" in options &&
         options.allowPrivateAddress === true,
+      signal: options.signal,
     });
     if (jrd?.links == null) return null;
     for (const l of jrd.links) {

--- a/packages/fedify/src/vocab/lookup.ts
+++ b/packages/fedify/src/vocab/lookup.ts
@@ -49,6 +49,7 @@ export interface LookupObjectOptions {
 
   /**
    * AbortSignal for cancelling the request.
+   * @since 1.8.0
    */
   signal?: AbortSignal;
 }

--- a/packages/fedify/src/vocab/lookup.ts
+++ b/packages/fedify/src/vocab/lookup.ts
@@ -139,7 +139,9 @@ async function lookupObjectInternal(
   let document: unknown | null = null;
   if (identifier.protocol === "http:" || identifier.protocol === "https:") {
     try {
-      const remoteDoc = await documentLoader(identifier.href);
+      const remoteDoc = await documentLoader(identifier.href, {
+        signal: options.signal,
+      });
       document = remoteDoc.document;
     } catch (error) {
       logger.debug("Failed to fetch remote document:\n{error}", { error });
@@ -162,7 +164,9 @@ async function lookupObjectInternal(
           ) || l.rel !== "self"
       ) continue;
       try {
-        const remoteDoc = await documentLoader(l.href);
+        const remoteDoc = await documentLoader(l.href, {
+          signal: options.signal,
+        });
         document = remoteDoc.document;
         break;
       } catch (error) {

--- a/packages/fedify/src/webfinger/lookup.ts
+++ b/packages/fedify/src/webfinger/lookup.ts
@@ -52,6 +52,11 @@ export interface LookupWebFingerOptions {
    * is used.
    */
   tracerProvider?: TracerProvider;
+
+  /**
+   * AbortSignal for cancelling the request.
+   */
+  signal?: AbortSignal;
 }
 
 /**
@@ -149,6 +154,7 @@ async function lookupWebFingerInternal(
             : getUserAgent(options.userAgent),
         },
         redirect: "manual",
+        signal: options.signal,
       });
     } catch (error) {
       logger.debug(

--- a/packages/fedify/src/webfinger/lookup.ts
+++ b/packages/fedify/src/webfinger/lookup.ts
@@ -55,6 +55,8 @@ export interface LookupWebFingerOptions {
 
   /**
    * AbortSignal for cancelling the request.
+   * @since 1.8.0
+   * @
    */
   signal?: AbortSignal;
 }


### PR DESCRIPTION
## Summary

Add AbortSignal to `fedify lookup`.

## Related Issue

- closes #51 

## Changes

- modified `lookupWebFinger` to accept an optional `signal` parameter of type `AbortSignal`
- added request cancellation handling using `AbortSignal `in `lookupWebFinger`
- added test cases in `lookupObject `to cover request cancellation scenarios

## Benefits

- allows canceling `lookupWebFinger `requests
- prepares for future support of `--timeout` option in the `fedify lookup` command

## Checklist

- [x] Did you add a changelog entry to the *CHANGES.md*?
- [ ] Did you write some relevant docs about this change (if it's a new feature)?
- [ ] Did you write a regression test to reproduce the bug (if it's a bug fix)?
- [x] Did you write some tests for this change (if it's a new feature)?
- [x] Did you run `deno task test-all` on your machine?
