### PR TITLE
Fix undici body lock error in NestJS middleware

### DIFF
--- a/docs/manual/integration.md
+++ b/docs/manual/integration.md
@@ -393,6 +393,7 @@ import {
   RequestMethod,
 } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import * as express from 'express';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { DatabaseModule } from './database/database.module';
@@ -439,8 +440,12 @@ export class AppModule implements NestModule {
       },
     );
 
-    // Apply middleware to all routes except auth endpoints
-    consumer.apply(fedifyMiddleware).forRoutes({ path: '*', method: RequestMethod.ALL });
+    // Fedify middleware requires the raw request body for HTTP signature verification
+    // so we apply `express.raw()` before `fedifyMiddleware` to preserve the body.
+    consumer.apply(
+      express.raw({ type: '*/*' }),
+      fedifyMiddleware
+    ).forRoutes({ path: '*', method: RequestMethod.ALL });
   }
 }
 ~~~~

--- a/packages/nestjs/README.md
+++ b/packages/nestjs/README.md
@@ -71,6 +71,8 @@ import {
   NestModule,
   RequestMethod,
 } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import * as express from 'express';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { DatabaseModule } from './database/database.module';
@@ -117,8 +119,12 @@ export class AppModule implements NestModule {
       },
     );
 
-    // Apply middleware to all routes except auth endpoints
-    consumer.apply(fedifyMiddleware)
+    // Fedify middleware requires the raw request body for HTTP signature verification
+    // so we apply `express.raw()` before `fedifyMiddleware` to preserve the body.
+    consumer.apply(
+      express.raw({ type: '*/*' }),
+      fedifyMiddleware,
+    ).forRoutes({ path: '*', method: RequestMethod.ALL
   }
 }
 

--- a/packages/nestjs/src/fedify.middleware.ts
+++ b/packages/nestjs/src/fedify.middleware.ts
@@ -86,7 +86,7 @@ function fromERequest(req: ERequest): Request {
     headers,
     // @ts-ignore: duplex is not supported in Deno, but it is in Node.js
     duplex: "half",
-    body: req.method === "GET" || req.method === "HEAD" ? undefined : req.body,
+    body: req.method === "GET" || req.method === "HEAD" ? undefined : (req.body && typeof req.body === 'object' && !Buffer.isBuffer(req.body) ? JSON.stringify(req.body) : req.body),
   });
 }
 

--- a/packages/nestjs/src/fedify.middleware.ts
+++ b/packages/nestjs/src/fedify.middleware.ts
@@ -86,9 +86,7 @@ function fromERequest(req: ERequest): Request {
     headers,
     // @ts-ignore: duplex is not supported in Deno, but it is in Node.js
     duplex: "half",
-    body: req.method === "GET" || req.method === "HEAD"
-      ? undefined
-      : (Readable.toWeb(req)),
+    body: req.method === "GET" || req.method === "HEAD" ? undefined : req.body,
   });
 }
 


### PR DESCRIPTION
Fixes an issue where undici threw a body lock error because NestJS had already consumed the request stream. Replaced Readable.toWeb(req) with req.body to ensure compatibility.
