### PR TITLE
fix: Remove documentLoader property from FederationOptions interface

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,10 +13,7 @@ To be released.
  - Remove documentLoader property from FederationOptions interface.
     [[#376],[#393] by Hasang Cho]
 
-    - In fedify/src/federation/federation.ts, removed documentLoader property.
-    - In cli/src/inbox.tsx, switched the inbox command to the loader factory API by replacing the deprecated documentLoader with documentLoaderFactory/contextLoaderFactory and reusing a single instance from getDocumentLoader(), with no functional changes.
-    - In fedify/src/federation/middleware.ts, refactored federationImpl to replace the deprecated documentLoader with documentLoaderFactory, drop the documentLoader-related allowPrivateAddress/userAgent guard, and route loader creation through factories with no intended behavior change.
-    - In fedify/src/federation/middleware.test.ts, migrated tests to the loader factory API (documentLoaderFactory), removed the obsolete allowPrivateAddress+documentLoader assertion, fixed ctx.documentLoader expectations, split mocks (/auth-check vs /object) to avoid URL collisions, and used a rejecting loader in the first context to ensure null on lookup.
+    - Replaced `documentLoader` with `documentLoaderFactory` with no user-facing behavior changes.
 
  -  Migrated from *@phensley/language-tag* package and its `LanguageTag` class
     to the standardized `Intl.Locale` class for representing language tags.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,13 +10,13 @@ To be released.
 
 ### @fedify/fedify
 
-- Remove documentLoader property from FederationOptions interface.
-  [[#376],[#393] by Hasang Cho]
+  - Remove documentLoader property from FederationOptions interface.
+    [[#376],[#393] by Hasang Cho]
 
     - In fedify/src/federation/federation.ts, removed documentLoader property.
     - In cli/src/inbox.tsx, switched the inbox command to the loader factory API by replacing the deprecated documentLoader with documentLoaderFactory/contextLoaderFactory and reusing a single instance from getDocumentLoader(), with no functional changes.
     - In fedify/src/federation/middleware.ts, refactored federationImpl to replace the deprecated documentLoader with documentLoaderFactory, drop the documentLoader-related allowPrivateAddress/userAgent guard, and route loader creation through factories with no intended behavior change.
-    -  In fedify/src/federation/middleware.test.ts, migrated tests to the loader factory API (documentLoaderFactory), removed the obsolete allowPrivateAddress+documentLoader assertion, fixed ctx.documentLoader expectations, split mocks (/auth-check vs /object) to avoid URL collisions, and used a rejecting loader in the first context to ensure null on lookup.
+    - In fedify/src/federation/middleware.test.ts, migrated tests to the loader factory API (documentLoaderFactory), removed the obsolete allowPrivateAddress+documentLoader assertion, fixed ctx.documentLoader expectations, split mocks (/auth-check vs /object) to avoid URL collisions, and used a rejecting loader in the first context to ensure null on lookup.
 
  -  Migrated from *@phensley/language-tag* package and its `LanguageTag` class
     to the standardized `Intl.Locale` class for representing language tags.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,14 @@ To be released.
 
 ### @fedify/fedify
 
+- Remove documentLoader property from FederationOptions interface.
+  [[#376],[#393] by Hasang Cho]
+
+    - In fedify/src/federation/federation.ts, removed documentLoader property.
+    - In cli/src/inbox.tsx, switched the inbox command to the loader factory API by replacing the deprecated documentLoader with documentLoaderFactory/contextLoaderFactory and reusing a single instance from getDocumentLoader(), with no functional changes.
+    - In fedify/src/federation/middleware.ts, refactored federationImpl to replace the deprecated documentLoader with documentLoaderFactory, drop the documentLoader-related allowPrivateAddress/userAgent guard, and route loader creation through factories with no intended behavior change.
+    -  In fedify/src/federation/middleware.test.ts, migrated tests to the loader factory API (documentLoaderFactory), removed the obsolete allowPrivateAddress+documentLoader assertion, fixed ctx.documentLoader expectations, split mocks (/auth-check vs /object) to avoid URL collisions, and used a rejecting loader in the first context to ensure null on lookup.
+
  -  Migrated from *@phensley/language-tag* package and its `LanguageTag` class
     to the standardized `Intl.Locale` class for representing language tags.
     [[#280], [#392] by Jang Hanarae]
@@ -24,7 +32,8 @@ To be released.
 
 [#280]: https://github.com/fedify-dev/fedify/issues/280
 [#392]: https://github.com/fedify-dev/fedify/pull/392
-
+[#376]: https://github.com/fedify-dev/fedify/issues/376
+[#393]: https://github.com/fedify-dev/fedify/pulls/393
 
 Version 1.9.0
 -------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,7 +10,7 @@ To be released.
 
 ### @fedify/fedify
 
-  - Remove documentLoader property from FederationOptions interface.
+ - Remove documentLoader property from FederationOptions interface.
     [[#376],[#393] by Hasang Cho]
 
     - In fedify/src/federation/federation.ts, removed documentLoader property.

--- a/packages/cli/src/inbox.tsx
+++ b/packages/cli/src/inbox.tsx
@@ -183,9 +183,11 @@ export const command = new Command()
     printServerInfo(fedCtx);
   });
 
+const cliDocumentLoader = await getDocumentLoader();
 const federation = createFederation<ContextData>({
   kv: new MemoryKvStore(),
-  documentLoader: await getDocumentLoader(),
+  documentLoaderFactory: () => cliDocumentLoader,
+  contextLoaderFactory: () => cliDocumentLoader,
 });
 
 const time = Temporal.Now.instant();

--- a/packages/fedify/src/federation/federation.ts
+++ b/packages/fedify/src/federation/federation.ts
@@ -675,13 +675,6 @@ export interface FederationOptions<TContextData> {
   contextLoaderFactory?: DocumentLoaderFactory;
 
   /**
-   * A custom JSON-LD document loader.  By default, this uses the built-in
-   * cache-backed loader that fetches remote documents over HTTP(S).
-   * @deprecated Use {@link documentLoaderFactory} instead.
-   */
-  documentLoader?: DocumentLoader;
-
-  /**
    * A custom JSON-LD context loader.  By default, this uses the same loader
    * as the document loader.
    * @deprecated Use {@link contextLoaderFactory} instead.

--- a/packages/fedify/src/federation/middleware.ts
+++ b/packages/fedify/src/federation/middleware.ts
@@ -16,9 +16,9 @@ import {
   ATTR_HTTP_RESPONSE_STATUS_CODE,
   ATTR_URL_FULL,
 } from "@opentelemetry/semantic-conventions";
+import metadata from "../../deno.json" with { type: "json" };
 import { getDefaultActivityTransformers } from "../compat/transformers.ts";
 import type { ActivityTransformer } from "../compat/types.ts";
-import metadata from "../../deno.json" with { type: "json" };
 import { getNodeInfo, type GetNodeInfoOptions } from "../nodeinfo/client.ts";
 import { handleNodeInfo, handleNodeInfoJrd } from "../nodeinfo/handler.ts";
 import type { JsonValue, NodeInfo } from "../nodeinfo/types.ts";
@@ -317,12 +317,7 @@ export class FederationImpl<TContextData>
       false;
     this._initializeRouter();
     if (options.allowPrivateAddress || options.userAgent != null) {
-      if (options.documentLoader != null) {
-        throw new TypeError(
-          "Cannot set documentLoader with allowPrivateAddress or " +
-            "userAgent options.",
-        );
-      } else if (options.contextLoader != null) {
+      if (options.contextLoader != null) {
         throw new TypeError(
           "Cannot set contextLoader with allowPrivateAddress or " +
             "userAgent options.",
@@ -336,32 +331,18 @@ export class FederationImpl<TContextData>
     }
     const { allowPrivateAddress, userAgent } = options;
     this.allowPrivateAddress = allowPrivateAddress ?? false;
-    if (options.documentLoader != null) {
-      if (options.documentLoaderFactory != null) {
-        throw new TypeError(
-          "Cannot set both documentLoader and documentLoaderFactory options " +
-            "at a time; use documentLoaderFactory only.",
-        );
-      }
-      this.documentLoaderFactory = () => options.documentLoader!;
-      logger.warn(
-        "The documentLoader option is deprecated; use documentLoaderFactory " +
-          "option instead.",
-      );
-    } else {
-      this.documentLoaderFactory = options.documentLoaderFactory ??
-        ((opts) => {
-          return kvCache({
-            loader: getDocumentLoader({
-              allowPrivateAddress: opts?.allowPrivateAddress ??
-                allowPrivateAddress,
-              userAgent: opts?.userAgent ?? userAgent,
-            }),
-            kv: options.kv,
-            prefix: this.kvPrefixes.remoteDocument,
-          });
+    this.documentLoaderFactory = options.documentLoaderFactory ??
+      ((opts) => {
+        return kvCache({
+          loader: getDocumentLoader({
+            allowPrivateAddress: opts?.allowPrivateAddress ??
+              allowPrivateAddress,
+            userAgent: opts?.userAgent ?? userAgent,
+          }),
+          kv: options.kv,
+          prefix: this.kvPrefixes.remoteDocument,
         });
-    }
+      });
     if (options.contextLoader != null) {
       if (options.contextLoaderFactory != null) {
         throw new TypeError(


### PR DESCRIPTION
## Summary

Remove documentLoader property from FederationOptions interface (use documentLoaderFactory instead)

## Related Issue

- Implemented #376 

## Changes

- In fedify/src/federation/federation.ts, removed documentLoader property.

- In cli/src/inbox.tsx, switched the inbox command to the loader factory API by replacing the deprecated documentLoader with documentLoaderFactory/contextLoaderFactory and reusing a single instance from getDocumentLoader(), with no functional changes.

- In fedify/src/federation/middleware.ts, refactored federationImpl to replace the deprecated documentLoader with documentLoaderFactory, drop the documentLoader-related allowPrivateAddress/userAgent guard, and route loader creation through factories with no intended behavior change.

-  In fedify/src/federation/middleware.test.ts, migrated tests to the loader factory API (documentLoaderFactory), removed the obsolete allowPrivateAddress+documentLoader assertion, fixed ctx.documentLoader expectations, split mocks (/auth-check vs /object) to avoid URL collisions, and used a rejecting loader in the first context to ensure null on lookup.

- Updated versions in deno.json and package.json from 1.9.0 to 2.0.0.

## Additional Notes
- Ran 'deno task test', all checks and tests passed.
- When I tried to run 'deno task test', I removed the '--doc' option in deno.json because an error occurred in next/README.md.