### PR TITLE
docs: Replace @typeParam with @template in JSDoc comments for consist…

### DIFF
--- a/fedify/compat/transformers.ts
+++ b/fedify/compat/transformers.ts
@@ -17,7 +17,7 @@ const logger = getLogger(["fedify", "compat", "transformers"]);
  * https://example.com/#Follow/12345678-1234-5678-1234-567812345678
  * ```
  *
- * @typeParam TContextData The type of the context data.
+ * @template TContextData The type of the context data.
  * @param activity The activity to assign an ID to.
  * @param context The context of the activity.
  * @return The activity with an ID assigned.
@@ -80,7 +80,7 @@ export function autoIdAssigner<TContextData>(
  *
  * As some ActivityPub implementations like Threads fail to deal with inlined
  * actor objects, this transformer can be used to work around this issue.
- * @typeParam TContextData The type of the context data.
+ * @template TContextData The type of the context data.
  * @param activity The activity to dehydrate the actor property of.
  * @param context The context of the activity.
  * @returns The dehydrated activity.
@@ -99,7 +99,7 @@ export function actorDehydrator<TContextData>(
 /**
  * Gets the default activity transformers that are applied to all outgoing
  * activities.
- * @typeParam TContextData The type of the context data.
+ * @template TContextData The type of the context data.
  * @returns The default activity transformers.
  * @since 1.4.0
  */

--- a/fedify/federation/builder.ts
+++ b/fedify/federation/builder.ts
@@ -1352,7 +1352,7 @@ export class FederationBuilderImpl<TContextData>
   /**
    * Get the URL path for a custom collection.
    * If the collection is not registered, returns null.
-   * @typeParam TParam The parameter names of the requested URL.
+   * @template TParam The parameter names of the requested URL.
    * @param {string | symbol} name The name of the custom collection.
    * @param {TParam} values The values to fill in the URL parameters.
    * @returns {string | null} The URL path for the custom collection, or null if not registered.

--- a/fedify/federation/callback.ts
+++ b/fedify/federation/callback.ts
@@ -9,7 +9,7 @@ import type { SenderKeyPair } from "./send.ts";
 /**
  * A callback that dispatches a {@link NodeInfo} object.
  *
- * @typeParam TContextData The context data to pass to the {@link Context}.
+ * @template TContextData The context data to pass to the {@link Context}.
  */
 export type NodeInfoDispatcher<TContextData> = (
   context: RequestContext<TContextData>,
@@ -18,7 +18,7 @@ export type NodeInfoDispatcher<TContextData> = (
 /**
  * A callback that dispatches an {@link Actor} object.
  *
- * @typeParam TContextData The context data to pass to the {@link Context}.
+ * @template TContextData The context data to pass to the {@link Context}.
  * @param context The request context.
  * @param identifier The actor's internal identifier or username.
  */
@@ -30,7 +30,7 @@ export type ActorDispatcher<TContextData> = (
 /**
  * A callback that dispatches key pairs for an actor.
  *
- * @typeParam TContextData The context data to pass to the {@link Context}.
+ * @template TContextData The context data to pass to the {@link Context}.
  * @param context The context.
  * @param identifier The actor's internal identifier or username.
  * @returns The key pairs.
@@ -44,7 +44,7 @@ export type ActorKeyPairsDispatcher<TContextData> = (
 /**
  * A callback that maps a WebFinger username to the corresponding actor's
  * internal identifier, or `null` if the username is not found.
- * @typeParam TContextData The context data to pass to the {@link Context}.
+ * @template TContextData The context data to pass to the {@link Context}.
  * @param context The context.
  * @param username The WebFinger username.
  * @returns The actor's internal identifier, or `null` if the username is not
@@ -59,7 +59,7 @@ export type ActorHandleMapper<TContextData> = (
 /**
  * A callback that maps a WebFinger query to the corresponding actor's
  * internal identifier or username, or `null` if the query is not found.
- * @typeParam TContextData The context data to pass to the {@link Context}.
+ * @template TContextData The context data to pass to the {@link Context}.
  * @param context The request context.
  * @param resource The URL that was queried through WebFinger.
  * @returns The actor's internal identifier or username, or `null` if the query
@@ -78,9 +78,9 @@ export type ActorAliasMapper<TContextData> = (
 /**
  * A callback that dispatches an object.
  *
- * @typeParam TContextData The context data to pass to the {@link Context}.
- * @typeParam TObject The type of object to dispatch.
- * @typeParam TParam The parameter names of the requested URL.
+ * @template TContextData The context data to pass to the {@link Context}.
+ * @template TObject The type of object to dispatch.
+ * @template TParam The parameter names of the requested URL.
  * @since 0.7.0
  */
 export type ObjectDispatcher<
@@ -95,11 +95,11 @@ export type ObjectDispatcher<
 /**
  * A callback that dispatches a collection.
  *
- * @typeParam TItem The type of items in the collection.
- * @typeParam TContext The type of the context. {@link Context} or
+ * @template TItem The type of items in the collection.
+ * @template TContext The type of the context. {@link Context} or
  *                     {@link RequestContext}.
- * @typeParam TContextData The context data to pass to the `TContext`.
- * @typeParam TFilter The type of the filter, if any.
+ * @template TContextData The context data to pass to the `TContext`.
+ * @template TFilter The type of the filter, if any.
  * @param context The context.
  * @param identifier The internal identifier or the username of the collection
  *                   owner.
@@ -122,7 +122,7 @@ export type CollectionDispatcher<
 /**
  * A callback that counts the number of items in a collection.
  *
- * @typeParam TContextData The context data to pass to the {@link Context}.
+ * @template TContextData The context data to pass to the {@link Context}.
  * @param context The context.
  * @param identifier The internal identifier or the username of the collection
  *                   owner.
@@ -137,10 +137,10 @@ export type CollectionCounter<TContextData, TFilter> = (
 /**
  * A callback that returns a cursor for a collection.
  *
- * @typeParam TContext The type of the context. {@link Context} or
+ * @template TContext The type of the context. {@link Context} or
  *                     {@link RequestContext}.
- * @typeParam TContextData The context data to pass to the {@link Context}.
- * @typeParam TFilter The type of the filter, if any.
+ * @template TContextData The context data to pass to the {@link Context}.
+ * @template TFilter The type of the filter, if any.
  * @param context The context.
  * @param identifier The internal identifier or the username of the collection
  *                   owner.
@@ -159,8 +159,8 @@ export type CollectionCursor<
 /**
  * A callback that listens for activities in an inbox.
  *
- * @typeParam TContextData The context data to pass to the {@link Context}.
- * @typeParam TActivity The type of activity to listen for.
+ * @template TContextData The context data to pass to the {@link Context}.
+ * @template TActivity The type of activity to listen for.
  * @param context The inbox context.
  * @param activity The activity that was received.
  */
@@ -172,7 +172,7 @@ export type InboxListener<TContextData, TActivity extends Activity> = (
 /**
  * A callback that handles errors in an inbox.
  *
- * @typeParam TContextData The context data to pass to the {@link Context}.
+ * @template TContextData The context data to pass to the {@link Context}.
  * @param context The inbox context.
  */
 export type InboxErrorHandler<TContextData> = (
@@ -184,7 +184,7 @@ export type InboxErrorHandler<TContextData> = (
  * A callback that dispatches the key pair for the authenticated document loader
  * of the {@link Context} passed to the shared inbox listener.
  *
- * @typeParam TContextData The context data to pass to the {@link Context}.
+ * @template TContextData The context data to pass to the {@link Context}.
  * @param context The context.
  * @returns The username or the internal identifier of the actor or the key pair
  *          for the authenticated document loader of the {@link Context} passed
@@ -224,7 +224,7 @@ export type OutboxErrorHandler = (
 /**
  * A callback that determines if a request is authorized or not.
  *
- * @typeParam TContextData The context data to pass to the {@link Context}.
+ * @template TContextData The context data to pass to the {@link Context}.
  * @param context The request context.
  * @param identifier The internal identifier of the actor that is being requested.
  * @param signedKey *Deprecated in Fedify 1.5.0 in favor of
@@ -250,8 +250,8 @@ export type AuthorizePredicate<TContextData> = (
 /**
  * A callback that determines if a request is authorized or not.
  *
- * @typeParam TContextData The context data to pass to the {@link Context}.
- * @typeParam TParam The parameter names of the requested URL.
+ * @template TContextData The context data to pass to the {@link Context}.
+ * @template TParam The parameter names of the requested URL.
  * @param context The request context.
  * @param values The parameters of the requested URL.
  * @param signedKey *Deprecated in Fedify 1.5.0 in favor of
@@ -277,12 +277,12 @@ export type ObjectAuthorizePredicate<TContextData, TParam extends string> = (
 /**
  * A callback that dispatches a custom collection.
  *
- * @typeParam TItem The type of items in the collection.
- * @typeParam TParams The parameter names of the requested URL.
- * @typeParam TContext The type of the context. {@link Context} or
+ * @template TItem The type of items in the collection.
+ * @template TParams The parameter names of the requested URL.
+ * @template TContext The type of the context. {@link Context} or
  *                     {@link RequestContext}.
- * @typeParam TContextData The context data to pass to the `TContext`.
- * @typeParam TFilter The type of the filter, if any.
+ * @template TContextData The context data to pass to the `TContext`.
+ * @template TFilter The type of the filter, if any.
  * @param context The context.
  * @param values The parameters of the requested URL.
  * @param cursor The cursor to start the collection from, or `null` to dispatch
@@ -303,8 +303,8 @@ export type CustomCollectionDispatcher<
 /**
  * A callback that counts the number of items in a custom collection.
  *
- * @typeParam TParams The parameter names of the requested URL.
- * @typeParam TContextData The context data to pass to the {@link Context}.
+ * @template TParams The parameter names of the requested URL.
+ * @template TContextData The context data to pass to the {@link Context}.
  * @param context The context.
  * @param values The parameters of the requested URL.
  * @since 1.8.0
@@ -320,11 +320,11 @@ export type CustomCollectionCounter<
 /**
  * A callback that returns a cursor for a custom collection.
  *
- * @typeParam TParams The parameter names of the requested URL.
- * @typeParam TContext The type of the context. {@link Context} or
+ * @template TParams The parameter names of the requested URL.
+ * @template TContext The type of the context. {@link Context} or
  *                     {@link RequestContext}.
- * @typeParam TContextData The context data to pass to the {@link Context}.
- * @typeParam TFilter The type of the filter, if any.
+ * @template TContextData The context data to pass to the {@link Context}.
+ * @template TFilter The type of the filter, if any.
  * @param context The context.
  * @param values The parameters of the requested URL.
  * @since 1.8.0

--- a/fedify/federation/federation.ts
+++ b/fedify/federation/federation.ts
@@ -61,7 +61,7 @@ export interface FederationStartQueueOptions {
 
 /**
  * A common interface between {@link Federation} and {@link FederationBuilder}.
- * @typeParam TContextData The context data to pass to the {@link Context}.
+ * @template TContextData The context data to pass to the {@link Context}.
  * @since 1.6.0
  */
 export interface Federatable<TContextData> {
@@ -111,9 +111,9 @@ export interface Federatable<TContextData> {
   /**
    * Registers an object dispatcher.
    *
-   * @typeParam TContextData The context data to pass to the {@link Context}.
-   * @typeParam TObject The type of object to dispatch.
-   * @typeParam TParam The parameter names of the requested URL.
+   * @template TContextData The context data to pass to the {@link Context}.
+   * @template TObject The type of object to dispatch.
+   * @template TParam The parameter names of the requested URL.
    * @param cls The Activity Vocabulary class of the object to dispatch.
    * @param path The URI path pattern for the object dispatcher.  The syntax is
    *             based on URI Template
@@ -132,9 +132,9 @@ export interface Federatable<TContextData> {
   /**
    * Registers an object dispatcher.
    *
-   * @typeParam TContextData The context data to pass to the {@link Context}.
-   * @typeParam TObject The type of object to dispatch.
-   * @typeParam TParam The parameter names of the requested URL.
+   * @template TContextData The context data to pass to the {@link Context}.
+   * @template TObject The type of object to dispatch.
+   * @template TParam The parameter names of the requested URL.
    * @param cls The Activity Vocabulary class of the object to dispatch.
    * @param path The URI path pattern for the object dispatcher.  The syntax is
    *             based on URI Template
@@ -153,9 +153,9 @@ export interface Federatable<TContextData> {
   /**
    * Registers an object dispatcher.
    *
-   * @typeParam TContextData The context data to pass to the {@link Context}.
-   * @typeParam TObject The type of object to dispatch.
-   * @typeParam TParam The parameter names of the requested URL.
+   * @template TContextData The context data to pass to the {@link Context}.
+   * @template TObject The type of object to dispatch.
+   * @template TParam The parameter names of the requested URL.
    * @param cls The Activity Vocabulary class of the object to dispatch.
    * @param path The URI path pattern for the object dispatcher.  The syntax is
    *             based on URI Template
@@ -174,9 +174,9 @@ export interface Federatable<TContextData> {
   /**
    * Registers an object dispatcher.
    *
-   * @typeParam TContextData The context data to pass to the {@link Context}.
-   * @typeParam TObject The type of object to dispatch.
-   * @typeParam TParam The parameter names of the requested URL.
+   * @template TContextData The context data to pass to the {@link Context}.
+   * @template TObject The type of object to dispatch.
+   * @template TParam The parameter names of the requested URL.
    * @param cls The Activity Vocabulary class of the object to dispatch.
    * @param path The URI path pattern for the object dispatcher.  The syntax is
    *             based on URI Template
@@ -195,9 +195,9 @@ export interface Federatable<TContextData> {
   /**
    * Registers an object dispatcher.
    *
-   * @typeParam TContextData The context data to pass to the {@link Context}.
-   * @typeParam TObject The type of object to dispatch.
-   * @typeParam TParam The parameter names of the requested URL.
+   * @template TContextData The context data to pass to the {@link Context}.
+   * @template TObject The type of object to dispatch.
+   * @template TParam The parameter names of the requested URL.
    * @param cls The Activity Vocabulary class of the object to dispatch.
    * @param path The URI path pattern for the object dispatcher.  The syntax is
    *             based on URI Template
@@ -215,9 +215,9 @@ export interface Federatable<TContextData> {
   /**
    * Registers an object dispatcher.
    *
-   * @typeParam TContextData The context data to pass to the {@link Context}.
-   * @typeParam TObject The type of object to dispatch.
-   * @typeParam TParam The parameter names of the requested URL.
+   * @template TContextData The context data to pass to the {@link Context}.
+   * @template TObject The type of object to dispatch.
+   * @template TParam The parameter names of the requested URL.
    * @param cls The Activity Vocabulary class of the object to dispatch.
    * @param path The URI path pattern for the object dispatcher.  The syntax is
    *             based on URI Template
@@ -451,9 +451,9 @@ export interface Federatable<TContextData> {
   /**
    * Registers a collection of objects dispatcher.
    *
-   * @typeParam TContextData The context data to pass to the {@link Context}.
-   * @typeParam TObject The type of objects to dispatch.
-   * @typeParam TParam The parameter names of the requested URL.
+   * @template TContextData The context data to pass to the {@link Context}.
+   * @template TObject The type of objects to dispatch.
+   * @template TParam The parameter names of the requested URL.
    * @param name A unique name for the collection dispatcher.
    * @param itemType The Activity Vocabulary class of the object to dispatch.
    * @param path The URI path pattern for the collection dispatcher.
@@ -484,9 +484,9 @@ export interface Federatable<TContextData> {
   /**
    * Registers an ordered collection of objects dispatcher.
    *
-   * @typeParam TContextData The context data to pass to the {@link Context}.
-   * @typeParam TObject The type of objects to dispatch.
-   * @typeParam TParam The parameter names of the requested URL.
+   * @template TContextData The context data to pass to the {@link Context}.
+   * @template TObject The type of objects to dispatch.
+   * @template TParam The parameter names of the requested URL.
    * @param name A unique name for the collection dispatcher.
    * @param itemType The Activity Vocabulary class of the object to dispatch.
    * @param path The URI path pattern for the collection dispatcher.
@@ -521,7 +521,7 @@ export interface Federatable<TContextData> {
  *
  * It also provides a middleware interface for handling requests before your
  * web framework's router; see {@link Federation.fetch}.
- * @typeParam TContextData The context data to pass to the {@link Context}.
+ * @template TContextData The context data to pass to the {@link Context}.
  * @since 0.13.0
  */
 export interface Federation<TContextData> extends Federatable<TContextData> {
@@ -594,7 +594,7 @@ export interface Federation<TContextData> extends Federatable<TContextData> {
  * instantiation of the {@link Federation} object until the {@link build}
  * method is called so that dispatchers and listeners can be registered
  * before the {@link Federation} object is instantiated.
- * @typeParam TContextData The context data to pass to the {@link Context}.
+ * @template TContextData The context data to pass to the {@link Context}.
  * @since 1.6.0
  */
 export interface FederationBuilder<TContextData>
@@ -610,7 +610,7 @@ export interface FederationBuilder<TContextData>
 
 /**
  * Options for creating a {@link Federation} object.
- * @typeParam TContextData The context data to pass to the {@link Context}.
+ * @template TContextData The context data to pass to the {@link Context}.
  * @since 1.6.0
  */
 export interface FederationOptions<TContextData> {
@@ -895,10 +895,10 @@ export interface ObjectCallbackSetters<
 /**
  * Additional settings for a collection dispatcher.
  *
- * @typeParam TContext The type of the context.  {@link Context} or
+ * @template TContext The type of the context.  {@link Context} or
  *                     {@link RequestContext}.
- * @typeParam TContextData The context data to pass to the {@link Context}.
- * @typeParam TFilter The type of filter for the collection.
+ * @template TContextData The context data to pass to the {@link Context}.
+ * @template TFilter The type of filter for the collection.
  */
 export interface CollectionCallbackSetters<
   TContext extends Context<TContextData>,
@@ -988,7 +988,7 @@ export interface InboxListenerSetters<TContextData> {
 /**
  * Parameters of {@link Federation.fetch} method.
  *
- * @typeParam TContextData The context data to pass to the {@link Context}.
+ * @template TContextData The context data to pass to the {@link Context}.
  * @since 0.6.0
  */
 export interface FederationFetchOptions<TContextData> {
@@ -1026,11 +1026,11 @@ export interface FederationFetchOptions<TContextData> {
 /**
  * Additional settings for a custom collection dispatcher.
  *
- * @typeParam TParams The type of the parameters in the URL path.
- * @typeParam TContext The type of the context.  {@link Context} or
+ * @template TParams The type of the parameters in the URL path.
+ * @template TContext The type of the context.  {@link Context} or
  *                     {@link RequestContext}.
- * @typeParam TContextData The context data to pass to the {@link Context}.
- * @typeParam TFilter The type of filter for the collection.
+ * @template TContextData The context data to pass to the {@link Context}.
+ * @template TFilter The type of filter for the collection.
  */
 export interface CustomCollectionCallbackSetters<
   TParams extends Record<string, string>,
@@ -1106,7 +1106,7 @@ export interface CustomCollectionCallbackSetters<
  * Represents an object with a type ID, which is either a constructor or an
  * instance of the object.
  *
- * @typeParam TObject The type of the object.
+ * @template TObject The type of the object.
  */
 export type ConstructorWithTypeId<TObject extends Object> =
   // deno-lint-ignore no-explicit-any
@@ -1172,7 +1172,7 @@ type ParamPath<Param extends string> = `${string}{${Param}}${string}`;
 /**
  * Converts union types to intersection types.
  *
- * @typeParam U - The union type to convert.
+ * @template U - The union type to convert.
  * @returns The intersection type of the union.
  * @example
  * ```ts

--- a/fedify/federation/handler.ts
+++ b/fedify/federation/handler.ts
@@ -60,7 +60,7 @@ export function acceptsJsonLd(request: Request): boolean {
 
 /**
  * Parameters for handling an actor request.
- * @typeParam TContextData The context data to pass to the context.
+ * @template TContextData The context data to pass to the context.
  */
 export interface ActorHandlerParameters<TContextData> {
   identifier: string;
@@ -74,7 +74,7 @@ export interface ActorHandlerParameters<TContextData> {
 
 /**
  * Handles an actor request.
- * @typeParam TContextData The context data to pass to the context.
+ * @template TContextData The context data to pass to the context.
  * @param request The HTTP request.
  * @param parameters The parameters for handling the actor.
  * @returns A promise that resolves to an HTTP response.
@@ -138,7 +138,7 @@ export async function handleActor<TContextData>(
 
 /**
  * Parameters for handling an object request.
- * @typeParam TContextData The context data to pass to the context.
+ * @template TContextData The context data to pass to the context.
  */
 export interface ObjectHandlerParameters<TContextData> {
   values: Record<string, string>;
@@ -152,7 +152,7 @@ export interface ObjectHandlerParameters<TContextData> {
 
 /**
  * Handles an object request.
- * @typeParam TContextData The context data to pass to the context.
+ * @template TContextData The context data to pass to the context.
  * @param request The HTTP request.
  * @param parameters The parameters for handling the object.
  * @returns A promise that resolves to an HTTP response.
@@ -209,10 +209,10 @@ export async function handleObject<TContextData>(
 
 /**
  * Callbacks for handling a collection.
- * @typeParam TItem The type of items in the collection.
- * @typeParam TContext The type of the context. {@link Context} or {@link RequestContext}.
- * @typeParam TContextData The context data to pass to the `TContext`.
- * @typeParam TFilter The type of the filter.
+ * @template TItem The type of items in the collection.
+ * @template TContext The type of the context. {@link Context} or {@link RequestContext}.
+ * @template TContextData The context data to pass to the `TContext`.
+ * @template TFilter The type of the filter.
  */
 export interface CollectionCallbacks<
   TItem,
@@ -248,10 +248,10 @@ export interface CollectionCallbacks<
 
 /**
  * Parameters for handling a collection request.
- * @typeParam TItem The type of items in the collection.
- * @typeParam TContext The type of the context, extending {@link RequestContext}.
- * @typeParam TContextData The context data to pass to the `TContext`.
- * @typeParam TFilter The type of the filter.
+ * @template TItem The type of items in the collection.
+ * @template TContext The type of the context, extending {@link RequestContext}.
+ * @template TContextData The context data to pass to the `TContext`.
+ * @template TFilter The type of the filter.
  */
 export interface CollectionHandlerParameters<
   TItem,
@@ -279,10 +279,10 @@ export interface CollectionHandlerParameters<
 
 /**
  * Handles a collection request.
- * @typeParam TItem The type of items in the collection.
- * @typeParam TContext The type of the context, extending {@link RequestContext}.
- * @typeParam TContextData The context data to pass to the `TContext`.
- * @typeParam TFilter The type of the filter.
+ * @template TItem The type of items in the collection.
+ * @template TContext The type of the context, extending {@link RequestContext}.
+ * @template TContextData The context data to pass to the `TContext`.
+ * @template TFilter The type of the filter.
  * @param request The HTTP request.
  * @param parameters The parameters for handling the collection.
  * @returns A promise that resolves to an HTTP response.
@@ -490,7 +490,7 @@ export async function handleCollection<
 
 /**
  * Filters collection items based on the provided predicate.
- * @typeParam TItem The type of items to filter.
+ * @template TItem The type of items to filter.
  * @param items The items to filter.
  * @param collectionName The name of the collection for logging purposes.
  * @param filterPredicate Optional predicate function to filter items.
@@ -528,7 +528,7 @@ function filterCollectionItems<TItem extends Object | Link | Recipient | URL>(
 
 /**
  * Parameters for handling an inbox request.
- * @typeParam TContextData The context data to pass to the context.
+ * @template TContextData The context data to pass to the context.
  */
 export interface InboxHandlerParameters<TContextData> {
   recipient: string | null;
@@ -556,7 +556,7 @@ export interface InboxHandlerParameters<TContextData> {
 
 /**
  * Handles an inbox request for ActivityPub activities.
- * @typeParam TContextData The context data to pass to the context.
+ * @template TContextData The context data to pass to the context.
  * @param request The HTTP request.
  * @param options The parameters for handling the inbox.
  * @returns A promise that resolves to an HTTP response.
@@ -591,7 +591,7 @@ export async function handleInbox<TContextData>(
 
 /**
  * Internal function for handling inbox requests with detailed processing.
- * @typeParam TContextData The context data to pass to the context.
+ * @template TContextData The context data to pass to the context.
  * @param request The HTTP request.
  * @param options The parameters for handling the inbox.
  * @param span The OpenTelemetry span for tracing.
@@ -861,10 +861,10 @@ async function handleInboxInternal<TContextData>(
 
 /**
  * Callbacks for handling a custom collection.
- * @typeParam TItem The type of items in the collection.
- * @typeParam TParams The parameter names of the requested URL.
- * @typeParam TContext The type of the context. {@link Context} or {@link RequestContext}.
- * @typeParam TContextData The context data to pass to the `TContext`.
+ * @template TItem The type of items in the collection.
+ * @template TParams The parameter names of the requested URL.
+ * @template TContext The type of the context. {@link Context} or {@link RequestContext}.
+ * @template TContextData The context data to pass to the `TContext`.
  * @since 1.8.0
  */
 export interface CustomCollectionCallbacks<
@@ -909,10 +909,10 @@ export interface CustomCollectionCallbacks<
 
 /**
  * Parameters for handling a custom collection.
- * @typeParam TItem The type of items in the collection.
- * @typeParam TParams The parameter names of the requested URL.
- * @typeParam TContext The type of the context, extending {@link RequestContext}.
- * @typeParam TContextData The context data to pass to the `TContext`.
+ * @template TItem The type of items in the collection.
+ * @template TParams The parameter names of the requested URL.
+ * @template TContext The type of the context, extending {@link RequestContext}.
+ * @template TContextData The context data to pass to the `TContext`.
  * @since 1.8.0
  */
 export interface CustomCollectionHandlerParameters<
@@ -936,10 +936,10 @@ export interface CustomCollectionHandlerParameters<
 
 /**
  * Handles a custom collection request.
- * @typeParam TItem The type of items in the collection.
- * @typeParam TParams The parameter names of the requested URL.
- * @typeParam TContext The type of the context, extending {@link RequestContext}.
- * @typeParam TContextData The context data to pass to the `TContext`.
+ * @template TItem The type of items in the collection.
+ * @template TParams The parameter names of the requested URL.
+ * @template TContext The type of the context, extending {@link RequestContext}.
+ * @template TContextData The context data to pass to the `TContext`.
  * @param request The HTTP request.
  * @param handleParams Parameters for handling the collection.
  * @returns A promise that resolves to an HTTP response.
@@ -1000,10 +1000,10 @@ async function _handleCustomCollection<
 
 /**
  * Handles an ordered collection request.
- * @typeParam TItem The type of items in the collection.
- * @typeParam TParams The parameter names of the requested URL.
- * @typeParam TContext The type of the context, extending {@link RequestContext}.
- * @typeParam TContextData The context data to pass to the `TContext`.
+ * @template TItem The type of items in the collection.
+ * @template TParams The parameter names of the requested URL.
+ * @template TContext The type of the context, extending {@link RequestContext}.
+ * @template TContextData The context data to pass to the `TContext`.
  * @param request The HTTP request.
  * @param handleParams Parameters for handling the collection.
  * @returns A promise that resolves to an HTTP response.
@@ -1066,12 +1066,12 @@ async function _handleOrderedCollection<
  * Handling custom collections with support for pagination and filtering.
  * The main flow is on `getCollection`, `dispatch`.
  *
- * @typeParam TItem The type of items in the collection.
- * @typeParam TParams The parameter names of the requested URL.
- * @typeParam TContext The type of the context. {@link Context} or {@link RequestContext}.
- * @typeParam TContextData The context data to pass to the `TContext`.
- * @typeParam TCollection The type of the collection, extending {@link Collection}.
- * @typeParam TCollectionPage The type of the collection page, extending {@link CollectionPage}.
+ * @template TItem The type of items in the collection.
+ * @template TParams The parameter names of the requested URL.
+ * @template TContext The type of the context. {@link Context} or {@link RequestContext}.
+ * @template TContextData The context data to pass to the `TContext`.
+ * @template TCollection The type of the collection, extending {@link Collection}.
+ * @template TCollectionPage The type of the collection page, extending {@link CollectionPage}.
  * @since 1.8.0
  */
 class CustomCollectionHandler<
@@ -1401,7 +1401,7 @@ type TotalItems = number | bigint | null | undefined;
 
 /**
  * A wrapper function that catches specific errors and handles them appropriately.
- * @typeParam TParams The type of parameters that extend ErrorHandlers.
+ * @template TParams The type of parameters that extend ErrorHandlers.
  * @param handler The handler function to wrap.
  * @returns A wrapped handler function that catches and handles specific errors.
  * @since 1.8.0
@@ -1440,7 +1440,7 @@ interface ErrorHandlers {
 
 /**
  * Verifies that a value is defined (not undefined).
- * @typeParam T The type of the value, excluding undefined.
+ * @template T The type of the value, excluding undefined.
  * @param callbacks The value to verify.
  * @throws {ItemsNotFoundError} If the value is undefined.
  * @since 1.8.0
@@ -1465,7 +1465,7 @@ const verifyJsonLdRequest = (request: Request): void | never => {
 
 /**
  * Performs authorization if needed based on the authorization predicate.
- * @typeParam TContextData The context data type.
+ * @template TContextData The context data type.
  * @param {RequestContext<TContextData>} context The request context.
  * @param {Record<string, string>} values The parameter values.
  * @param options Options containing the authorization predicate.
@@ -1519,7 +1519,7 @@ const warning = {
 
 /**
  * Appends a cursor parameter to a URL if the cursor exists.
- * @typeParam Cursor The type of the cursor (string, null, or undefined).
+ * @template Cursor The type of the cursor (string, null, or undefined).
  * @param {URL} url The base URL to append the cursor to.
  * @param {string | null | undefined} cursor The cursor value to append.
  * @returns The URL with cursor appended if cursor is a string, null otherwise.

--- a/fedify/federation/kv.ts
+++ b/fedify/federation/kv.ts
@@ -29,7 +29,7 @@ export interface KvStore {
    * Gets the value for the given key.
    * @param key The key to get the value for.
    * @returns The value for the key, or `undefined` if the key does not exist.
-   * @typeParam T The type of the value to get.
+   * @template T The type of the value to get.
    */
   get<T = unknown>(key: KvKey): Promise<T | undefined>;
 

--- a/fedify/federation/middleware.ts
+++ b/fedify/federation/middleware.ts
@@ -108,7 +108,7 @@ import { extractInboxes, sendActivity, type SenderKeyPair } from "./send.ts";
 
 /**
  * Options for {@link createFederation} function.
- * @typeParam TContextData The type of the context data.
+ * @template TContextData The type of the context data.
  * @since 0.10.0
  * @deprecated Use {@link FederationOptions} instead.
  */

--- a/fedify/sig/key.ts
+++ b/fedify/sig/key.ts
@@ -193,7 +193,7 @@ export interface FetchKeyResult<T extends CryptographicKey | Multikey> {
  * Fetches a {@link CryptographicKey} or {@link Multikey} from the given URL.
  * If the given URL contains an {@link Actor} object, it tries to find
  * the corresponding key in the `publicKey` or `assertionMethod` property.
- * @typeParam T The type of the key to fetch.  Either {@link CryptographicKey}
+ * @template T The type of the key to fetch.  Either {@link CryptographicKey}
  *              or {@link Multikey}.
  * @param keyId The URL of the key.
  * @param cls The class of the key to fetch.  Either {@link CryptographicKey}

--- a/fedify/sig/proof.ts
+++ b/fedify/sig/proof.ts
@@ -390,7 +390,7 @@ export interface VerifyObjectOptions extends VerifyProofOptions {
  * Verifies the given object.  It will verify all the proofs in the object,
  * and succeed only if all the proofs are valid and all attributions and
  * actors are authenticated by the proofs.
- * @typeParam T The type of the object to verify.
+ * @template T The type of the object to verify.
  * @param cls The class of the object to verify.  It must be a subclass of
  *            the {@link Object}.
  * @param jsonLd The JSON-LD object to verify.  It's assumed that the object

--- a/fedify/x/fresh.ts
+++ b/fedify/x/fresh.ts
@@ -84,9 +84,9 @@ export function integrateFetchOptions(
  * export const handler = integrateHandler(federation, () => undefined);
  * ```
  *
- * @typeParam TContextData A type of the context data for the {@link Federation}
+ * @template TContextData A type of the context data for the {@link Federation}
  *                         object.
- * @typeParam TFreshContext A type of the Fresh context.
+ * @template TFreshContext A type of the Fresh context.
  * @param federation A {@link Federation} object to integrate with Fresh.
  * @param createContextData A function to create a context data for the
  *                          {@link Federation} object.

--- a/fedify/x/hono.ts
+++ b/fedify/x/hono.ts
@@ -32,9 +32,9 @@ type HonoMiddleware<THonoContext extends HonoContext> = (
  * A factory function to create a context data for the {@link Federation}
  * object.
  *
- * @typeParam TContextData A type of the context data for the {@link Federation}
+ * @template TContextData A type of the context data for the {@link Federation}
  *                         object.
- * @typeParam THonoContext A type of the Hono context.
+ * @template THonoContext A type of the Hono context.
  * @param context A Hono context object.
  * @returns A context data for the {@link Federation} object.
  */
@@ -45,9 +45,9 @@ export type ContextDataFactory<TContextData, THonoContext> = (
 /**
  * Create a Hono middleware to integrate with the {@link Federation} object.
  *
- * @typeParam TContextData A type of the context data for the {@link Federation}
+ * @template TContextData A type of the context data for the {@link Federation}
  *                         object.
- * @typeParam THonoContext A type of the Hono context.
+ * @template THonoContext A type of the Hono context.
  * @param federation A {@link Federation} object to integrate with Hono.
  * @param contextDataFactory A function to create a context data for the
  *                           {@link Federation} object.

--- a/fedify/x/sveltekit.ts
+++ b/fedify/x/sveltekit.ts
@@ -35,7 +35,7 @@ type HookParams = {
  * export const handle = fedifyHook(federation, () => undefined);
  * ```
  *
- * @typeParam TContextData A type of the context data for the {@link Federation}
+ * @template TContextData A type of the context data for the {@link Federation}
  *                         object.
  * @param federation A {@link Federation} object to integrate with SvelteKit.
  * @param createContextData A function to create a context data for the

--- a/h3/index.ts
+++ b/h3/index.ts
@@ -12,7 +12,7 @@ import {
 /**
  * A factory function that creates the context data that will be passed to the
  * `Federation` instance.
- * @typeParam TContextData The type of the context data that will be passed to
+ * @template TContextData The type of the context data that will be passed to
  *                         the `Federation` instance.
  * @param event The event that triggered the handler.
  * @param request The request that triggered the handler.

--- a/testing/mock.ts
+++ b/testing/mock.ts
@@ -99,7 +99,7 @@ export interface SentActivity {
  * await federation.receiveActivity(createActivity);
  * ```
  *
- * @typeParam TContextData The context data to pass to the {@link Context}.
+ * @template TContextData The context data to pass to the {@link Context}.
  * @since 1.8.0
  */
 export class MockFederation<TContextData> implements Federation<TContextData> {
@@ -616,7 +616,7 @@ interface InboxListener<TContextData, TActivity extends Activity> {
  * console.log(sent[0].activity);
  * ```
  *
- * @typeParam TContextData The context data to pass to the {@link Context}.
+ * @template TContextData The context data to pass to the {@link Context}.
  * @since 1.8.0
  */
 export class MockContext<TContextData> implements Context<TContextData> {


### PR DESCRIPTION
## Summary
Replaced all incorrect usages of the @typeParam JSDoc tag with the correct @template tag across the Fedify codebase.

## Related Issue

- closes #336 

## Changes

- Replaced all instances of @typeParam with @template in JSDoc comments

## Benefits
- Aligns with the official JSDoc specification for documenting type parameters
- Ensures proper recognition by documentation generation tools
- Improves IDE support for autocompletion, type hints, and documentation previews
- Enhances developer experience and removes potential confusion

## Checklist

- [ ] Did you add a changelog entry to the *CHANGES.md*?
- [ ] Did you write some relevant docs about this change (if it's a new feature)?
- [ ] Did you write a regression test to reproduce the bug (if it's a bug fix)?
- [ ] Did you write some tests for this change (if it's a new feature)?
- [x] Did you run `deno task test-all` on your machine?
