### PR TITLE
fix: Remove contextLoader property from FederationOptions interface

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,10 @@ To be released.
 
 ### @fedify/fedify
 
+ -  Remove `contextLoader` option (which was deprecated) from
+    `FederationOptions` interface in favor of `contextLoaderFactory` option
+    for better flexibility.  [[#376], [#444] by Hasang Cho]
+
  -  Migrated from *@phensley/language-tag* package and its `LanguageTag` class
     to the standardized `Intl.Locale` class for representing language tags.
     [[#280], [#392] by Jang Hanarae]
@@ -68,6 +72,9 @@ To be released.
 [#393]: https://github.com/fedify-dev/fedify/pulls/393
 [#433]: https://github.com/fedify-dev/fedify/pull/433
 [#434]: https://github.com/fedify-dev/fedify/pull/434
+[#444]: https://github.com/fedify-dev/fedify/pull/444
+
+
 
 ### @fedify/cli
 

--- a/packages/fedify/src/federation/federation.ts
+++ b/packages/fedify/src/federation/federation.ts
@@ -2,7 +2,6 @@ import type { TracerProvider } from "@opentelemetry/api";
 import type { ActivityTransformer } from "../compat/types.ts";
 import type {
   AuthenticatedDocumentLoaderFactory,
-  DocumentLoader,
   DocumentLoaderFactory,
   GetUserAgentOptions,
 } from "../runtime/docloader.ts";
@@ -682,13 +681,6 @@ export interface FederationOptions<TContextData> {
    * @since 1.4.0
    */
   contextLoaderFactory?: DocumentLoaderFactory;
-
-  /**
-   * A custom JSON-LD context loader.  By default, this uses the same loader
-   * as the document loader.
-   * @deprecated Use {@link contextLoaderFactory} instead.
-   */
-  contextLoader?: DocumentLoader;
 
   /**
    * A factory function that creates an authenticated document loader for a

--- a/packages/fedify/src/federation/middleware.test.ts
+++ b/packages/fedify/src/federation/middleware.test.ts
@@ -59,7 +59,7 @@ test("createFederation()", async (t) => {
     assertThrows(() =>
       createFederation<number>({
         kv,
-        contextLoader: mockDocumentLoader,
+        contextLoaderFactory: () => mockDocumentLoader,
         allowPrivateAddress: true,
       }), TypeError);
     assertThrows(() =>
@@ -543,7 +543,7 @@ test({
         kv,
         origin: "https://ap.example.com",
         documentLoaderFactory: () => mockDocumentLoader,
-        contextLoader: mockDocumentLoader,
+        contextLoaderFactory: () => mockDocumentLoader,
       });
       const ctx = federation.createContext(
         new URL("https://example.com:1234/"),
@@ -1637,7 +1637,7 @@ test("FederationImpl.sendActivity()", async (t) => {
   const kv = new MemoryKvStore();
   const federation = new FederationImpl<void>({
     kv,
-    contextLoader: mockDocumentLoader,
+    contextLoaderFactory: () => mockDocumentLoader,
   });
   const context = federation.createContext(new URL("https://example.com/"));
 
@@ -2007,7 +2007,7 @@ test("ContextImpl.sendActivity()", async (t) => {
   const kv = new MemoryKvStore();
   const federation = new FederationImpl<void>({
     kv,
-    contextLoader: mockDocumentLoader,
+    contextLoaderFactory: () => mockDocumentLoader,
   });
 
   federation
@@ -2166,7 +2166,7 @@ test("ContextImpl.sendActivity()", async (t) => {
   };
   const federation2 = new FederationImpl<void>({
     kv,
-    contextLoader: mockDocumentLoader,
+    contextLoaderFactory: () => mockDocumentLoader,
     queue,
   });
   federation2
@@ -2621,7 +2621,7 @@ test("InboxContextImpl.forwardActivity()", async (t) => {
   const kv = new MemoryKvStore();
   const federation = new FederationImpl<void>({
     kv,
-    contextLoader: mockDocumentLoader,
+    contextLoaderFactory: () => mockDocumentLoader,
   });
 
   await t.step("skip", async () => {

--- a/packages/fedify/src/federation/middleware.ts
+++ b/packages/fedify/src/federation/middleware.ts
@@ -238,7 +238,6 @@ export class FederationImpl<TContextData>
 
   constructor(options: FederationOptions<TContextData>) {
     super();
-    const logger = getLogger(["fedify", "federation"]);
     this.kv = options.kv;
     this.kvPrefixes = {
       ...({
@@ -318,12 +317,19 @@ export class FederationImpl<TContextData>
       false;
     this._initializeRouter();
     if (options.allowPrivateAddress || options.userAgent != null) {
-      if (options.contextLoader != null) {
+      if (options.documentLoaderFactory != null) {
         throw new TypeError(
-          "Cannot set contextLoader with allowPrivateAddress or " +
+          "Cannot set documentLoaderFactory with allowPrivateAddress or " +
             "userAgent options.",
         );
-      } else if (options.authenticatedDocumentLoaderFactory != null) {
+      }
+      if (options.contextLoaderFactory != null) {
+        throw new TypeError(
+          "Cannot set contextLoaderFactory with allowPrivateAddress or " +
+            "userAgent options.",
+        );
+      }
+      if (options.authenticatedDocumentLoaderFactory != null) {
         throw new TypeError(
           "Cannot set authenticatedDocumentLoaderFactory with " +
             "allowPrivateAddress or userAgent options.",
@@ -344,22 +350,8 @@ export class FederationImpl<TContextData>
           prefix: this.kvPrefixes.remoteDocument,
         });
       });
-    if (options.contextLoader != null) {
-      if (options.contextLoaderFactory != null) {
-        throw new TypeError(
-          "Cannot set both contextLoader and contextLoaderFactory options " +
-            "at a time; use contextLoaderFactory only.",
-        );
-      }
-      this.contextLoaderFactory = () => options.contextLoader!;
-      logger.warn(
-        "The contextLoader option is deprecated; use contextLoaderFactory " +
-          "option instead.",
-      );
-    } else {
-      this.contextLoaderFactory = options.contextLoaderFactory ??
-        this.documentLoaderFactory;
-    }
+    this.contextLoaderFactory = options.contextLoaderFactory ??
+      this.documentLoaderFactory;
     this.authenticatedDocumentLoaderFactory =
       options.authenticatedDocumentLoaderFactory ??
         ((identity) =>


### PR DESCRIPTION
## Summary

Remove contextLoader property from FederationOptions interface (use documentLoaderFactory instead)

## Related Issue

- Implemented #376 

## Changes

- In fedify/src/federation/federation.ts, removed contextLoader property.

- In fedify/src/federation/middleware.ts:
  - Removed deprecated contextLoader option handling and related warning messages from FederationImpl constructor
  - Added validation to require documentLoaderFactory and contextLoaderFactory when allowPrivateAddress or userAgent options are used
  - Simplified property initialization by using direct assignment this.contextLoaderFactory = options.contextLoaderFactory ?? this.documentLoaderFactory instead of complex conditional logic
  - Updated error messages to reference contextLoaderFactory instead of the old contextLoader option name


-  In fedify/src/federation/middleware.test.ts, updated test cases to use contextLoaderFactory instead of deprecated contextLoader option.


## Additional Notes
- Ran 'deno task test-all' and 'deno task check-all', all checks and tests passed.