### PR TITLE
CI/CD: Cancel concurrent workflow runs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,10 @@
 name: build
 on: [push, pull_request_target]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

This prevents multiple pushes from blocking up the workflow runner queue

## Related Issue

No related issue to my knowledge, observed during #434 

## Changes

List the specific modifications made in this PR.
Focus on *what* was changed without going into detail about impact.

- Uses the workflow concurrency controls to cancel prior workflow runs automatically.

## Benefits

This improves the performance of the workflow runners by reducing their workload when people push multiple commits in quick succession to a branch.

## Checklist

- [ ] Did you add a changelog entry to the *CHANGES.md*?
- [ ] Did you write some relevant docs about this change (if it's a new feature)?
- [ ] Did you write a regression test to reproduce the bug (if it's a bug fix)?
- [ ] Did you write some tests for this change (if it's a new feature)?
- [ ] Did you run `deno task test-all` on your machine?

## Additional Notes

Docs: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency
