### PR TITLE
Fix Flooding alerts from "sponsors.yml" action

### DIFF
--- a/.github/workflows/sponsors.yaml
+++ b/.github/workflows/sponsors.yaml
@@ -14,6 +14,8 @@ on:
 
 jobs:
   update-sponsors:
+    ## Only run on the upstream repository.
+    if: github.repository == 'fedify-dev/fedify'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/sponsors.yaml
+++ b/.github/workflows/sponsors.yaml
@@ -1,15 +1,5 @@
 name: sponsors
 on:
-  schedule:
-  #        ┌───────────── minute (0 - 59)
-  #        │ ┌───────────── hour (0 - 23)
-  #        │ │ ┌───────────── day of the month (1 - 31)
-  #        │ │ │ ┌───────────── month (1 - 12 or JAN-DEC)
-  #        │ │ │ │ ┌───────────── day of the week (0 - 6 or SUN-SAT)
-  #        │ │ │ │ │
-  #        │ │ │ │ │
-  #        │ │ │ │ │
-  - cron: '0 * * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Summary

Fix Flooding alerts from "sponsors.yml" action by splitting the trigger action repository.

## Related Issue

- fixes #317 

## Changes

- Remove scheduled sponsors.yml action
- Add <https://github.com/fedify-dev/sponsor-automation>.

## Benefits

After this, the owner of the forked repository doesn't get notifications hourly.

## Checklist

- [ ] Did you add a changelog entry to the *CHANGES.md*?
- [ ] Did you write some relevant docs about this change (if it's a new feature)?
- [ ] Did you write a regression test to reproduce the bug (if it's a bug fix)?
- [ ] Did you write some tests for this change (if it's a new feature)?
- [ ] Did you run `deno task test-all` on your machine?

## Additional Notes

Include any other information, context, or considerations.
