### PR TITLE
fix: display object type of an activity for inbox command

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -112,8 +112,10 @@ the versioning.
      -  Added `getCollectionUri()` method to the `Context` interface.
      -  Added utility types `ConstructorWithTypeId` and `ParamsKeyPath` for
         custom collection dispatchers.
+  - Update the `fedify inbox` command to display the type of the object contained in each activity, in addition to the activity’s own type. [[#191], [#342] by Jang Hanarae]
 
 [#168]: https://github.com/fedify-dev/fedify/issues/168
+[#191]: https://github.com/fedify-dev/fedify/issues/191
 [#197]: https://github.com/fedify-dev/fedify/issues/197
 [#248]: https://github.com/fedify-dev/fedify/issues/248
 [#260]: https://github.com/fedify-dev/fedify/issues/260
@@ -136,7 +138,7 @@ the versioning.
 [#328]: https://github.com/fedify-dev/fedify/pull/328
 [#331]: https://github.com/fedify-dev/fedify/pull/331
 [#332]: https://github.com/fedify-dev/fedify/pull/332
-
+[#342]: https://github.com/fedify-dev/fedify/pull/342
 
 Version 1.7.7
 -------------

--- a/cli/inbox.tsx
+++ b/cli/inbox.tsx
@@ -399,18 +399,22 @@ function printServerInfo(fedCtx: Context<ContextData>): void {
     .render();
 }
 
-function printActivityEntry(idx: number, entry: ActivityEntry): void {
+async function printActivityEntry(
+  idx: number,
+  entry: ActivityEntry,
+): Promise<void> {
   const request = entry.request.clone();
   const response = entry.response?.clone();
   const url = new URL(request.url);
   const activity = entry.activity;
+  const object = await activity?.getObject();
   new Table(
     [new Cell("Request #:").align("right"), colors.bold(idx.toString())],
     [
       new Cell("Activity type:").align("right"),
-      activity == null
-        ? colors.red("failed to parse")
-        : colors.green(activity.constructor.name),
+      activity == null ? colors.red("failed to parse") : colors.green(
+        `${activity.constructor.name}(${object?.constructor.name})`,
+      ),
     ],
     [
       new Cell("HTTP request:").align("right"),
@@ -508,7 +512,7 @@ function createFetchHandler(
       recordingSink.stopRecording();
       activities[idx].response = response.clone();
       activities[idx].logs = recordingSink.getRecords();
-      printActivityEntry(idx, activities[idx]);
+      await printActivityEntry(idx, activities[idx]);
     }
     return response;
   };


### PR DESCRIPTION
## Summary

Update the `fedify inbox` command to display the type of the object contained in each activity, in addition to the activity’s own type.

## Related Issue

Reference the related issue(s) by number, e.g.: 

- fixes #191 

## Changes

Use getObject() to fetch the activity’s object, obtain its type from the constructor, and display it alongside the activity type.
Because getObject() is asynchronous, update printActivityEntry() to be an async function.

## Benefits

This makes it easier to see which object the activity refers to:
e.g) as-is: Undo → to-be: Undo(Follow), Create → Create(Note).

## Checklist

- [x] Did you add a changelog entry to the *CHANGES.md*?
- [ ] Did you write some relevant docs about this change (if it's a new feature)?
- [ ] Did you write a regression test to reproduce the bug (if it's a bug fix)?
- [ ] Did you write some tests for this change (if it's a new feature)?
- [x] Did you run `deno task test-all` on your machine?