### PR TITLE
fix: change nodeinfo version fallback behavior

### DIFF
--- a/packages/fedify/src/nodeinfo/client.test.ts
+++ b/packages/fedify/src/nodeinfo/client.test.ts
@@ -371,6 +371,42 @@ test("parseSoftware()", () => {
       version: { major: 1, minor: 2, patch: 3, build: [], prerelease: [] },
     },
   );
+  assertEquals(
+    parseSoftware({
+      name: "foo",
+      version: "2.81",
+      repository: "",
+      homepage: "",
+    }, { tryBestEffort: true }),
+    {
+      name: "foo",
+      version: { major: 2, minor: 81, patch: 0, build: [], prerelease: [] },
+    },
+  );
+  assertEquals(
+    parseSoftware({
+      name: "foo",
+      version: "3",
+      repository: "",
+      homepage: "",
+    }, { tryBestEffort: true }),
+    {
+      name: "foo",
+      version: { major: 3, minor: 0, patch: 0, build: [], prerelease: [] },
+    },
+  );
+  assertEquals(
+    parseSoftware({
+      name: "foo",
+      version: "2.1.3.4",
+      repository: "",
+      homepage: "",
+    }, { tryBestEffort: true }),
+    {
+      name: "foo",
+      version: { major: 2, minor: 1, patch: 3, build: [], prerelease: [] },
+    },
+  );
 });
 
 test("parseProtocol()", () => {

--- a/packages/fedify/src/nodeinfo/client.ts
+++ b/packages/fedify/src/nodeinfo/client.ts
@@ -271,7 +271,18 @@ export function parseSoftware(
       version = parseSemVer(data.version);
     } catch {
       if (!options.tryBestEffort) return null;
-      version = { major: 0, minor: 0, patch: 0, build: [], prerelease: [] };
+      const splitted_numbers = data.version.split(".");
+
+      const toInt = (letter: string) => {
+        const num = parseInt(letter ?? "0");
+        return isNaN(num) ? 0 : num;
+      };
+
+      const major = toInt(splitted_numbers[0]);
+      const minor = toInt(splitted_numbers[1]);
+      const patch = toInt(splitted_numbers[2]);
+
+      version = { major, minor, patch, build: [], prerelease: [] };
     }
   } else {
     if (!options.tryBestEffort) return null;
@@ -304,6 +315,7 @@ export function parseSoftware(
   const result: Software = { name, version };
   if (repository != null) result.repository = repository;
   if (homepage != null) result.homepage = homepage;
+
   return result;
 }
 


### PR DESCRIPTION
## Summary

Implementation of the immediate fix mentioned in #353, which supports non-Semver version strings.

## Related Issue

- fixes #353 

## Changes

- Change fallback behavior of `parseSoftware()` to handle non-Semver number string.

## Benefits

- Since the version field of the nodeinfo specification doesn't have to be semver, it supports other formats.

## Checklist

- [ ] Did you add a changelog entry to the *CHANGES.md*?
- [ ] Did you write some relevant docs about this change (if it's a new feature)?
- [x] Did you write a regression test to reproduce the bug (if it's a bug fix)?
- [ ] Did you write some tests for this change (if it's a new feature)?
- [x] Did you run `deno task test-all` on your machine?

## Additional Notes

Include any other information, context, or considerations.
