### PR TITLE
Fixed SvelteKit integration hook types

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -116,6 +116,8 @@ To be released.
  -  Created SvelteKit integration as the *@fedify/sveltekit* package.
     Separated from `@fedify/fedify/x/sveltekit` to improve modularity and
     reduce bundle size.  [[#375] by Chanhaeng Lee]
+ -  Fixed SvelteKit integration hook types to correctly infer the request
+    and response types in hooks.  [ by Chanhaeng Lee]
 
 
 Version 1.8.8

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -117,7 +117,10 @@ To be released.
     Separated from `@fedify/fedify/x/sveltekit` to improve modularity and
     reduce bundle size.  [[#375] by Chanhaeng Lee]
  -  Fixed SvelteKit integration hook types to correctly infer the request
-    and response types in hooks.  [ by Chanhaeng Lee]
+    and response types in hooks.  [[#271], [#394] by Chanhaeng Lee]
+
+[#271]: https://github.com/fedify-dev/fedify/pull/271
+[#394]: https://github.com/fedify-dev/fedify/pull/394
 
 
 Version 1.8.8

--- a/packages/sveltekit/deno.json
+++ b/packages/sveltekit/deno.json
@@ -3,15 +3,13 @@
   "version": "1.9.0",
   "license": "MIT",
   "imports": {
-    "@std/assert": "jsr:@std/assert@^1.0.13"
+    "@std/assert": "jsr:@std/assert@^1.0.13",
+    "@sveltejs/kit": "npm:@sveltejs/kit@^2.0.0"
   },
   "exports": {
     ".": "./src/mod.ts"
   },
-  "exclude": [
-    "dist",
-    "node_modules"
-  ],
+  "exclude": ["dist", "node_modules"],
   "tasks": {
     "check": "deno fmt --check && deno lint && deno check src/*.ts",
     "test": "deno test --allow-net --allow-env"

--- a/packages/sveltekit/src/mod.test.ts
+++ b/packages/sveltekit/src/mod.test.ts
@@ -1,29 +1,19 @@
 import { strictEqual } from "node:assert/strict";
 import { describe, test } from "node:test";
 import { fedifyHook } from "./mod.ts";
+import type { RequestEvent } from "@sveltejs/kit";
 
-interface MockRequestEvent {
-  request: Request;
-}
-
-interface MockHookParams {
-  event: MockRequestEvent;
-  resolve: (event: MockRequestEvent) => Promise<Response>;
-}
-
-interface MockFederation<T> {
+interface MockFederation {
   fetch(request: Request, options: unknown): Promise<Response>;
 }
 
 describe("fedifyHook", () => {
   test("creates hook handler function", () => {
-    const mockFederation: MockFederation<undefined> = {
+    const mockFederation = {
       fetch: () => Promise.resolve(new Response("OK")),
     };
 
-    const createContextData = () => undefined;
-
-    const hookHandler = fedifyHook(mockFederation as never, createContextData);
+    const hookHandler = fedifyHook(mockFederation as never);
     strictEqual(typeof hookHandler, "function");
   });
 
@@ -31,7 +21,7 @@ describe("fedifyHook", () => {
     let capturedRequest: Request | undefined;
     let capturedOptions: unknown;
 
-    const mockFederation: MockFederation<string> = {
+    const mockFederation: MockFederation = {
       fetch: (request, options) => {
         capturedRequest = request;
         capturedOptions = options;
@@ -44,7 +34,7 @@ describe("fedifyHook", () => {
     const hookHandler = fedifyHook(mockFederation as never, createContextData);
 
     const mockRequest = new Request("https://example.com/test");
-    const mockEvent: MockRequestEvent = { request: mockRequest };
+    const mockEvent: RequestEvent = { request: mockRequest } as RequestEvent;
     const mockResolve = () =>
       Promise.resolve(new Response("SvelteKit response"));
 
@@ -64,7 +54,7 @@ describe("fedifyHook", () => {
   test("handles async context data creation", async () => {
     let capturedContextData: unknown;
 
-    const mockFederation: MockFederation<string> = {
+    const mockFederation: MockFederation = {
       fetch: (_request, options) => {
         capturedContextData = (options as { contextData: string }).contextData;
         return Promise.resolve(new Response("OK"));
@@ -79,7 +69,7 @@ describe("fedifyHook", () => {
     const hookHandler = fedifyHook(mockFederation as never, createContextData);
 
     const mockRequest = new Request("https://example.com/test");
-    const mockEvent: MockRequestEvent = { request: mockRequest };
+    const mockEvent: RequestEvent = { request: mockRequest } as RequestEvent;
     const mockResolve = () =>
       Promise.resolve(new Response("SvelteKit response"));
 


### PR DESCRIPTION
## Summary

Fixed SvelteKit integration hook types.

## Related Issue

- fixes #271

## Changes

- `packages/sveltekit`

## Benefits

Now users who use SvelteKit integration can get proper hook types.

## Checklist

- [x] Did you add a changelog entry to the *CHANGES.md*?
- ~~[ ] Did you write some relevant docs about this change (if it's a new feature)?~~
- [x] Did you write a regression test to reproduce the bug (if it's a bug fix)?
- ~~[ ] Did you write some tests for this change (if it's a new feature)?~~
- [x] Did you run `deno task test-all` on your machine?

## Additional Notes


