### PR TITLE
Add skip guard to RedisKvStore tests temporarily

### DIFF
--- a/redis/kv.test.ts
+++ b/redis/kv.test.ts
@@ -15,6 +15,7 @@ function getRedis(): { redis: Redis; keyPrefix: string; store: RedisKvStore } {
 }
 
 test("RedisKvStore.get()", { skip }, async () => {
+  if (skip) return; // see https://github.com/oven-sh/bun/issues/19412
   const { redis, keyPrefix, store } = getRedis();
   try {
     await redis.set(`${keyPrefix}foo::bar`, '"foobar"');
@@ -25,6 +26,7 @@ test("RedisKvStore.get()", { skip }, async () => {
 });
 
 test("RedisKvStore.set()", { skip }, async () => {
+  if (skip) return; // see https://github.com/oven-sh/bun/issues/19412
   const { redis, keyPrefix, store } = getRedis();
   try {
     await store.set(["foo", "baz"], "baz");
@@ -35,6 +37,7 @@ test("RedisKvStore.set()", { skip }, async () => {
 });
 
 test("RedisKvStore.delete()", { skip }, async () => {
+  if (skip) return; // see https://github.com/oven-sh/bun/issues/19412
   const { redis, keyPrefix, store } = getRedis();
   try {
     await redis.set(`${keyPrefix}foo::baz`, '"baz"');


### PR DESCRIPTION
## Summary

Add `if (skip) return` guards to `RedisKvStore` tests to prevent test execution when marked as skipped. This is a temporary workaround for a known Bun issue.

Prevents runtime errors when tests are conditionally skipped due to Bun issue. Ensures test suite can run reliably in environments affected by this issue.


## Related Issue

* refs [https://github.com/oven-sh/bun/issues/19412](https://github.com/oven-sh/bun/issues/19412)

## Changes

* Added skip guards to:

  * `RedisKvStore.get()` test
  * `RedisKvStore.set()` test
  * `RedisKvStore.delete()` test

## Checklist

* [ ] Did you add a changelog entry to the *CHANGES.md*?
* [ ] Did you write some relevant docs about this change (if it's a new feature)?
* [ ] Did you write a regression test to reproduce the bug (if it's a bug fix)?
* [x] Did you write some tests for this change (if it's a new feature)? *(N/A — updated existing tests)*
* [x] Did you run `deno task test-all` on your machine?

## Additional Notes

This is a temporary workaround. Once the upstream Bun issue is resolved, these skip guards can be removed.
