### PR TITLE
Enhancement/cli dynamic dependency versions

### DIFF
--- a/cli/init.test.ts
+++ b/cli/init.test.ts
@@ -1,6 +1,7 @@
 import { assertEquals, assertStringIncludes } from "@std/assert";
 import { join } from "@std/path";
 import { exists } from "@std/fs";
+import { getLatestVersion } from "./init.ts";
 
 const CLI_PATH = join(import.meta.dirname!, "mod.ts");
 
@@ -250,4 +251,37 @@ Deno.test("init --dry-run shows dev dependencies for Node.js", async () => {
   } finally {
     await Deno.remove(testDir, { recursive: true });
   }
+});
+
+Deno.test("init - getLatestVersion: returns version for AMQP package", () => {
+  const amqpVersion = getLatestVersion("@fedify/amqp");
+  assertEquals(typeof amqpVersion, "string");
+  assertEquals(/^\d+\.\d+\.\d+$/.test(amqpVersion), true);
+});
+
+Deno.test("init - getLatestVersion: returns version for Redis package", () => {
+  const redisVersion = getLatestVersion("@fedify/redis");
+  assertEquals(typeof redisVersion, "string");
+  assertEquals(/^\d+\.\d+\.\d+$/.test(redisVersion), true);
+});
+
+Deno.test("init - getLatestVersion: matches actual deno.json version for fedify package", async () => {
+  const denoJsonPath = new URL("../fedify/deno.json", import.meta.url).pathname;
+  const denoJsonContent = await Deno.readTextFile(denoJsonPath);
+  const denoJson = JSON.parse(denoJsonContent);
+  const actualVersion = denoJson.version;
+
+  const expectedVersion = getLatestVersion("@fedify/fedify");
+  assertEquals(expectedVersion, actualVersion);
+});
+
+Deno.test("init - getLatestVersion: matches actual deno.json version for Postgres package", async () => {
+  const denoJsonPath =
+    new URL("../postgres/deno.json", import.meta.url).pathname;
+  const denoJsonContent = await Deno.readTextFile(denoJsonPath);
+  const denoJson = JSON.parse(denoJsonContent);
+  const actualVersion = denoJson.version;
+
+  const expectedVersion = getLatestVersion("@fedify/postgres");
+  assertEquals(expectedVersion, actualVersion);
 });

--- a/cli/init.ts
+++ b/cli/init.ts
@@ -319,7 +319,7 @@ Then, try look up an actor from your server:
     init: (projectName, runtime, pm) => ({
       dependencies: {
         express: "^4.19.2",
-        "@fedify/express": "^0.2.1",
+        "@fedify/express": getLatestVersion("@fedify/express"),
         ...(runtime === "node"
           ? {
             "@dotenvx/dotenvx": "^1.14.1",
@@ -405,7 +405,7 @@ Then, try look up an actor from your server:
         ".",
       ],
       dependencies: {
-        "@fedify/h3": "^0.1.2",
+        "@fedify/h3": getLatestVersion("@fedify/h3"),
       },
       federationFile: "server/federation.ts",
       loggingFile: "server/logging.ts",
@@ -462,7 +462,7 @@ const kvStores: Record<KvStore, KvStoreDescription> = {
   redis: {
     label: "Redis",
     dependencies: {
-      "@fedify/redis": "^0.2.1",
+      "@fedify/redis": getLatestVersion("@fedify/redis"),
       "npm:ioredis": "^5.4.1",
     },
     imports: { "@fedify/redis": ["RedisKvStore"], ioredis: ["Redis"] },
@@ -478,7 +478,7 @@ const kvStores: Record<KvStore, KvStoreDescription> = {
   postgres: {
     label: "PostgreSQL",
     dependencies: {
-      "@fedify/postgres": "^0.2.0",
+      "@fedify/postgres": getLatestVersion("@fedify/postgres"),
       "npm:postgres": "^3.4.5",
     },
     imports: { "@fedify/postgres": ["PostgresKvStore"], postgres: "postgres" },
@@ -517,7 +517,7 @@ const messageQueues: Record<MessageQueue, MessageQueueDescription> = {
   redis: {
     label: "Redis",
     dependencies: {
-      "@fedify/redis": "^0.2.1",
+      "@fedify/redis": getLatestVersion("@fedify/redis"),
       "npm:ioredis": "^5.4.1",
     },
     imports: { "@fedify/redis": ["RedisMessageQueue"], ioredis: ["Redis"] },
@@ -533,7 +533,7 @@ const messageQueues: Record<MessageQueue, MessageQueueDescription> = {
   postgres: {
     label: "PostgreSQL",
     dependencies: {
-      "@fedify/postgres": "^0.2.0",
+      "@fedify/postgres": getLatestVersion("@fedify/postgres"),
       "npm:postgres": "^3.4.5",
     },
     imports: {
@@ -552,7 +552,7 @@ const messageQueues: Record<MessageQueue, MessageQueueDescription> = {
   amqp: {
     label: "AMQP (e.g., RabbitMQ)",
     dependencies: {
-      "@fedify/amqp": "^0.1.0",
+      "@fedify/amqp": getLatestVersion("@fedify/amqp"),
       "npm:amqplib": "^0.10.4",
     },
     devDependencies: {
@@ -1082,7 +1082,7 @@ await configure({
       }
     }
     const dependencies: Record<string, string> = {
-      "@fedify/fedify": `^${getLatestVersion("@fedify/fedify")}`,
+      "@fedify/fedify": getLatestVersion("@fedify/fedify"),
       "@logtape/logtape": "^0.8.2",
       ...initializer.dependencies,
       ...kvStoreDesc?.dependencies,


### PR DESCRIPTION
## Summary
add `getLatestVersion()` function in the CLI init command to dynamically fetch the latest package versions from JSR API instead of using local metadata files.

## Related Issue
- #306 

## Changes
- Add `getLatestVersion()` and Replaced all hardcoded @fedify package versions throughout the init command with getLatestVersion() calls
- Added comprehensive test coverage for getLatestVersion() function in init.test.ts

## Benefits

- `@fedify/cli` run support latest version about `@fedify/projects` 

## Checklist

- [ ] Did you add a changelog entry to the *CHANGES.md*?
- [ ] Did you write some relevant docs about this change (if it's a new feature)?
- [ ] Did you write a regression test to reproduce the bug (if it's a bug fix)?
- [x] Did you write some tests for this change (if it's a new feature)?
- [x] Did you run `deno task test-all` on your machine?
