### PR TITLE
CLI: Add tunnel command using Optique

### DIFF
--- a/packages/cli/src/globals.ts
+++ b/packages/cli/src/globals.ts
@@ -29,7 +29,7 @@ export async function configureLogging() {
       {
         category: "localtunnel",
         lowestLevel: "debug",
-        sinks: ["console", "file"],
+        sinks: ["console", "recording", "file"],
       },
       {
         category: ["logtape", "meta"],

--- a/packages/cli/src/mod.ts
+++ b/packages/cli/src/mod.ts
@@ -1,11 +1,11 @@
 import { or } from "@optique/core";
 import { run } from "@optique/run";
-import { lookupCommand, runLookup } from "./lookup.ts";
-import { runWebFinger, webFingerCommand } from "./webfinger.ts";
-import { initCommand, runInit } from "./init.ts";
 import { inboxCommand, runInbox } from "./inbox.ts";
+import { initCommand, runInit } from "./init.ts";
+import { lookupCommand, runLookup } from "./lookup.ts";
 import { nodeInfoCommand, runNodeInfo } from "./nodeinfo.ts";
 import { runTunnel, tunnelCommand } from "./tunnel.ts";
+import { runWebFinger, webFingerCommand } from "./webfinger.ts";
 
 const command = or(
   initCommand,
@@ -37,7 +37,7 @@ async function main() {
     runNodeInfo(result);
   }
   if (result.command === "tunnel") {
-    runTunnel(result);
+    await runTunnel(result);
   }
 }
 

--- a/packages/cli/src/tunnel.test.ts
+++ b/packages/cli/src/tunnel.test.ts
@@ -1,0 +1,50 @@
+import { getDocPage } from "@optique/core";
+import { run } from "@optique/run";
+import { assert, assertEquals } from "@std/assert";
+import test from "node:test";
+import { recordingSink } from "./log.ts";
+import { runTunnel, tunnelCommand } from "./tunnel.ts";
+
+test("tunnel description", () => {
+  const description = getDocPage(tunnelCommand)?.description?.[0];
+  const text = description?.type === "text" ? description.text : undefined;
+  assert(
+    text?.includes(
+      "Expose a local HTTP server to the public internet using a secure tunnel.",
+    ),
+  );
+});
+
+test("tunnel command structure", () => {
+  const testCommandWithOptions = run(tunnelCommand, {
+    args: ["tunnel", "3001", "-s", "pinggy.io", "-d"],
+  });
+  const testCommandWithoutOptions = run(tunnelCommand, {
+    args: ["tunnel", "3000"],
+  });
+
+  assertEquals(testCommandWithOptions.command, "tunnel");
+  assertEquals(testCommandWithOptions.port, 3001);
+  assertEquals(testCommandWithOptions.service, "pinggy.io");
+  assertEquals(testCommandWithOptions.debug, true);
+
+  assertEquals(testCommandWithoutOptions.port, 3000);
+  assertEquals(testCommandWithoutOptions.service, undefined);
+  assertEquals(testCommandWithoutOptions.debug, false);
+});
+
+test("tunnel successfully creates and manages tunnel", async () => {
+  recordingSink.startRecording();
+
+  const testCommandWithOptions = run(tunnelCommand, {
+    args: ["tunnel", "3001", "-s", "pinggy.io", "-d"],
+  });
+  await runTunnel(testCommandWithOptions);
+
+  recordingSink.stopRecording();
+
+  const logs = recordingSink.getRecords();
+  assert(
+    logs.some((log) => log.rawMessage.includes("The tunnel URL is found")),
+  );
+});

--- a/packages/cli/src/tunnel.ts
+++ b/packages/cli/src/tunnel.ts
@@ -1,3 +1,4 @@
+import { openTunnel, type Tunnel } from "@hongminhee/localtunnel";
 import {
   argument,
   command,
@@ -7,26 +8,68 @@ import {
   merge,
   message,
   object,
+  option,
+  optional,
 } from "@optique/core";
-import { debugOption } from "./globals.ts";
+import { choice } from "@optique/core/valueparser";
+import { print } from "@optique/run";
+import process from "node:process";
+import ora from "ora";
+import { configureLogging, debugOption } from "./globals.ts";
 
 export const tunnelCommand = command(
   "tunnel",
   merge(
+    "Tunnel options",
     object({
       command: constant("tunnel"),
-      port: argument(integer({ metavar: "PORT", min: 0, max: 65_535 })),
+    }),
+    object({
+      port: argument(integer({ metavar: "PORT", min: 0, max: 65535 }), {
+        description: message`The local port number to expose.`,
+      }),
+      service: optional(
+        option(
+          "-s",
+          "--service",
+          choice(["localhost.run", "serveo.net", "pinggy.io"]),
+          {
+            description: message`The localtunnel service to use.`,
+          },
+        ),
+      ),
     }),
     debugOption,
   ),
   {
     description:
-      message`Expose a local HTTP server to the public internet using a secure tunnel.`,
+      message`Expose a local HTTP server to the public internet using a secure tunnel.\nNote that the HTTP requests through the tunnel have X-Forwarded-* headers.`,
   },
 );
 
-export function runTunnel(
+export async function runTunnel(
   command: InferValue<typeof tunnelCommand>,
 ) {
-  console.debug(command);
+  if (command.debug) {
+    await configureLogging();
+  }
+  const spinner = ora({
+    text: "Creating a secure tunnel...",
+    discardStdin: false,
+  }).start();
+  let tunnel: Tunnel;
+  try {
+    tunnel = await openTunnel({ port: command.port, service: command.service });
+  } catch {
+    spinner.fail("Failed to create a secure tunnel.");
+    process.exit(1);
+  }
+  spinner.succeed(
+    `Your local server at ${command.port} is now publicly accessible:\n`,
+  );
+  print(message`${tunnel.url.href}`);
+  print(message`\nPress ^C to close the tunnel.`);
+  process.on("SIGINT", async () => {
+    await tunnel.close();
+  });
 }


### PR DESCRIPTION
## Summary

Add tunnel command using `Optique`.

## Related Issue

- closes #400 

## Changes

- Added `tunnel` command using `Optique`.
- Added tunnel test 
- Added recording sinks for `localtunnel` logger in logging configure (for tunnel test)

## Benefits

 Migrate CLI `tunnel` command implementation from `Cliffy` to `Optique`

## Checklist

- [ ] Did you add a changelog entry to the *CHANGES.md*?
- [ ] Did you write some relevant docs about this change (if it's a new feature)?
- [ ] Did you write a regression test to reproduce the bug (if it's a bug fix)?
- [ ] Did you write some tests for this change (if it's a new feature)?
- [ ] Did you run `deno task test-all` on your machine?

## Additional Notes

- I’ve written a test that uses recordingSink to verify that a tunnel is successfully created, am I using it correctly?
