### PR TITLE
Add relay follower query API and refactor types

### DIFF
--- a/packages/relay/README.md
+++ b/packages/relay/README.md
@@ -168,7 +168,8 @@ internal storage details.
 for await (const follower of relay.listFollowers()) {
   console.log(`Follower: ${follower.actorId}`);
   console.log(`State: ${follower.state}`);
-  console.log(`Actor data:`, follower.actor);
+  console.log(`Actor name: ${follower.actor.name}`);
+  console.log(`Actor type: ${follower.actor.constructor.name}`);
 }
 ~~~~
 
@@ -178,20 +179,10 @@ for await (const follower of relay.listFollowers()) {
 const follower = await relay.getFollower("https://mastodon.example.com/users/alice");
 if (follower) {
   console.log(`Found follower in state: ${follower.state}`);
+  console.log(`Actor username: ${follower.actor.preferredUsername}`);
+  console.log(`Inbox: ${follower.actor.inboxId?.href}`);
 } else {
   console.log("Follower not found");
-}
-~~~~
-
-#### Validating follower objects
-
-~~~~ typescript
-import { isRelayFollower } from "@fedify/relay";
-
-for await (const follower of relay.listFollowers()) {
-  if (isRelayFollower(follower)) {
-    console.log(`Valid follower in state: ${follower.state}`);
-  }
 }
 ~~~~
 
@@ -289,9 +280,9 @@ Abstract base class for relay implementations.
 #### Methods
 
  -  `fetch(request: Request): Promise<Response>`: Handle incoming HTTP requests
- -  `listFollowers(): AsyncIterableIterator<RelayFollowerEntry>`: Lists all
+ -  `listFollowers(): AsyncIterableIterator<RelayFollower>`: Lists all
     followers of the relay
- -  `getFollower(actorId: string): Promise<RelayFollowerEntry | null>`: Gets
+ -  `getFollower(actorId: string): Promise<RelayFollower | null>`: Gets
     a specific follower by actor ID
 
 ### `MastodonRelay`
@@ -346,14 +337,14 @@ type SubscriptionRequestHandler = (
  -  `true` to approve the subscription
  -  `false` to reject the subscription
 
-### `RelayFollowerEntry`
+### `RelayFollower`
 
-An entry representing a follower of the relay:
+A follower of the relay with validated Actor instance:
 
 ~~~~ typescript
-interface RelayFollowerEntry {
+interface RelayFollower {
   readonly actorId: string;
-  readonly actor: unknown;
+  readonly actor: Actor;
   readonly state: "pending" | "accepted";
 }
 ~~~~
@@ -361,7 +352,7 @@ interface RelayFollowerEntry {
 **Properties:**
 
  -  `actorId`: The actor ID (URL) of the follower
- -  `actor`: The actor's JSON-LD data
+ -  `actor`: The validated Actor object
  -  `state`: The follower's state (`"pending"` or `"accepted"`)
 
 

--- a/packages/relay/README.md
+++ b/packages/relay/README.md
@@ -157,6 +157,44 @@ const relay = createRelay("mastodon", {
 });
 ~~~~
 
+### Managing followers
+
+The relay provides methods to query and manage followers without exposing
+internal storage details.
+
+#### Listing all followers
+
+~~~~ typescript
+for await (const follower of relay.listFollowers()) {
+  console.log(`Follower: ${follower.actorId}`);
+  console.log(`State: ${follower.state}`);
+  console.log(`Actor data:`, follower.actor);
+}
+~~~~
+
+#### Getting a specific follower
+
+~~~~ typescript
+const follower = await relay.getFollower("https://mastodon.example.com/users/alice");
+if (follower) {
+  console.log(`Found follower in state: ${follower.state}`);
+} else {
+  console.log("Follower not found");
+}
+~~~~
+
+#### Validating follower objects
+
+~~~~ typescript
+import { isRelayFollower } from "@fedify/relay";
+
+for await (const follower of relay.listFollowers()) {
+  if (isRelayFollower(follower)) {
+    console.log(`Valid follower in state: ${follower.state}`);
+  }
+}
+~~~~
+
 ### Integration with web frameworks
 
 The relay's `fetch()` method returns a standard `Response` object, making it
@@ -251,6 +289,10 @@ Abstract base class for relay implementations.
 #### Methods
 
  -  `fetch(request: Request): Promise<Response>`: Handle incoming HTTP requests
+ -  `listFollowers(): AsyncIterableIterator<RelayFollowerEntry>`: Lists all
+    followers of the relay
+ -  `getFollower(actorId: string): Promise<RelayFollowerEntry | null>`: Gets
+    a specific follower by actor ID
 
 ### `MastodonRelay`
 
@@ -303,6 +345,24 @@ type SubscriptionRequestHandler = (
 
  -  `true` to approve the subscription
  -  `false` to reject the subscription
+
+### `RelayFollowerEntry`
+
+An entry representing a follower of the relay:
+
+~~~~ typescript
+interface RelayFollowerEntry {
+  readonly actorId: string;
+  readonly actor: unknown;
+  readonly state: "pending" | "accepted";
+}
+~~~~
+
+**Properties:**
+
+ -  `actorId`: The actor ID (URL) of the follower
+ -  `actor`: The actor's JSON-LD data
+ -  `state`: The follower's state (`"pending"` or `"accepted"`)
 
 
 [JSR]: https://jsr.io/@fedify/relay

--- a/packages/relay/README.md
+++ b/packages/relay/README.md
@@ -263,7 +263,7 @@ Factory function to create a relay instance.
 function createRelay(
   type: "mastodon" | "litepub",
   options: RelayOptions
-): BaseRelay
+): Relay
 ~~~~
 
 **Parameters:**
@@ -271,11 +271,11 @@ function createRelay(
  -  `type`: The type of relay to create (`"mastodon"` or `"litepub"`)
  -  `options`: Configuration options for the relay
 
-**Returns:** A relay instance (`MastodonRelay` or `LitePubRelay`)
+**Returns:** A `Relay` instance
 
-### `BaseRelay`
+### `Relay`
 
-Abstract base class for relay implementations.
+Public interface for ActivityPub relay implementations.
 
 #### Methods
 
@@ -285,21 +285,14 @@ Abstract base class for relay implementations.
  -  `getFollower(actorId: string): Promise<RelayFollower | null>`: Gets
     a specific follower by actor ID
 
-### `MastodonRelay`
+#### Relay types
 
-A Mastodon-compatible ActivityPub relay implementation that extends `BaseRelay`.
+The relay type is specified when calling `createRelay()`:
 
- -  Uses direct activity forwarding
- -  Immediate subscription approval
- -  Compatible with standard ActivityPub implementations
-
-### `LitePubRelay`
-
-A LitePub-compatible ActivityPub relay implementation that extends `BaseRelay`.
-
- -  Uses bidirectional following
- -  Activities wrapped in `Announce`
- -  Two-phase subscription (pending → accepted)
+ -  `"mastodon"`: Mastodon-compatible relay using direct activity forwarding,
+    immediate subscription approval, and LD signatures
+ -  `"litepub"`: LitePub-compatible relay using bidirectional following,
+    activities wrapped in `Announce`, and two-phase subscription
 
 ### `RelayOptions`
 

--- a/packages/relay/src/base.ts
+++ b/packages/relay/src/base.ts
@@ -71,9 +71,19 @@ export abstract class BaseRelay {
    *
    * @example
    * ```ts
+   * import { createRelay } from "@fedify/relay";
+   * import { MemoryKvStore } from "@fedify/fedify";
+   *
+   * const relay = createRelay("mastodon", {
+   *   kv: new MemoryKvStore(),
+   *   domain: "relay.example.com",
+   *   subscriptionHandler: async (ctx, actor) => true,
+   * });
+   *
    * for await (const follower of relay.listFollowers()) {
    *   console.log(`Follower: ${follower.actorId}`);
    *   console.log(`State: ${follower.state}`);
+   *   console.log(`Actor: ${follower.actor.name}`);
    * }
    * ```
    *
@@ -97,9 +107,21 @@ export abstract class BaseRelay {
    *
    * @example
    * ```ts
-   * const follower = await relay.getFollower("https://mastodon.example.com/users/alice");
+   * import { createRelay } from "@fedify/relay";
+   * import { MemoryKvStore } from "@fedify/fedify";
+   *
+   * const relay = createRelay("mastodon", {
+   *   kv: new MemoryKvStore(),
+   *   domain: "relay.example.com",
+   *   subscriptionHandler: async (ctx, actor) => true,
+   * });
+   *
+   * const follower = await relay.getFollower(
+   *   "https://mastodon.example.com/users/alice"
+   * );
    * if (follower) {
    *   console.log(`State: ${follower.state}`);
+   *   console.log(`Actor: ${follower.actor.preferredUsername}`);
    * }
    * ```
    *

--- a/packages/relay/src/base.ts
+++ b/packages/relay/src/base.ts
@@ -2,6 +2,7 @@ import type { Federation, FederationBuilder } from "@fedify/fedify";
 import { isActor, Object as APObject } from "@fedify/fedify/vocab";
 import {
   isRelayFollowerData,
+  type Relay,
   type RelayFollower,
   type RelayOptions,
 } from "./types.ts";
@@ -10,9 +11,9 @@ import {
  * Abstract base class for relay implementations.
  * Provides common infrastructure for both Mastodon and LitePub relays.
  *
- * @since 2.0.0
+ * @internal
  */
-export abstract class BaseRelay {
+export abstract class BaseRelay implements Relay {
   protected federationBuilder: FederationBuilder<RelayOptions>;
   protected options: RelayOptions;
   protected federation?: Federation<RelayOptions>;
@@ -49,14 +50,11 @@ export abstract class BaseRelay {
     actorId: string,
     data: unknown,
   ): Promise<RelayFollower | null> {
-    // Validate storage format
     if (!isRelayFollowerData(data)) return null;
 
-    // Deserialize and validate actor
     const actor = await APObject.fromJsonLd(data.actor);
     if (!isActor(actor)) return null;
 
-    // Construct and return RelayFollower
     return {
       actorId,
       actor,

--- a/packages/relay/src/builder.ts
+++ b/packages/relay/src/builder.ts
@@ -9,7 +9,7 @@ import {
 import { Application, isActor, Object } from "@fedify/fedify/vocab";
 import type { Actor } from "@fedify/fedify/vocab";
 import {
-  isRelayFollower,
+  isRelayFollowerData,
   RELAY_SERVER_ACTOR,
   type RelayOptions,
 } from "./types.ts";
@@ -79,7 +79,7 @@ async function getFollowerActors(
   const actors: Actor[] = [];
 
   for await (const { value } of ctx.data.kv.list(["follower"])) {
-    if (!isRelayFollower(value)) continue;
+    if (!isRelayFollowerData(value)) continue;
     if (value.state !== "accepted") continue;
     const actor = await Object.fromJsonLd(value.actor);
     if (!isActor(actor)) continue;

--- a/packages/relay/src/factory.ts
+++ b/packages/relay/src/factory.ts
@@ -1,8 +1,7 @@
-import type { BaseRelay } from "./base.ts";
 import { relayBuilder } from "./builder.ts";
 import { LitePubRelay } from "./litepub.ts";
 import { MastodonRelay } from "./mastodon.ts";
-import type { RelayOptions, RelayType } from "./types.ts";
+import type { Relay, RelayOptions, RelayType } from "./types.ts";
 
 /**
  * Factory function to create a relay instance.
@@ -28,7 +27,7 @@ import type { RelayOptions, RelayType } from "./types.ts";
 export function createRelay(
   type: RelayType,
   options: RelayOptions,
-): BaseRelay {
+): Relay {
   switch (type) {
     case "mastodon":
       return new MastodonRelay(options, relayBuilder);

--- a/packages/relay/src/litepub.test.ts
+++ b/packages/relay/src/litepub.test.ts
@@ -19,7 +19,8 @@ import {
 } from "@fedify/vocab-runtime";
 import { ok, strictEqual } from "node:assert";
 import test, { describe } from "node:test";
-import { createRelay, isRelayFollower, type RelayOptions } from "@fedify/relay";
+import { createRelay, type RelayOptions } from "@fedify/relay";
+import { isRelayFollowerData } from "./types.ts";
 
 // Simple mock document loader that returns a minimal context
 const mockDocumentLoader = async (url: string): Promise<RemoteDocument> => {
@@ -316,7 +317,7 @@ describe("LitePubRelay", () => {
       "follower",
       "https://remote.example.com/users/alice",
     ]);
-    ok(isRelayFollower(followerData));
+    ok(isRelayFollowerData(followerData));
     strictEqual(followerData.state, "pending");
   });
 
@@ -418,7 +419,7 @@ describe("LitePubRelay", () => {
       "follower",
       "https://remote.example.com/users/alice",
     ]);
-    ok(isRelayFollower(followerData));
+    ok(isRelayFollowerData(followerData));
     strictEqual(followerData.state, "pending");
   });
 
@@ -578,7 +579,7 @@ describe("LitePubRelay", () => {
       "follower",
       "https://remote.example.com/users/alice",
     ]);
-    ok(isRelayFollower(followerData));
+    ok(isRelayFollowerData(followerData));
     strictEqual(followerData.state, "accepted");
   });
 
@@ -930,7 +931,7 @@ describe("LitePubRelay", () => {
       strictEqual(key.length, 2);
       strictEqual(key[0], "follower");
       retrievedIds.push(key[1] as string);
-      ok(isRelayFollower(value));
+      ok(isRelayFollowerData(value));
       strictEqual(value.state, "accepted");
     }
 
@@ -1007,7 +1008,7 @@ describe("LitePubRelay", () => {
     // Verify list returns both with correct states
     const followers: { id: string; state: string }[] = [];
     for await (const { key, value } of kv.list(["follower"])) {
-      if (!isRelayFollower(value)) continue;
+      if (!isRelayFollowerData(value)) continue;
       followers.push({
         id: key[1] as string,
         state: value.state,
@@ -1044,7 +1045,7 @@ describe("LitePubRelay", () => {
     // Verify list returns complete actor data
     for await (const { key, value } of kv.list(["follower"])) {
       strictEqual(key[1], followerId);
-      ok(isRelayFollower(value));
+      ok(isRelayFollowerData(value));
       strictEqual(value.state, "accepted");
       ok(value.actor && typeof value.actor === "object");
       const actor = value.actor as Record<string, unknown>;

--- a/packages/relay/src/litepub.ts
+++ b/packages/relay/src/litepub.ts
@@ -20,7 +20,7 @@ import {
 } from "./follow.ts";
 import {
   RELAY_SERVER_ACTOR,
-  type RelayFollower,
+  type RelayFollowerData,
   type RelayOptions,
 } from "./types.ts";
 
@@ -68,7 +68,7 @@ export class LitePubRelay extends BaseRelay {
           if (!follower || !follower.id) return;
 
           // Litepub-specific: check if already in pending state
-          const existingFollow = await ctx.data.kv.get<RelayFollower>([
+          const existingFollow = await ctx.data.kv.get<RelayFollowerData>([
             "follower",
             follower.id.href,
           ]);

--- a/packages/relay/src/mod.ts
+++ b/packages/relay/src/mod.ts
@@ -8,9 +8,8 @@
  * @module
  */
 export { createRelay } from "./factory.ts";
-export { LitePubRelay } from "./litepub.ts";
-export { MastodonRelay } from "./mastodon.ts";
 export {
+  type Relay,
   RELAY_SERVER_ACTOR,
   type RelayFollower,
   type RelayOptions,

--- a/packages/relay/src/mod.ts
+++ b/packages/relay/src/mod.ts
@@ -15,6 +15,7 @@ export {
   isRelayFollower,
   RELAY_SERVER_ACTOR,
   type RelayFollower,
+  type RelayFollowerEntry,
   type RelayOptions,
   type RelayType,
   type SubscriptionRequestHandler,

--- a/packages/relay/src/mod.ts
+++ b/packages/relay/src/mod.ts
@@ -7,7 +7,6 @@
  *
  * @module
  */
-export { relayBuilder } from "./builder.ts";
 export { createRelay } from "./factory.ts";
 export { LitePubRelay } from "./litepub.ts";
 export { MastodonRelay } from "./mastodon.ts";

--- a/packages/relay/src/mod.ts
+++ b/packages/relay/src/mod.ts
@@ -12,10 +12,8 @@ export { createRelay } from "./factory.ts";
 export { LitePubRelay } from "./litepub.ts";
 export { MastodonRelay } from "./mastodon.ts";
 export {
-  isRelayFollower,
   RELAY_SERVER_ACTOR,
   type RelayFollower,
-  type RelayFollowerEntry,
   type RelayOptions,
   type RelayType,
   type SubscriptionRequestHandler,

--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -63,6 +63,37 @@ export interface RelayFollower {
 }
 
 /**
+ * Public interface for ActivityPub relay implementations.
+ * Use {@link createRelay} to create a relay instance.
+ *
+ * @since 2.0.0
+ */
+export interface Relay {
+  /**
+   * Handle incoming HTTP requests.
+   *
+   * @param request The incoming HTTP request
+   * @returns The HTTP response
+   */
+  fetch(request: Request): Promise<Response>;
+
+  /**
+   * Lists all followers of the relay.
+   *
+   * @returns An async iterator of follower entries
+   */
+  listFollowers(): AsyncIterableIterator<RelayFollower>;
+
+  /**
+   * Gets a specific follower by actor ID.
+   *
+   * @param actorId The actor ID (URL) of the follower to retrieve
+   * @returns The follower entry if found, null otherwise
+   */
+  getFollower(actorId: string): Promise<RelayFollower | null>;
+}
+
+/**
  * Type predicate to check if a value is valid RelayFollowerData from KV store.
  * Validates the storage format (JSON-LD), not the deserialized Actor instance.
  *

--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -33,33 +33,46 @@ export interface RelayOptions {
   subscriptionHandler: SubscriptionRequestHandler;
 }
 
-export interface RelayFollower {
-  readonly actor: unknown;
-  readonly state: "pending" | "accepted";
-}
-
 /**
- * An entry representing a follower of the relay.
+ * Internal storage format for follower data in KV store.
+ * Contains JSON-LD representation of the actor.
+ * Exported for internal package use but not re-exported from mod.ts.
  *
- * @since 2.0.0
+ * @internal
  */
-export interface RelayFollowerEntry {
-  /** The actor ID (URL) of the follower. */
-  readonly actorId: string;
-  /** The actor's JSON-LD data. */
+export interface RelayFollowerData {
+  /** The actor's JSON-LD representation (serialized for storage). */
   readonly actor: unknown;
   /** The follower's state. */
   readonly state: "pending" | "accepted";
 }
 
 /**
- * Type predicate to check if a value is a valid RelayFollower.
- * Provides both runtime validation and compile-time type narrowing.
+ * A follower of the relay with validated Actor instance.
+ * This is the public API type returned by follower query methods.
+ *
+ * @since 2.0.0
+ */
+export interface RelayFollower {
+  /** The actor ID (URL) of the follower. */
+  readonly actorId: string;
+  /** The validated Actor object. */
+  readonly actor: Actor;
+  /** The follower's state. */
+  readonly state: "pending" | "accepted";
+}
+
+/**
+ * Type predicate to check if a value is valid RelayFollowerData from KV store.
+ * Validates the storage format (JSON-LD), not the deserialized Actor instance.
  *
  * @param value The value to check
- * @returns true if the value is a RelayFollower
+ * @returns true if the value is a RelayFollowerData
+ * @internal
  */
-export function isRelayFollower(value: unknown): value is RelayFollower {
+export function isRelayFollowerData(
+  value: unknown,
+): value is RelayFollowerData {
   if (!value || typeof value !== "object") return false;
   const obj = value as Record<string, unknown>;
   return (

--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -39,6 +39,20 @@ export interface RelayFollower {
 }
 
 /**
+ * An entry representing a follower of the relay.
+ *
+ * @since 2.0.0
+ */
+export interface RelayFollowerEntry {
+  /** The actor ID (URL) of the follower. */
+  readonly actorId: string;
+  /** The actor's JSON-LD data. */
+  readonly actor: unknown;
+  /** The follower's state. */
+  readonly state: "pending" | "accepted";
+}
+
+/**
  * Type predicate to check if a value is a valid RelayFollower.
  * Provides both runtime validation and compile-time type narrowing.
  *


### PR DESCRIPTION
## Summary

Adds public API methods to query relay followers and refactors the type system for better type safety and maintainability.

Related to: https://github.com/fedify-dev/fedify/pull/512#discussion_r2653133284

## Changes

### New Public API Methods

- `listFollowers(): AsyncIterableIterator<RelayFollower>` - Lists all followers of the relay
- `getFollower(actorId: string): Promise<RelayFollower | null>` - Gets a specific follower by actor ID

### Type System Refactor

**Two-type design for clarity:**

- **`RelayFollowerData`** (internal): Storage format with JSON-LD actor data (`actor: unknown`)
- **`RelayFollower`** (public): API format with validated Actor instances (`actor: Actor`, includes `actorId`)

**Why separate types?**
- KV stores require JSON-serializable data (can't store class instances)
- Deserialization happens at read time
- Public API provides typed Actor objects for better DX

### Implementation Details

- Added `parseFollowerData()` helper to centralize validation and deserialization
- Both API methods use the same validation logic (no duplication)
- Enhanced tests to verify typed Actor properties

## Benefits

- Users can query relay followers without accessing KV store directly  
- Type-safe Actor instances in public API  
- Clear separation between storage and API layers  
- No code duplication in validation logic  
