### PR TITLE
Support multiple URLs for -t/--traverse in cli command fedify lookup

### DIFF
--- a/packages/cli/src/lookup.ts
+++ b/packages/cli/src/lookup.ts
@@ -508,8 +508,7 @@ export async function runLookup(command: InferValue<typeof lookupCommand>) {
   try {
     objects = await Promise.all(promises);
   } catch (_error) {
-    //TODO: implement -a --authorized-fetch
-    // await server?.close();
+    await server?.close();
     process.exit(1);
   }
 

--- a/packages/cli/src/lookup.ts
+++ b/packages/cli/src/lookup.ts
@@ -69,7 +69,7 @@ const traverseOption = withDefault(
   object({
     traverse: flag("-t", "--traverse", {
       description:
-        message`Traverse the given collection to fetch all items. If it is turned on, the argument cannot be multiple.`,
+        message`Traverse the given collection(s) to fetch all items.`,
     }),
     suppressErrors: option("-S", "--suppress-errors", {
       description:
@@ -276,14 +276,8 @@ function handleTimeoutError(
 }
 
 export async function runLookup(command: InferValue<typeof lookupCommand>) {
-  // FIXME: Implement -t, --traverse when multiple URLs are provided
   if (command.urls.length < 1) {
     printError(message`At least one URL or actor handle must be provided.`);
-    process.exit(1);
-  } else if (command.traverse && command.urls.length > 1) {
-    printError(
-      message`The -t/--traverse option cannot be used with multiple arguments.`,
-    );
     process.exit(1);
   }
 
@@ -389,84 +383,103 @@ export async function runLookup(command: InferValue<typeof lookupCommand>) {
   }...`;
 
   if (command.traverse) {
-    const url = command.urls[0];
-    let collection: APObject | null;
-    try {
-      collection = await lookupObject(url, {
-        documentLoader: authLoader ?? documentLoader,
-        contextLoader,
-        userAgent: command.userAgent,
-      });
-    } catch (error) {
-      if (error instanceof TimeoutError) {
-        handleTimeoutError(spinner, command.timeout, url);
-      } else {
+    let totalItems = 0;
+
+    for (let urlIndex = 0; urlIndex < command.urls.length; urlIndex++) {
+      const url = command.urls[urlIndex];
+
+      if (urlIndex > 0) {
+        spinner.text = `Looking up collection ${
+          urlIndex + 1
+        }/${command.urls.length}...`;
+      }
+
+      let collection: APObject | null;
+      try {
+        collection = await lookupObject(url, {
+          documentLoader: authLoader ?? documentLoader,
+          contextLoader,
+          userAgent: command.userAgent,
+        });
+      } catch (error) {
+        if (error instanceof TimeoutError) {
+          handleTimeoutError(spinner, command.timeout, url);
+        } else {
+          spinner.fail(`Failed to fetch object: ${colors.red(url)}.`);
+          if (authLoader == null) {
+            printError(
+              message`It may be a private object.  Try with -a/--authorized-fetch.`,
+            );
+          }
+        }
+        await server?.close();
+        process.exit(1);
+      }
+      if (collection == null) {
         spinner.fail(`Failed to fetch object: ${colors.red(url)}.`);
         if (authLoader == null) {
           printError(
             message`It may be a private object.  Try with -a/--authorized-fetch.`,
           );
         }
+        await server?.close();
+        process.exit(1);
       }
-      await server?.close();
-      process.exit(1);
-    }
-    if (collection == null) {
-      spinner.fail(`Failed to fetch object: ${colors.red(url)}.`);
-      if (authLoader == null) {
-        printError(
-          message`It may be a private object.  Try with -a/--authorized-fetch.`,
+      if (!(collection instanceof Collection)) {
+        spinner.fail(
+          `Not a collection: ${colors.red(url)}.  ` +
+            "The -t/--traverse option requires a collection.",
         );
+        await server?.close();
+        process.exit(1);
       }
-      await server?.close();
-      process.exit(1);
-    }
-    if (!(collection instanceof Collection)) {
-      spinner.fail(
-        `Not a collection: ${colors.red(url)}.  ` +
-          "The -t/--traverse option requires a collection.",
-      );
-      await server?.close();
-      process.exit(1);
-    }
-    spinner.succeed(`Fetched collection: ${colors.green(url)}.`);
+      spinner.succeed(`Fetched collection: ${colors.green(url)}.`);
 
-    try {
-      let i = 0;
-      for await (
-        const item of traverseCollection(collection, {
-          documentLoader: authLoader ?? documentLoader,
-          contextLoader,
-          suppressError: command.suppressErrors,
-        })
-      ) {
-        if (!command.output && i > 0) print(message`${command.separator}`);
-        await writeObjectToStream(
-          item,
-          command.output,
-          command.format,
-          contextLoader,
-        );
-        i++;
-      }
-    } catch (error) {
-      logger.error("Failed to complete the traversal: {error}", { error });
-      if (error instanceof TimeoutError) {
-        handleTimeoutError(spinner, command.timeout);
-      } else {
-        spinner.fail("Failed to complete the traversal.");
-        if (authLoader == null) {
-          printError(
-            message`It may be a private object.  Try with -a/--authorized-fetch.`,
+      try {
+        let collectionItems = 0;
+        for await (
+          const item of traverseCollection(collection, {
+            documentLoader: authLoader ?? documentLoader,
+            contextLoader,
+            suppressError: command.suppressErrors,
+          })
+        ) {
+          if (!command.output && (totalItems > 0 || collectionItems > 0)) {
+            print(message`${command.separator}`);
+          }
+          await writeObjectToStream(
+            item,
+            command.output,
+            command.format,
+            contextLoader,
           );
-        } else {
-          printError(
-            message`Use the -S/--suppress-errors option to suppress partial errors.`,
-          );
+          collectionItems++;
+          totalItems++;
         }
+      } catch (error) {
+        logger.error("Failed to complete the traversal for {url}: {error}", {
+          url,
+          error,
+        });
+        if (error instanceof TimeoutError) {
+          handleTimeoutError(spinner, command.timeout, url);
+        } else {
+          spinner.fail(
+            `Failed to complete the traversal for: ${colors.red(url)}.`,
+          );
+          if (authLoader == null) {
+            printError(
+              message`It may be a private object.  Try with -a/--authorized-fetch.`,
+            );
+          } else {
+            printError(
+              message`Use the -S/--suppress-errors option to suppress partial errors.`,
+            );
+          }
+        }
+        await server?.close();
+        process.exit(1);
       }
-      await server?.close();
-      process.exit(1);
     }
     spinner.succeed("Successfully fetched all items in the collection.");
 


### PR DESCRIPTION
## Summary

  Enhanced the `fedify lookup --traverse` command to support multiple collection URLs, removing the previous limitation
  that restricted traversal to a single collection at a time.

## Related Issue

Reference the related issue(s) by number, e.g.:

- closes #408 

## Changes

  - Removed validation restriction: Eliminated the error that prevented using `--traverse` with multiple URLs
  - Updated traverse logic: Modified the traversal implementation to process all provided collection URLs sequentially
  instead of just the first one
  - Updated help text: Changed description from "traverse the given collection" to "traverse the given collection(s)"
  to reflect multi-URL support

## Benefits

  - Increased flexibility: Users can now traverse multiple collections in a single command, improving workflow
  efficiency

## Checklist

- [ ] Did you add a changelog entry to the *CHANGES.md*?
- [ ] Did you write some relevant docs about this change (if it's a new feature)?
- [ ] Did you write a regression test to reproduce the bug (if it's a bug fix)?
- [ ] Did you write some tests for this change (if it's a new feature)?
- [ ] Did you run `deno task test-all` on your machine?

## Additional Notes

Uncomment line 511-512