### PR TITLE
Add label property to the merge function

### DIFF
--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -6,7 +6,7 @@
   "imports": {
     "@cross/dir": "jsr:@cross/dir@^1.1.0",
     "@david/dax": "jsr:@david/dax@^0.43.2",
-    "@optique/core": "jsr:@optique/core@^0.3.0",
+    "@optique/core": "jsr:@optique/core@^0.4.0-dev.52+12ee9e92",
     "@optique/run": "jsr:@optique/run@^0.3.0",
     "@std/fmt": "jsr:@std/fmt@^1.0.8",
     "ora": "npm:ora@^8.2.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@fedify/fedify": "workspace:",
-    "@optique/core": "^0.3.0",
+    "@optique/core": "^0.4.0-dev.52+12ee9e92",
     "@optique/run": "^0.3.0",
     "cli-highlight": "^2.1.11",
     "jimp": "^1.6.0",

--- a/packages/cli/src/lookup.ts
+++ b/packages/cli/src/lookup.ts
@@ -82,11 +82,18 @@ const traverseOption = withDefault(
 export const lookupCommand = command(
   "lookup",
   merge(
+    "Looking up options",
     object({ command: constant("lookup") }),
     traverseOption,
     authorizedFetchOption,
     debugOption,
-    object("Looking up options", {
+    object({
+      urls: multiple(
+        argument(string({ metavar: "URL_OR_HANDLE" }), {
+          description: message`One or more URLs or handles to look up.`,
+        }),
+        { min: 1 },
+      ),
       format: withDefault(
         or(
           map(
@@ -138,12 +145,6 @@ export const lookupCommand = command(
         float({ min: 0, metavar: "SECONDS" }),
         { description: message`Set timeout for network requests in seconds.` },
       )),
-      urls: multiple(
-        argument(string({ metavar: "URL_OR_HANDLE" }), {
-          description: message`One or more URLs or handles to look up.`,
-        }),
-        { min: 1 },
-      ),
     }),
   ),
   {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -574,8 +574,8 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0
       '@optique/core':
-        specifier: ^0.3.0
-        version: 0.3.0
+        specifier: ^0.4.0-dev.52+12ee9e92
+        version: 0.4.0-dev.52
       '@optique/run':
         specifier: ^0.3.0
         version: 0.3.0
@@ -2781,6 +2781,10 @@ packages:
 
   '@optique/core@0.3.0':
     resolution: {integrity: sha512-URh4/zzVpjRbS/5D6ryBeW5sdQf4pAJbqo3dC6BAwpFRX4aEsQhngCLMWS19ily0YCdbEW7YPvwEoRFEAX8U8g==}
+    engines: {bun: '>=1.2.0', deno: '>=2.3.0', node: '>=20.0.0'}
+
+  '@optique/core@0.4.0-dev.52':
+    resolution: {integrity: sha512-dzLrX32MnWsRNobyy/nUChFRA/M6TG6fOM7z1jH7Znc32+XDQDvkPoPjLioYQPBGE/4ra4Zsi5g7yzBMmSdNHg==}
     engines: {bun: '>=1.2.0', deno: '>=2.3.0', node: '>=20.0.0'}
 
   '@optique/run@0.3.0':
@@ -9474,6 +9478,8 @@ snapshots:
 
   '@optique/core@0.3.0': {}
 
+  '@optique/core@0.4.0-dev.52': {}
+
   '@optique/run@0.3.0':
     dependencies:
       '@optique/core': 0.3.0
@@ -11723,7 +11729,7 @@ snapshots:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
@@ -11787,7 +11793,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1
@@ -11817,18 +11823,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.32.0(jiti@2.5.1)))(eslint@9.32.0(jiti@2.5.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.5.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -11850,7 +11856,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11879,7 +11885,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.32.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.32.0(jiti@2.5.1)))(eslint@9.32.0(jiti@2.5.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.5.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## Summary

Added a label property to the merge() function. Unlabeled options can now be grouped and tagged by this new label.
 from [optique beta](https://jsr.io/@optique/core@0.4.0-dev.52+12ee9e92) 

## Related Issue

Additional changes #390 

## Changes

Added a label property to the merge() function. 

## Benefits

Unlabeled options can now be grouped and tagged by this new label.

## Checklist

- [ ] Did you add a changelog entry to the *CHANGES.md*?
- [ ] Did you write some relevant docs about this change (if it's a new feature)?
- [ ] Did you write a regression test to reproduce the bug (if it's a bug fix)?
- [ ] Did you write some tests for this change (if it's a new feature)?
- [ ] Did you run `deno task test-all` on your machine?

## Additional Notes
