### PR TITLE
Fix nodeinfo color support in Windows Terminal

### DIFF
--- a/packages/cli/src/nodeinfo.ts
+++ b/packages/cli/src/nodeinfo.ts
@@ -299,6 +299,14 @@ function checkTerminalColorSupport(): "truecolor" | "256color" | "none" {
     return "256color";
   }
 
+  // Check for Windows Terminal support
+  // FIXME: WT_SESSION is not a reliable way to check for Windows Terminal support
+  const isWindows = Deno.build.os === "windows";
+  const isWT = Deno.env.get("WT_SESSION");
+  if (isWindows && isWT != null && isWT !== "") {
+    return "truecolor";
+  }
+
   return "none";
 }
 


### PR DESCRIPTION
## Summary

Adds a temporary check for Windows Terminal support using the `WT_SESSION` environment variable.  

## Related Issue

- fixes #358 

## Changes

- Added platform check for Windows via `Deno.build.os === "windows"`.
- If running on Windows and the `WT_SESSION` environment variable is present and non-empty,
  the terminal is assumed to support `truecolor`.
- Added a `FIXME` comment to indicate the limitation and future work.

## Benefits

- Improved compatibility with Windows Terminal
  Enables `truecolor` support when running in Windows Terminal, improving visual output of CLI tools.
<img width="1115" height="628" alt="image" src="https://github.com/user-attachments/assets/4a11fa7f-57fb-4dbb-8402-83c060c3b037" />


## Additional Notes

- This is a heuristic, not a guaranteed detection.


