### PR TITLE
Add support for Redis Cluster

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -30,6 +30,11 @@ To be released.
  -  Created [Next.js] integration as the *@fedify/next* package.
     [[#313] by Chanhaeng Lee]
 
+### @fedify/redis
+
+ -  Added support for Redis Cluster to the *@fedify/redis* package.
+    [TODO]
+
 [Next.js]: https://nextjs.org/
 [#313]: https://github.com/fedify-dev/fedify/issues/313
 [#353]: https://github.com/fedify-dev/fedify/issues/353

--- a/packages/redis/README.md
+++ b/packages/redis/README.md
@@ -16,11 +16,26 @@ implementations for Redis:
 ~~~~ typescript
 import { createFederation } from "@fedify/fedify";
 import { RedisKvStore, RedisMessageQueue } from "@fedify/redis";
-import { Redis } from "ioredis";
+import { Redis, Cluster } from "ioredis";
 
+// Using a standalone Redis instance:
 const federation = createFederation({
   kv: new RedisKvStore(new Redis()),
   queue: new RedisMessageQueue(() => new Redis()),
+});
+
+// Using a Redis Cluster:
+const federation = createFederation({
+  kv: new RedisKvStore(new Cluster([
+    { host: "127.0.0.1", port: 7000 },
+    { host: "127.0.0.1", port: 7001 },
+    { host: "127.0.0.1", port: 7002 },
+  ])),
+  queue: new RedisMessageQueue(() => new Cluster([
+    { host: "127.0.0.1", port: 7000 },
+    { host: "127.0.0.1", port: 7001 },
+    { host: "127.0.0.1", port: 7002 },
+  ])),
 });
 ~~~~
 


### PR DESCRIPTION
## Summary

Added support for Redis Cluster

This change allows for `Cluster` to be used instead of `Redis` when initialising the `kvstore` / `mq`

`Cluster` implements the same interface as `Redis` and exposes the same methods, so should be ok as a drop-in replacement

## Related Issue

n/a

## Changes

Redis `kv` and `mq` updated to accept `Cluster` in place of `Redis`

## Benefits

Allows clustered Redis to be used

## Checklist

- [x] Did you add a changelog entry to the *CHANGES.md*?
- [x] Did you write some relevant docs about this change (if it's a new feature)?
- [ ] Did you write a regression test to reproduce the bug (if it's a bug fix)?
- [ ] Did you write some tests for this change (if it's a new feature)?
- [x] Did you run `deno task test-all` on your machine?

## Additional Notes

n/a