### PR TITLE
deps: add debug package to fix VitePress dev server import error

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -28,6 +28,7 @@
     "@types/node": "catalog:",
     "amqplib": "catalog:",
     "dayjs": "^1.11.13",
+    "debug": "^4.4.1",
     "express": "catalog:",
     "h3": "catalog:",
     "hono": "^4.6.14",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ importers:
       dayjs:
         specifier: ^1.11.13
         version: 1.11.13
+      debug:
+        specifier: ^4.4.1
+        version: 4.4.1
       express:
         specifier: 'catalog:'
         version: 4.21.2


### PR DESCRIPTION
## Summary

This PR adds the `debug` package directly to the fedify/docs package to resolve a vitepress dev runtime syntax error caused by a missing indirect dependency.

## Related Issue

- closes #330 

## Changes

- Added `debug` as a direct dependency in `fedify/docs` to resolve module resolution failure.

## Benefits

- Fixes `Uncaught SyntaxError` when launching the VitePress dev server.
- Ensures that Mermaid diagrams continue to render correctly.
- Improves local development experience without compromising on plugin features.

## Checklist

- [ ] Did you add a changelog entry to the *CHANGES.md*?
- [ ] Did you write some relevant docs about this change (if it's a new feature)?
- [ ] Did you write a regression test to reproduce the bug (if it's a bug fix)?
- [ ] Did you write some tests for this change (if it's a new feature)?
- [x] Did you run `deno task test-all` on your machine?

## Additional Notes
The root cause is that `vitepress-mermaid-plugin` indirectly depends on `debug`, which isn't hoisted properly by pnpm, leading to module resolution errors in monorepo environments.

See related discussion: [vitepress-plugin-mermaid issue #87](https://github.com/emersonbottero/vitepress-plugin-mermaid/issues/87)

Alternative solutions considered:

**1. Remove `vitepress-mermaid-plugin`**
   - ✅ Resolves the error  
   - ❌ Disables Mermaid diagram rendering

**2. Use `pnpm install --shamefully-hoist`**
   - ✅ Recommended by plugin author  
   - ❌ Ineffective in monorepo setup and may negatively impact performance due to full dependency flattening

After evaluation, directly adding `debug` was the most stable and minimal-impact solution.
