### PR TITLE
feat: add custom link to WebFinger's Links fields.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,9 +58,12 @@ To be released.
      -  Changed the `href` field optional from the `Link` interface according to
         [RFC 7033 Section 4.4.4.3].
 
+ - Added setWebFingerLinkDispatcher(dispatcher) to set additional links to Links of Webfinger. [[#119], [#407] by HyeonseoKim]
+
 [FEP-5711]: https://w3id.org/fep/5711
 [OStatus 1.0 Draft 2]: https://www.w3.org/community/ostatus/wiki/images/9/93/OStatus_1.0_Draft_2.pdf
 [RFC 7033 Section 4.4.4.3]: https://datatracker.ietf.org/doc/html/rfc7033#section-4.4.4.3
+[#119]: https://github.com/fedify-dev/fedify/issues/119
 [#353]: https://github.com/fedify-dev/fedify/issues/353
 [#365]: https://github.com/fedify-dev/fedify/pull/365
 [#373]: https://github.com/fedify-dev/fedify/issues/373
@@ -68,6 +71,7 @@ To be released.
 [#381]: https://github.com/fedify-dev/fedify/pull/381
 [#402]: https://github.com/fedify-dev/fedify/issues/402
 [#404]: https://github.com/fedify-dev/fedify/pull/404
+[#407]: https://github.com/fedify-dev/fedify/pull/407
 
 ### @fedify/cli
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -68,6 +68,7 @@ const MANUAL = {
     { text: "Collections", link: "/manual/collections.md" },
     { text: "Object dispatcher", link: "/manual/object.md" },
     { text: "Access control", link: "/manual/access-control.md" },
+    { text: "WebFinger", link: "/manual/webfinger.md" },
     { text: "NodeInfo", link: "/manual/nodeinfo.md" },
     { text: "Pragmatics", link: "/manual/pragmatics.md" },
     { text: "Key–value store", link: "/manual/kv.md" },

--- a/docs/manual/webfinger.md
+++ b/docs/manual/webfinger.md
@@ -103,21 +103,21 @@ Example WebFinger response (including both automatic and custom links):
 
 ~~~~ json
 {
-  "subject": "acct:alice@example.com",
+  "subject": "acct:alice@your-domain.com",
   "links": [
     {
       "rel": "self",
       "type": "application/activity+json", 
-      "href": "https://example.com/users/alice"
+      "href": "https://your-domain.com/users/alice"
     },
     {
       "rel": "http://webfinger.net/rel/profile-page",
       "type": "text/html",
-      "href": "https://example.com/@alice"
+      "href": "https://your-domain.com/@alice"
     },
     {
       "rel": "http://ostatus.org/schema/1.0/subscribe",
-      "template": "https://example.com/authorize_interaction?uri={uri}"
+      "template": "https://your-domain.com/authorize_interaction?uri={uri}"
     }
   ]
 }
@@ -146,16 +146,41 @@ const federation = createFederation({
   // Omitted for brevity; see the related section for details.
 });
 
-federation.setWebFingerLinksDispatcher(async (ctx, _resource) => {
+federation.setWebFingerLinksDispatcher(async (ctx, resource) => {
     return [
       {
         rel: "http://ostatus.org/schema/1.0/subscribe",
-        template: "https://example.com/authorize_interaction?uri={uri}"
+        template: `https://your-domain.com/@${resource.pathname}/authorize_interaction?uri={uri}`
       }
     ];
   }
 );
 ~~~~
+
+This gives results like below:
+
+~~~~json
+{
+  "subject": "acct:alice@your-domain.com",
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/activity+json", 
+      "href": "https://your-domain.com/users/alice"
+    },
+    {
+      "rel": "http://webfinger.net/rel/profile-page",
+      "type": "text/html",
+      "href": "https://your-domain.com/@alice"
+    },
+    {
+      "rel": "http://ostatus.org/schema/1.0/subscribe",
+      "template": "https://your-domain.com/@alice@your-domain.com/authorize_interaction?uri={uri}"
+    }
+  ]
+}
+~~~~
+
 
 The WebFinger links dispatcher receives two parameters:
 

--- a/docs/manual/webfinger.md
+++ b/docs/manual/webfinger.md
@@ -150,7 +150,7 @@ federation.setWebFingerLinksDispatcher(async (ctx, _resource) => {
     return [
       {
         rel: "http://ostatus.org/schema/1.0/subscribe",
-        template: "https://your-domain.com/authorize_interaction?uri={uri}"
+        template: "https://example.com/authorize_interaction?uri={uri}"
       }
     ];
   }
@@ -169,6 +169,14 @@ The WebFinger links dispatcher receives two parameters:
 > The WebFinger endpoint is automatically exposed at `/.well-known/webfinger`
 > by the `Federation.fetch()` method. You don't need to manually handle this
 > route.
+
+> [!NOTE]
+> WebFinger responses can also be customized through 
+> `~Federatable.setActorDispatcher()` without using 
+> `~Federatable.setWebFingerLinksDispatcher()`. When an actor is configured,
+> Fedify automatically includes standard ActivityPub links in the WebFinger 
+> response. See the [WebFinger links section](./actor.md#webfinger-links) 
+> in the Actor manual for details.
 
 WebFinger lookups
 -----------------

--- a/docs/manual/webfinger.md
+++ b/docs/manual/webfinger.md
@@ -159,8 +159,11 @@ federation.setWebFingerLinksDispatcher(async (ctx, _resource) => {
 
 The WebFinger links dispatcher receives two parameters:
 
-- `ctx`: The federation context
-- `resource`: The resource The URL that provide additional info to dispatcher
+`ctx`
+:   The federation context
+
+`resource`
+:   The URL queried via WebFinger
 
 > [!TIP]
 > The WebFinger endpoint is automatically exposed at `/.well-known/webfinger`

--- a/docs/manual/webfinger.md
+++ b/docs/manual/webfinger.md
@@ -1,0 +1,212 @@
+---
+description: >-
+  WebFinger is a protocol that allows for the discovery of information
+  about people and other entities on the Internet using just their identifier.
+  This section explains how to implement WebFinger endpoints and use the
+  WebFinger client in Fedify.
+---
+
+WebFinger
+=========
+
+According to [WebFinger Website]:
+
+ > WebFinger is used to discover information about people or other entities 
+ > on the Internet that are identified by a URI using standard 
+ > Hypertext Transfer Protocol (HTTP) methods over a secure transport.
+ > A WebFinger resource returns a JavaScript Object Notation (JSON) object
+ > describing the entity that is queried. The JSON object is referred to as
+ > the JSON Resource Descriptor (JRD).
+
+WebFinger is essential for ActivityPub federation as it allows servers to
+discover actor profiles and endpoints using familiar identifiers like
+`@user@example.com`. Many ActivityPub servers, including Mastodon and Misskey,
+rely on WebFinger for account discovery.
+
+> [!NOTE]
+> Fedify implements WebFinger according to [RFC 7033] specification.
+
+[WebFinger Website]: https://webfinger.net/
+[RFC 7033]: https://datatracker.ietf.org/doc/html/rfc7033
+
+WebFinger schema
+----------------
+
+The WebFinger response follows the JSON Resource Descriptor (JRD) format
+as defined in [RFC 7033]. The main interfaces are:
+
+### `ResourceDescriptor`
+
+The main WebFinger response object:
+
+`subject`
+:   A URI that identifies the entity that this descriptor describes.
+    This is typically set automatically by Fedify.
+
+`aliases`
+:   URIs that identify the same entity as the `subject`.
+
+`properties`
+:   Additional key-value properties about the `subject`.
+
+`links`
+:   An array of [`Link`] objects pointing to related resources.
+
+### `Link`
+
+Represents a link to a related resource:
+
+`rel`
+:   *Required.* The link's relation type, which is either a URI or a
+    registered relation type (see [RFC 5988]).
+
+`type`
+:   The media type of the target resource (see [RFC 6838]).
+
+`href`
+:   A URI pointing to the target resource.
+
+`titles`
+:   Human-readable titles describing the link relation. If the language is
+    unknown or unspecified, the key is `"und"`.
+
+`properties`
+:   Additional key-value properties about the link relation.
+
+`template`
+:   *Since Fedify 1.9.0.* A URI Template ([RFC 6570]) that can be used to
+    construct URIs by substituting variables. Used primarily for subscription
+    endpoints where parameters like account URIs need to be dynamically inserted.
+
+### Common link relations
+
+Fedify automatically includes these standard link relations for ActivityPub actors:
+
+`"self"`
+:   Points to the actor's ActivityPub profile. Uses `application/activity+json`
+    as the media type.
+
+`"http://webfinger.net/rel/profile-page"`
+:   Points to the actor's human-readable profile page. Uses `text/html` as the
+    media type.
+
+`"http://webfinger.net/rel/avatar"`
+:   Points to the actor's avatar image.
+
+You can add additional custom links through the WebFinger links dispatcher:
+
+`"http://ostatus.org/schema/1.0/subscribe"`
+:   OStatus subscription endpoint for remote follows. Uses a URI template
+    with `{uri}` parameter for the account being followed.
+
+Example WebFinger response (including both automatic and custom links):
+
+~~~~ json
+{
+  "subject": "acct:alice@example.com",
+  "links": [
+    {
+      "rel": "self",
+      "type": "application/activity+json", 
+      "href": "https://example.com/users/alice"
+    },
+    {
+      "rel": "http://webfinger.net/rel/profile-page",
+      "type": "text/html",
+      "href": "https://example.com/@alice"
+    },
+    {
+      "rel": "http://ostatus.org/schema/1.0/subscribe",
+      "template": "https://example.com/authorize_interaction?uri={uri}"
+    }
+  ]
+}
+~~~~
+
+[`Link`]: https://jsr.io/@fedify/fedify/doc/webfinger/~/Link
+[RFC 5988]: https://datatracker.ietf.org/doc/html/rfc5988
+[RFC 6838]: https://datatracker.ietf.org/doc/html/rfc6838
+[RFC 6570]: https://datatracker.ietf.org/doc/html/rfc6570
+
+Customizing WebFinger endpoint
+---------------------------
+
+*This API is available since Fedify 1.9.0.*
+
+The WebFinger endpoint is automatically exposed at `/.well-known/webfinger` 
+by the `Federation.fetch()` method. You can register an additional WebFinger 
+links dispatcher with `~Federatable.setWebFingerLinksDispatcher()` method.
+The following shows how to customize a WebFinger endpoint:
+
+~~~~ typescript twoslash
+// @noErrors: 2345
+import { createFederation } from "@fedify/fedify";
+
+const federation = createFederation({
+  // Omitted for brevity; see the related section for details.
+});
+
+federation.setWebFingerLinksDispatcher(async (ctx, _resource) => {
+    return [
+      {
+        rel: "http://ostatus.org/schema/1.0/subscribe",
+        template: "https://your-domain.com/authorize_interaction?uri={uri}"
+      }
+    ];
+  }
+);
+~~~~
+
+The WebFinger links dispatcher receives two parameters:
+
+- `ctx`: The federation context
+- `resource`: The resource The URL that provide additional info to dispatcher
+
+> [!TIP]
+> The WebFinger endpoint is automatically exposed at `/.well-known/webfinger`
+> by the `Federation.fetch()` method. You don't need to manually handle this
+> route.
+
+WebFinger lookups
+-----------------
+
+*This API is available since Fedify 1.6.0.*
+
+The `Context` provides a dedicated method for WebFinger lookups when you need
+to find information about accounts and resources across federated networks.
+The `~Context.lookupWebFinger()` method allows you to query a remote server's
+WebFinger endpoint directly:
+
+~~~~ typescript twoslash
+import { type Context } from "@fedify/fedify";
+const ctx = null as unknown as Context<void>;
+// ---cut-before---
+const webfingerData = await ctx.lookupWebFinger("acct:fedify@hollo.social");
+~~~~
+
+If the lookup fails or the account doesn't exist, the method returns `null`.
+The returned WebFinger document contains links to various resources associated
+with the account, such as profile pages, ActivityPub actor URIs, and more:
+
+~~~~ typescript twoslash
+import { type Context } from "@fedify/fedify";
+const ctx = null as unknown as Context<void>;
+// ---cut-before---
+const webfingerData = await ctx.lookupWebFinger("acct:fedify@hollo.social");
+
+// Find the ActivityPub actor URI
+const activityPubActorLink = webfingerData?.links?.find(link =>
+  link.rel === "self" && link.type === "application/activity+json"
+);
+
+if (activityPubActorLink?.href) {
+  const actor = await ctx.lookupObject(activityPubActorLink.href);
+  // Work with the actor...
+}
+~~~~
+
+> [!NOTE]
+> In most cases, you can use the higher-level `~Context.lookupObject()` method
+> which automatically performs WebFinger lookups when given a handle.
+> Use `~Context.lookupWebFinger()` when you need the raw WebFinger data or
+> want more direct control over the lookup process.

--- a/docs/manual/webfinger.md
+++ b/docs/manual/webfinger.md
@@ -9,7 +9,7 @@ description: >-
 WebFinger
 =========
 
-According to [WebFinger Website]:
+According to the [WebFinger website]:
 
  > WebFinger is used to discover information about people or other entities 
  > on the Internet that are identified by a URI using standard 
@@ -26,7 +26,7 @@ rely on WebFinger for account discovery.
 > [!NOTE]
 > Fedify implements WebFinger according to [RFC 7033] specification.
 
-[WebFinger Website]: https://webfinger.net/
+[WebFinger website]: https://webfinger.net/
 [RFC 7033]: https://datatracker.ietf.org/doc/html/rfc7033
 
 WebFinger schema
@@ -129,7 +129,7 @@ Example WebFinger response (including both automatic and custom links):
 [RFC 6570]: https://datatracker.ietf.org/doc/html/rfc6570
 
 Customizing WebFinger endpoint
----------------------------
+------------------------------
 
 *This API is available since Fedify 1.9.0.*
 

--- a/packages/fedify/src/federation/builder.ts
+++ b/packages/fedify/src/federation/builder.ts
@@ -22,7 +22,7 @@ import type {
   ObjectAuthorizePredicate,
   ObjectDispatcher,
   SharedInboxKeyDispatcher,
-  WebFingerLinkDispatcher,
+  WebFingerLinksDispatcher,
 } from "./callback.ts";
 import type { Context, RequestContext } from "./context.ts";
 import type {
@@ -49,7 +49,7 @@ export class FederationBuilderImpl<TContextData>
   router: Router;
   actorCallbacks?: ActorCallbacks<TContextData>;
   nodeInfoDispatcher?: NodeInfoDispatcher<TContextData>;
-  webFingerDispatcher?: WebFingerLinkDispatcher<TContextData>;
+  webFingerLinksDispatcher?: WebFingerLinksDispatcher<TContextData>;
   objectCallbacks: Record<string, ObjectCallbacks<TContextData, string>>;
   objectTypeIds: Record<
     string,
@@ -150,7 +150,7 @@ export class FederationBuilderImpl<TContextData>
       ? undefined
       : { ...this.actorCallbacks };
     f.nodeInfoDispatcher = this.nodeInfoDispatcher;
-    f.webFingerDispatcher = this.webFingerDispatcher;
+    f.webFingerLinksDispatcher = this.webFingerLinksDispatcher;
     f.objectCallbacks = { ...this.objectCallbacks };
     f.objectTypeIds = { ...this.objectTypeIds };
     f.inboxPath = this.inboxPath;
@@ -494,10 +494,10 @@ export class FederationBuilderImpl<TContextData>
     this.nodeInfoDispatcher = dispatcher;
   }
 
-  setWebFingerLinkDispatcher(
-    dispatcher: WebFingerLinkDispatcher<TContextData>,
+  setWebFingerLinksDispatcher(
+    dispatcher: WebFingerLinksDispatcher<TContextData>,
   ): void {
-    this.webFingerDispatcher = dispatcher;
+    this.webFingerLinksDispatcher = dispatcher;
   }
 
   setObjectDispatcher<TObject extends Object, TParam extends string>(

--- a/packages/fedify/src/federation/builder.ts
+++ b/packages/fedify/src/federation/builder.ts
@@ -22,6 +22,7 @@ import type {
   ObjectAuthorizePredicate,
   ObjectDispatcher,
   SharedInboxKeyDispatcher,
+  WebFingerLinkDispatcher,
 } from "./callback.ts";
 import type { Context, RequestContext } from "./context.ts";
 import type {
@@ -48,6 +49,7 @@ export class FederationBuilderImpl<TContextData>
   router: Router;
   actorCallbacks?: ActorCallbacks<TContextData>;
   nodeInfoDispatcher?: NodeInfoDispatcher<TContextData>;
+  webFingerDispatcher?: WebFingerLinkDispatcher<TContextData>;
   objectCallbacks: Record<string, ObjectCallbacks<TContextData, string>>;
   objectTypeIds: Record<
     string,
@@ -148,6 +150,7 @@ export class FederationBuilderImpl<TContextData>
       ? undefined
       : { ...this.actorCallbacks };
     f.nodeInfoDispatcher = this.nodeInfoDispatcher;
+    f.webFingerDispatcher = this.webFingerDispatcher;
     f.objectCallbacks = { ...this.objectCallbacks };
     f.objectTypeIds = { ...this.objectTypeIds };
     f.inboxPath = this.inboxPath;
@@ -489,6 +492,12 @@ export class FederationBuilderImpl<TContextData>
       );
     }
     this.nodeInfoDispatcher = dispatcher;
+  }
+
+  setWebFingerLinkDispatcher(
+    dispatcher: WebFingerLinkDispatcher<TContextData>,
+  ): void {
+    this.webFingerDispatcher = dispatcher;
   }
 
   setObjectDispatcher<TObject extends Object, TParam extends string>(

--- a/packages/fedify/src/federation/callback.ts
+++ b/packages/fedify/src/federation/callback.ts
@@ -21,7 +21,7 @@ export type NodeInfoDispatcher<TContextData> = (
  *
  * @template TContextData The context data to pass to the {@link Context}.
  * @param resource The URL queried via WebFinger.
- * @returns Links related to the queried resource. 
+ * @returns Links related to the queried resource.
  */
 export type WebFingerLinksDispatcher<TContextData> = (
   context: RequestContext<TContextData>,

--- a/packages/fedify/src/federation/callback.ts
+++ b/packages/fedify/src/federation/callback.ts
@@ -21,9 +21,10 @@ export type NodeInfoDispatcher<TContextData> = (
  *
  * @template TContextData The context data to pass to the {@link Context}.
  */
-export type WebFingerLinkDispatcher<TContextData> = (
+export type WebFingerLinksDispatcher<TContextData> = (
   context: RequestContext<TContextData>,
-) => Link[] | Promise<Link[]>;
+  resource: URL,
+) => readonly Link[] | Promise<readonly Link[]>;
 
 /**
  * A callback that dispatches an {@link Actor} object.

--- a/packages/fedify/src/federation/callback.ts
+++ b/packages/fedify/src/federation/callback.ts
@@ -20,6 +20,7 @@ export type NodeInfoDispatcher<TContextData> = (
  * A callback that dispatches a array of {@link Link}.
  *
  * @template TContextData The context data to pass to the {@link Context}.
+ * @param resource The URL that provide additional info to dispatcher
  */
 export type WebFingerLinksDispatcher<TContextData> = (
   context: RequestContext<TContextData>,

--- a/packages/fedify/src/federation/callback.ts
+++ b/packages/fedify/src/federation/callback.ts
@@ -20,7 +20,8 @@ export type NodeInfoDispatcher<TContextData> = (
  * A callback that dispatches a array of {@link Link}.
  *
  * @template TContextData The context data to pass to the {@link Context}.
- * @param resource The URL that provide additional info to dispatcher
+ * @param resource The URL queried via WebFinger.
+ * @returns Links related to the queried resource. 
  */
 export type WebFingerLinksDispatcher<TContextData> = (
   context: RequestContext<TContextData>,

--- a/packages/fedify/src/federation/callback.ts
+++ b/packages/fedify/src/federation/callback.ts
@@ -2,6 +2,7 @@ import type { NodeInfo } from "../nodeinfo/types.ts";
 import type { Actor } from "../vocab/actor.ts";
 import type { Activity, CryptographicKey } from "../vocab/mod.ts";
 import type { Object } from "../vocab/vocab.ts";
+import type { Link } from "../webfinger/mod.ts";
 import type { PageItems } from "./collection.ts";
 import type { Context, InboxContext, RequestContext } from "./context.ts";
 import type { SenderKeyPair } from "./send.ts";
@@ -14,6 +15,15 @@ import type { SenderKeyPair } from "./send.ts";
 export type NodeInfoDispatcher<TContextData> = (
   context: RequestContext<TContextData>,
 ) => NodeInfo | Promise<NodeInfo>;
+
+/**
+ * A callback that dispatches a array of {@link Link}.
+ *
+ * @template TContextData The context data to pass to the {@link Context}.
+ */
+export type WebFingerLinkDispatcher<TContextData> = (
+  context: RequestContext<TContextData>,
+) => Link[] | Promise<Link[]>;
 
 /**
  * A callback that dispatches an {@link Actor} object.

--- a/packages/fedify/src/federation/federation.ts
+++ b/packages/fedify/src/federation/federation.ts
@@ -28,7 +28,7 @@ import type {
   ObjectDispatcher,
   OutboxErrorHandler,
   SharedInboxKeyDispatcher,
-  WebFingerLinkDispatcher,
+  WebFingerLinksDispatcher,
 } from "./callback.ts";
 import type { Context, RequestContext } from "./context.ts";
 import type { KvStore } from "./kv.ts";
@@ -84,8 +84,8 @@ export interface Federatable<TContextData> {
    * Registers a links dispatcher to WebFinger
    * @param dispatcher A links dispatcher callback to register.
    */
-  setWebFingerLinkDispatcher(
-    dispatcher: WebFingerLinkDispatcher<TContextData>,
+  setWebFingerLinksDispatcher(
+    dispatcher: WebFingerLinksDispatcher<TContextData>,
   ): void;
 
   /**

--- a/packages/fedify/src/federation/federation.ts
+++ b/packages/fedify/src/federation/federation.ts
@@ -28,6 +28,7 @@ import type {
   ObjectDispatcher,
   OutboxErrorHandler,
   SharedInboxKeyDispatcher,
+  WebFingerLinkDispatcher,
 } from "./callback.ts";
 import type { Context, RequestContext } from "./context.ts";
 import type { KvStore } from "./kv.ts";
@@ -77,6 +78,14 @@ export interface Federatable<TContextData> {
   setNodeInfoDispatcher(
     path: string,
     dispatcher: NodeInfoDispatcher<TContextData>,
+  ): void;
+
+  /**
+   * Registers a links dispatcher to WebFinger
+   * @param dispatcher A links dispatcher callback to register.
+   */
+  setWebFingerLinkDispatcher(
+    dispatcher: WebFingerLinkDispatcher<TContextData>,
   ): void;
 
   /**

--- a/packages/fedify/src/federation/middleware.ts
+++ b/packages/fedify/src/federation/middleware.ts
@@ -1280,6 +1280,7 @@ export class FederationImpl<TContextData>
           actorDispatcher: this.actorCallbacks?.dispatcher,
           actorHandleMapper: this.actorCallbacks?.handleMapper,
           actorAliasMapper: this.actorCallbacks?.aliasMapper,
+          webFingerLinkDispatcher: this.webFingerDispatcher,
           onNotFound,
           tracer,
         });

--- a/packages/fedify/src/federation/middleware.ts
+++ b/packages/fedify/src/federation/middleware.ts
@@ -16,9 +16,9 @@ import {
   ATTR_HTTP_RESPONSE_STATUS_CODE,
   ATTR_URL_FULL,
 } from "@opentelemetry/semantic-conventions";
+import metadata from "../../deno.json" with { type: "json" };
 import { getDefaultActivityTransformers } from "../compat/transformers.ts";
 import type { ActivityTransformer } from "../compat/types.ts";
-import metadata from "../../deno.json" with { type: "json" };
 import { getNodeInfo, type GetNodeInfoOptions } from "../nodeinfo/client.ts";
 import { handleNodeInfo, handleNodeInfoJrd } from "../nodeinfo/handler.ts";
 import type { JsonValue, NodeInfo } from "../nodeinfo/types.ts";
@@ -1280,7 +1280,7 @@ export class FederationImpl<TContextData>
           actorDispatcher: this.actorCallbacks?.dispatcher,
           actorHandleMapper: this.actorCallbacks?.handleMapper,
           actorAliasMapper: this.actorCallbacks?.aliasMapper,
-          webFingerLinkDispatcher: this.webFingerDispatcher,
+          webFingerLinksDispatcher: this.webFingerLinksDispatcher,
           onNotFound,
           tracer,
         });

--- a/packages/fedify/src/webfinger/handler.test.ts
+++ b/packages/fedify/src/webfinger/handler.test.ts
@@ -3,7 +3,7 @@ import type {
   ActorAliasMapper,
   ActorDispatcher,
   ActorHandleMapper,
-  WebFingerLinkDispatcher,
+  WebFingerLinksDispatcher,
 } from "../federation/callback.ts";
 import type { RequestContext } from "../federation/context.ts";
 import { MemoryKvStore } from "../federation/kv.ts";
@@ -540,8 +540,8 @@ test("handleWebFinger()", async (t) => {
     assertEquals(await response.json(), expectedForHostnameWithPort);
   });
 
-  await t.step("webFingerLinkDispatcher", async () => {
-    const webFingerLinkDispatcher: WebFingerLinkDispatcher<void> = (_ctx) => {
+  await t.step("webFingerLinksDispatcher", async () => {
+    const webFingerLinksDispatcher: WebFingerLinksDispatcher<void> = (_ctx) => {
       return [
         {
           rel: "http://ostatus.org/schema/1.0/subscribe",
@@ -557,7 +557,7 @@ test("handleWebFinger()", async (t) => {
     const response = await handleWebFinger(request, {
       context,
       actorDispatcher,
-      webFingerLinkDispatcher,
+      webFingerLinksDispatcher,
       onNotFound,
     });
 

--- a/packages/fedify/src/webfinger/handler.test.ts
+++ b/packages/fedify/src/webfinger/handler.test.ts
@@ -3,6 +3,7 @@ import type {
   ActorAliasMapper,
   ActorDispatcher,
   ActorHandleMapper,
+  WebFingerLinkDispatcher,
 } from "../federation/callback.ts";
 import type { RequestContext } from "../federation/context.ts";
 import { MemoryKvStore } from "../federation/kv.ts";
@@ -537,5 +538,44 @@ test("handleWebFinger()", async (t) => {
     assertEquals(response.headers.get("Content-Type"), "application/jrd+json");
     assertEquals(response.headers.get("Access-Control-Allow-Origin"), "*");
     assertEquals(await response.json(), expectedForHostnameWithPort);
+  });
+
+  await t.step("webFingerLinkDispatcher", async () => {
+    const webFingerLinkDispatcher: WebFingerLinkDispatcher<void> = (_ctx) => {
+      return [
+        {
+          rel: "http://ostatus.org/schema/1.0/subscribe",
+          template: "https://example.com/follow?acct={uri}",
+        },
+      ];
+    };
+
+    const u = new URL(url);
+    u.searchParams.set("resource", "acct:someone@example.com");
+    const context = createContext(u);
+    const request = context.request;
+    const response = await handleWebFinger(request, {
+      context,
+      actorDispatcher,
+      webFingerLinkDispatcher,
+      onNotFound,
+    });
+
+    assertEquals(response.status, 200);
+    const result = await response.json();
+
+    // Check that custom links are added to the existing links
+    const expectedWithCustomLinks = {
+      ...expected,
+      links: [
+        ...expected.links,
+        {
+          rel: "http://ostatus.org/schema/1.0/subscribe",
+          template: "https://example.com/follow?acct={uri}",
+        },
+      ],
+    };
+
+    assertEquals(result, expectedWithCustomLinks);
   });
 });

--- a/packages/fedify/src/webfinger/handler.ts
+++ b/packages/fedify/src/webfinger/handler.ts
@@ -6,7 +6,7 @@ import type {
   ActorAliasMapper,
   ActorDispatcher,
   ActorHandleMapper,
-  WebFingerLinkDispatcher,
+  WebFingerLinksDispatcher,
 } from "../federation/callback.ts";
 import type { RequestContext } from "../federation/context.ts";
 import { Link as LinkObject } from "../vocab/mod.ts";
@@ -51,7 +51,7 @@ export interface WebFingerHandlerParameters<TContextData> {
   /**
    * The callback for dispatching the Links of webFinger.
    */
-  webFingerLinkDispatcher?: WebFingerLinkDispatcher<TContextData>;
+  webFingerLinksDispatcher?: WebFingerLinksDispatcher<TContextData>;
 
   /**
    * The function to call when the actor is not found.
@@ -118,7 +118,7 @@ async function handleWebFingerInternal<TContextData>(
     actorAliasMapper,
     onNotFound,
     span,
-    webFingerLinkDispatcher,
+    webFingerLinksDispatcher,
   }: WebFingerHandlerParameters<TContextData>,
 ): Promise<Response> {
   if (actorDispatcher == null) {
@@ -231,8 +231,8 @@ async function handleWebFingerInternal<TContextData>(
     links.push(link);
   }
 
-  if (webFingerLinkDispatcher != null) {
-    const customLinks = await webFingerLinkDispatcher(context);
+  if (webFingerLinksDispatcher != null) {
+    const customLinks = await webFingerLinksDispatcher(context, context.url);
     if (customLinks != null) {
       for (const link of customLinks) {
         links.push(link);

--- a/packages/fedify/src/webfinger/handler.ts
+++ b/packages/fedify/src/webfinger/handler.ts
@@ -232,7 +232,7 @@ async function handleWebFingerInternal<TContextData>(
   }
 
   if (webFingerLinksDispatcher != null) {
-    const customLinks = await webFingerLinksDispatcher(context, context.url);
+    const customLinks = await webFingerLinksDispatcher(context, resourceUrl);
     if (customLinks != null) {
       for (const link of customLinks) {
         links.push(link);

--- a/packages/testing/src/mock.ts
+++ b/packages/testing/src/mock.ts
@@ -21,6 +21,7 @@ import type {
   SendActivityOptions,
   SendActivityOptionsForCollection,
   SenderKeyPair,
+  WebFingerLinkDispatcher,
 } from "@fedify/fedify/federation";
 import type { JsonValue, NodeInfo } from "@fedify/fedify/nodeinfo";
 import type { DocumentLoader } from "@fedify/fedify/runtime";
@@ -108,6 +109,7 @@ export class MockFederation<TContextData> implements Federation<TContextData> {
   private activeQueues: Set<"inbox" | "outbox" | "fanout"> = new Set();
   public sentCounter = 0;
   private nodeInfoDispatcher?: NodeInfoDispatcher<TContextData>;
+  private webFingerDispatcher?: WebFingerLinkDispatcher<TContextData>;
   private actorDispatchers: Map<string, ActorDispatcher<TContextData>> =
     new Map();
   public actorPath?: string;
@@ -188,6 +190,12 @@ export class MockFederation<TContextData> implements Federation<TContextData> {
   ): void {
     this.nodeInfoDispatcher = dispatcher;
     this.nodeInfoPath = path;
+  }
+
+  setWebFingerLinkDispatcher(
+    dispatcher: WebFingerLinkDispatcher<TContextData>,
+  ): void {
+    this.webFingerDispatcher = dispatcher;
   }
 
   setActorDispatcher(

--- a/packages/testing/src/mock.ts
+++ b/packages/testing/src/mock.ts
@@ -21,7 +21,7 @@ import type {
   SendActivityOptions,
   SendActivityOptionsForCollection,
   SenderKeyPair,
-  WebFingerLinkDispatcher,
+  WebFingerLinksDispatcher,
 } from "@fedify/fedify/federation";
 import type { JsonValue, NodeInfo } from "@fedify/fedify/nodeinfo";
 import type { DocumentLoader } from "@fedify/fedify/runtime";
@@ -109,7 +109,7 @@ export class MockFederation<TContextData> implements Federation<TContextData> {
   private activeQueues: Set<"inbox" | "outbox" | "fanout"> = new Set();
   public sentCounter = 0;
   private nodeInfoDispatcher?: NodeInfoDispatcher<TContextData>;
-  private webFingerDispatcher?: WebFingerLinkDispatcher<TContextData>;
+  private webFingerDispatcher?: WebFingerLinksDispatcher<TContextData>;
   private actorDispatchers: Map<string, ActorDispatcher<TContextData>> =
     new Map();
   public actorPath?: string;
@@ -192,8 +192,8 @@ export class MockFederation<TContextData> implements Federation<TContextData> {
     this.nodeInfoPath = path;
   }
 
-  setWebFingerLinkDispatcher(
-    dispatcher: WebFingerLinkDispatcher<TContextData>,
+  setWebFingerLinksDispatcher(
+    dispatcher: WebFingerLinksDispatcher<TContextData>,
   ): void {
     this.webFingerDispatcher = dispatcher;
   }


### PR DESCRIPTION
## Summary

Added `setWebFingerLinksDispatcher(dispatcher)` to set additional links to `Links` of Webfinger.

## Related Issue

- closes #119 

## Changes

- Added `WebFingerLinksDispatcher` support to the federation builder pattern.
- Integrated `WebFingerLinksDispatcher` into the WebFinger request handling flow.
- Updated middleware to support the new dispatcher
- Added Test
- Extended `MockFederation` to support `WebFingerLinksDispatcher` testing

## Benefits

- Applications can now customize WebFinger responses with dynamic links
 
## Checklist

- [x] Did you add a changelog entry to the *CHANGES.md*?
- [x] Did you write some relevant docs about this change (if it's a new feature)?
- [ ] Did you write a regression test to reproduce the bug (if it's a bug fix)?
- [x] Did you write some tests for this change (if it's a new feature)?
- [x] Did you run `deno task test-all` on your machine?

## Additional Notes

Currently, I am working on writing docs. However, unlike `NodeInfo`, context about `WebFinger` is split, so I tried to collect it into one chapter first.
