### PR TITLE
feat(cli): Add --output option to fedify lookup to save results to a file

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -87,9 +87,14 @@ the versioning.
      -  Added `@fedify/nestjs` package.
      -  Added `FedifyModule` for integrating Fedify into NestJS applications.
 
+  -  Added `-o`/`--output` option to `fedify lookup` command. This option allows
+     users to save retrieved lookup results to specified path. 
+     [[#261], [#321] by Jiwon Kwon]
+
 [#168]: https://github.com/fedify-dev/fedify/issues/168
 [#248]: https://github.com/fedify-dev/fedify/issues/248
 [#260]: https://github.com/fedify-dev/fedify/issues/260
+[#261]: https://github.com/fedify-dev/fedify/issues/261
 [#262]: https://github.com/fedify-dev/fedify/issues/262
 [#263]: https://github.com/fedify-dev/fedify/issues/263
 [#269]: https://github.com/fedify-dev/fedify/issues/269
@@ -101,6 +106,8 @@ the versioning.
 [#300]: https://github.com/fedify-dev/fedify/pull/300
 [#304]: https://github.com/fedify-dev/fedify/issues/304
 [#309]: https://github.com/fedify-dev/fedify/pull/309
+[#321]: https://github.com/fedify-dev/fedify/pull/321
+
 
 
 Version 1.7.6

--- a/cli/lookup.test.ts
+++ b/cli/lookup.test.ts
@@ -1,0 +1,301 @@
+import { Activity, Note } from "@fedify/fedify";
+import { assertEquals, assertExists } from "@std/assert";
+import { getContextLoader } from "./docloader.ts";
+import { createFileStream, writeObjectToStream } from "./lookup.ts";
+
+Deno.test("createFileStream - creates file stream with proper directory creation", async () => {
+  const testDir = "./test_output";
+  const testFile = `${testDir}/test.json`;
+
+  try {
+    await Deno.remove(testDir, { recursive: true });
+  } catch {
+    // Ignore if doesn't exist
+  }
+
+  const stream = await createFileStream(testFile);
+  assertExists(stream);
+
+  const stat = await Deno.stat(testDir);
+  assertEquals(stat.isDirectory, true);
+
+  stream.close();
+
+  await Deno.remove(testDir, { recursive: true });
+});
+
+Deno.test("createFileStream - works with absolute paths", async () => {
+  const testDir = `${Deno.cwd()}/test_output_absolute`;
+  const testFile = `${testDir}/test.json`;
+
+  try {
+    await Deno.remove(testDir, { recursive: true });
+  } catch {
+    // Ignore if doesn't exist
+  }
+
+  const stream = await createFileStream(testFile);
+  assertExists(stream);
+
+  const stat = await Deno.stat(testDir);
+  assertEquals(stat.isDirectory, true);
+
+  stream.close();
+
+  await Deno.remove(testDir, { recursive: true });
+});
+
+Deno.test("createFileStream - creates nested directories", async () => {
+  const testDir = "./test_output_nested/deep/path";
+  const testFile = `${testDir}/test.json`;
+
+  try {
+    await Deno.remove("./test_output_nested", { recursive: true });
+  } catch {
+    // Ignore if doesn't exist
+  }
+
+  const stream = await createFileStream(testFile);
+  assertExists(stream);
+
+  // Verify nested directories were created
+  const stat = await Deno.stat(testDir);
+  assertEquals(stat.isDirectory, true);
+  stream.close();
+
+  await Deno.remove("./test_output_nested", { recursive: true });
+});
+
+Deno.test("createFileStream - writes data correctly", async () => {
+  const testDir = "./test_output_write";
+  const testFile = `${testDir}/test.txt`;
+
+  try {
+    await Deno.remove(testDir, { recursive: true });
+  } catch {
+    // Ignore if doesn't exist
+  }
+
+  const stream = await createFileStream(testFile);
+  const writer = stream.getWriter();
+
+  const testData = new TextEncoder().encode("Hello, World!");
+  await writer.write(testData);
+  await writer.close();
+
+  const content = await Deno.readTextFile(testFile);
+  assertEquals(content, "Hello, World!");
+
+  await Deno.remove(testDir, { recursive: true });
+});
+
+Deno.test("createFileStream - truncates existing file", async () => {
+  const testDir = "./test_output_truncate";
+  const testFile = `${testDir}/test.txt`;
+
+  try {
+    await Deno.remove(testDir, { recursive: true });
+  } catch {
+    // Ignore if doesn't exist
+  }
+
+  await Deno.mkdir(testDir, { recursive: true });
+  await Deno.writeTextFile(testFile, "Old content");
+
+  const stream = await createFileStream(testFile);
+  const writer = stream.getWriter();
+
+  const testData = new TextEncoder().encode("New content");
+  await writer.write(testData);
+  await writer.close();
+
+  // Verify file was truncated and new content written
+  const content = await Deno.readTextFile(testFile);
+  assertEquals(content, "New content");
+
+  await Deno.remove(testDir, { recursive: true });
+});
+
+Deno.test("writeObjectToStream - writes Note object with default options", {
+  sanitizeResources: false,
+}, async () => {
+  const testDir = "./test_output_note";
+  const testFile = `${testDir}/note.txt`;
+
+  try {
+    await Deno.remove(testDir, { recursive: true });
+  } catch {
+    // Ignore if doesn't exist
+  }
+
+  const note = new Note({
+    id: new URL("https://example.com/notes/1"),
+    content: "Hello, fediverse!",
+  });
+
+  const options = {
+    firstKnock: "rfc9421" as const,
+    separator: "----",
+    output: testFile,
+  };
+
+  const contextLoader = await getContextLoader({});
+
+  await writeObjectToStream(note, options, contextLoader);
+
+  const content = await Deno.readTextFile(testFile);
+  assertExists(content);
+  assertEquals(content.includes("Hello, fediverse!"), true);
+  assertEquals(content.includes("Note"), true);
+
+  await Deno.remove(testDir, { recursive: true });
+});
+
+Deno.test("writeObjectToStream - writes Activity object in raw JSON-LD format", async () => {
+  const testDir = "./test_output_activity";
+  const testFile = `${testDir}/activity.json`;
+
+  try {
+    await Deno.remove(testDir, { recursive: true });
+  } catch {
+    // Ignore if doesn't exist
+  }
+
+  const activity = new Activity({
+    id: new URL("https://example.com/activities/1"),
+  });
+
+  const options = {
+    firstKnock: "rfc9421" as const,
+    separator: "----",
+    output: testFile,
+    raw: true,
+  };
+
+  const contextLoader = await getContextLoader({});
+
+  await writeObjectToStream(activity, options, contextLoader);
+
+  // Verify file exists and contains JSON-LD
+  const content = await Deno.readTextFile(testFile);
+
+  assertExists(content);
+  assertEquals(content.includes("@context"), true);
+  assertEquals(content.includes("id"), true);
+
+  await Deno.remove(testDir, { recursive: true });
+});
+
+Deno.test("writeObjectToStream - writes object in compact JSON-LD format", async () => {
+  const testDir = "./test_output_compact";
+  const testFile = `${testDir}/compact.json`;
+
+  try {
+    await Deno.remove(testDir, { recursive: true });
+  } catch {
+    // Ignore if doesn't exist
+  }
+
+  const note = new Note({
+    id: new URL("https://example.com/notes/1"),
+    content: "Test note",
+  });
+
+  const options = {
+    firstKnock: "rfc9421" as const,
+    separator: "----",
+    output: testFile,
+    compact: true,
+  };
+
+  const contextLoader = await getContextLoader({});
+
+  await writeObjectToStream(note, options, contextLoader);
+
+  // Verify file exists and contains compacted JSON-LD
+  const content = await Deno.readTextFile(testFile);
+  assertExists(content);
+  assertEquals(content.includes("Test note"), true);
+
+  await Deno.remove(testDir, { recursive: true });
+});
+
+Deno.test("writeObjectToStream - writes object in expanded JSON-LD format", async () => {
+  const testDir = "./test_output_expand";
+  const testFile = `${testDir}/expand.json`;
+
+  try {
+    await Deno.remove(testDir, { recursive: true });
+  } catch {
+    // Ignore if doesn't exist
+  }
+
+  const note = new Note({
+    id: new URL("https://example.com/notes/1"),
+    content: "Test note for expansion",
+  });
+
+  const options = {
+    firstKnock: "rfc9421" as const,
+    separator: "----",
+    output: testFile,
+    expand: true,
+  };
+
+  const contextLoader = await getContextLoader({});
+
+  await writeObjectToStream(note, options, contextLoader);
+
+  const content = await Deno.readTextFile(testFile);
+  assertExists(content);
+  assertEquals(content.includes("Test note for expansion"), true);
+
+  await Deno.remove(testDir, { recursive: true });
+});
+
+Deno.test("writeObjectToStream - writes to stdout when no output file specified", async () => {
+  const note = new Note({
+    id: new URL("https://example.com/notes/1"),
+    content: "Test stdout note",
+  });
+
+  const options = {
+    firstKnock: "rfc9421" as const,
+    separator: "----",
+  };
+
+  const contextLoader = await getContextLoader({});
+
+  await writeObjectToStream(note, options, contextLoader);
+});
+
+Deno.test("writeObjectToStream - handles empty content properly", async () => {
+  const testDir = "./test_output_empty";
+  const testFile = `${testDir}/empty.txt`;
+
+  try {
+    await Deno.remove(testDir, { recursive: true });
+  } catch {
+    // Ignore if doesn't exist
+  }
+
+  const note = new Note({
+    id: new URL("https://example.com/notes/1"),
+  });
+
+  const options = {
+    firstKnock: "rfc9421" as const,
+    separator: "----",
+    output: testFile,
+  };
+
+  const contextLoader = await getContextLoader({});
+
+  await writeObjectToStream(note, options, contextLoader);
+
+  const content = await Deno.readTextFile(testFile);
+  assertExists(content);
+  assertEquals(content.includes("Note"), true);
+
+  await Deno.remove(testDir, { recursive: true });
+});

--- a/cli/lookup.ts
+++ b/cli/lookup.ts
@@ -16,7 +16,6 @@ import {
 } from "@fedify/fedify";
 import { getLogger } from "@logtape/logtape";
 import { dirname, isAbsolute, resolve } from "@std/path";
-import util from "node:util";
 import ora from "ora";
 import { getContextLoader, getDocumentLoader } from "./docloader.ts";
 import { spawnTemporaryServer, type TemporaryServer } from "./tempserver.ts";
@@ -108,8 +107,7 @@ export async function writeObjectToStream(
       content = object;
     }
 
-    content = util.inspect(content, {
-      depth: null,
+    content = Deno.inspect(content, {
       colors: !(options.output),
     });
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -811,7 +811,7 @@ It does not affect the output when looking up a single object.
 > The separator is also used when looking up a collection object with the
 > [`-t`/`--traverse`](#t-traverse-traverse-the-collection) option.
 
-### '-o' /'--output': Output file path
+### `-o`/`--output`: Output file path
 
 *This option is available since Fedify 1.8.0.*
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -811,6 +811,18 @@ It does not affect the output when looking up a single object.
 > The separator is also used when looking up a collection object with the
 > [`-t`/`--traverse`](#t-traverse-traverse-the-collection) option.
 
+### '-o' /'--output': Output file path
+
+*This option is available since Fedify 1.8.0.*
+
+You can specify the output file path to save lookup results, instead of 
+printing results to stdout. For example, to save the retrieved information
+about the specified objects to a given path, run the command below:
+
+~~~~ sh
+fedify lookup -o actors.json @fedify@hollo.social @hongminhee@fosstodon.org
+~~~~
+
 
 `fedify inbox`: Ephemeral inbox server
 --------------------------------------


### PR DESCRIPTION
## Summary

Add --output option to `fedify lookup` to save results to a file instead of printing  them

## Related Issue

Reference the related issue(s) by number, e.g.:

- closes #261 

## Changes

- Added `--output`, `-o` options to specify a file path for saving lookup results
- Ensures output is formatted and written based on the selected display options
- Automatically creates parent directories if they don’t exist

## Benefits

- Improves usability for long or verbose outputs
- Enables easier sharing, inspection, or post-processing of results outside the terminal

## Checklist

- [ ] Did you add a changelog entry to the *CHANGES.md*?
- [ ] Did you write some relevant docs about this change (if it's a new feature)?
- [ ] Did you write a regression test to reproduce the bug (if it's a bug fix)?
- [ ] Did you write some tests for this change (if it's a new feature)?
- [x] Did you run `deno task test-all` on your machine?
