### PR TITLE
Make recursive lookups honor `-p`/`--allow-private-address`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -117,9 +117,18 @@ To be released.
 
 ### @fedify/cli
 
+ -  Made `fedify lookup --recurse` honor `-p`/`--allow-private-address`
+    for recursively discovered object URLs, matching the policy already used
+    by `-t`/`--traverse`.  Recursive lookups still reject private or
+    localhost targets by default unless users explicitly opt in.
+    [[#700], [#718]]
+
  -  Added [FEP-044f] `quote` support to `fedify lookup --recurse`, so the CLI
     can follow both the new quote-post relation and the older `quoteUrl`
     compatibility surface.  [[#452], [#679]]
+
+[#700]: https://github.com/fedify-dev/fedify/issues/700
+[#718]: https://github.com/fedify-dev/fedify/pull/718
 
 ### @fedify/solidstart
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -545,11 +545,11 @@ For short names, only Fedify property naming is accepted.  For example,
 > `--recurse` and [`-t`/`--traverse`](#t-traverse-traverse-the-collection)
 > are mutually exclusive.
 >
-> Recursive fetches always disallow private/localhost addresses for safety.
-> URLs explicitly provided on the command line always allow private
-> addresses, while
+> Recursive fetches disallow private/localhost addresses by default for
+> safety.  URLs explicitly provided on the command line always allow private
+> addresses, while recursive steps honor
 > [`-p`/`--allow-private-address`](#p-allow-private-address-allow-private-ip-addresses)
-> has no effect on recursive steps.
+> when you explicitly opt in.
 
 ### `--recurse-depth`: Set recursion depth limit
 
@@ -1015,20 +1015,17 @@ fedify lookup http://localhost:8000/users/alice
 ~~~~
 
 The `-p`/`--allow-private-address` option additionally allows private
-addresses for URLs discovered during traversal.  It only has an effect
-when used together with
-[`-t`/`--traverse`](#t-traverse-traverse-the-collection), since URLs
+addresses for URLs discovered during traversal or recursion.  It only
+affects discovered URLs used by
+[`-t`/`--traverse`](#t-traverse-traverse-the-collection) and
+[`--recurse`](#recurse-recurse-through-object-relationships), since URLs
 embedded in remote responses are otherwise rejected to mitigate SSRF
 attacks against private addresses.
 
 ~~~~ sh
 fedify lookup --traverse --allow-private-address http://localhost:8000/users/alice/outbox
+fedify lookup --recurse=replyTarget --allow-private-address http://localhost:8000/notes/1
 ~~~~
-
-> [!NOTE]
-> Recursive fetches enabled by
-> [`--recurse`](#recurse-recurse-through-object-relationships) always
-> disallow private addresses regardless of this option.
 
 ### `-s`/`--separator`: Output separator
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -547,9 +547,10 @@ For short names, only Fedify property naming is accepted.  For example,
 >
 > Recursive fetches disallow private/localhost addresses by default for
 > safety.  URLs explicitly provided on the command line always allow private
-> addresses, while recursive steps honor
+> addresses, while recursive object fetches honor
 > [`-p`/`--allow-private-address`](#p-allow-private-address-allow-private-ip-addresses)
-> when you explicitly opt in.
+> when you explicitly opt in.  Recursive JSON-LD `@context` URLs still remain
+> blocked.
 
 ### `--recurse-depth`: Set recursion depth limit
 
@@ -1015,12 +1016,13 @@ fedify lookup http://localhost:8000/users/alice
 ~~~~
 
 The `-p`/`--allow-private-address` option additionally allows private
-addresses for URLs discovered during traversal or recursion.  It only
-affects discovered URLs used by
+addresses for URLs discovered during traversal or recursive object fetches.
+It only affects discovered URLs used by
 [`-t`/`--traverse`](#t-traverse-traverse-the-collection) and
 [`--recurse`](#recurse-recurse-through-object-relationships), since URLs
 embedded in remote responses are otherwise rejected to mitigate SSRF
-attacks against private addresses.
+attacks against private addresses.  Recursive JSON-LD `@context` URLs are
+still blocked even when this option is enabled.
 
 ~~~~ sh
 fedify lookup --traverse --allow-private-address http://localhost:8000/users/alice/outbox

--- a/packages/cli/src/lookup.test.ts
+++ b/packages/cli/src/lookup.test.ts
@@ -1057,6 +1057,32 @@ async function runLookupAndCaptureExitCode(
   }
 }
 
+async function captureStderr<T>(
+  callback: () => Promise<T>,
+): Promise<{ result: T; stderr: string }> {
+  const originalWrite = process.stderr.write;
+  let stderr = "";
+  process.stderr.write = ((
+    chunk: string | Uint8Array,
+    encodingOrCallback?: unknown,
+    callback?: () => void,
+  ) => {
+    stderr += typeof chunk === "string" ? chunk : Buffer.from(chunk).toString();
+    if (typeof encodingOrCallback === "function") {
+      encodingOrCallback();
+    } else {
+      callback?.();
+    }
+    return true;
+  }) as typeof process.stderr.write;
+  try {
+    const result = await callback();
+    return { result, stderr };
+  } finally {
+    process.stderr.write = originalWrite;
+  }
+}
+
 function extractIdsFromRawOutput(content: string): string[] {
   return [...content.matchAll(/"id"\s*:\s*"([^"]+)"/g)].map((match) =>
     match[1]
@@ -1152,26 +1178,8 @@ test("runLookup - rejects recursive private targets by default", async () => {
     await withRecursiveLookupServer(
       {},
       async ({ rootUrl, requestedPaths }) => {
-        const originalWrite = process.stderr.write;
-        let stderr = "";
-        process.stderr.write = ((
-          chunk: string | Uint8Array,
-          encodingOrCallback?: unknown,
-          callback?: () => void,
-        ) => {
-          stderr += typeof chunk === "string"
-            ? chunk
-            : Buffer.from(chunk).toString();
-          if (typeof encodingOrCallback === "function") {
-            encodingOrCallback();
-          } else {
-            callback?.();
-          }
-          return true;
-        }) as typeof process.stderr.write;
-        let exitCode: number | null;
-        try {
-          exitCode = await runLookupAndCaptureExitCode(
+        const { result: exitCode, stderr } = await captureStderr(() =>
+          runLookupAndCaptureExitCode(
             createLookupRunCommand({
               urls: [rootUrl.href],
               recurse: "replyTarget",
@@ -1179,10 +1187,8 @@ test("runLookup - rejects recursive private targets by default", async () => {
               allowPrivateAddress: false,
               output: testFile,
             }),
-          );
-        } finally {
-          process.stderr.write = originalWrite;
-        }
+          )
+        );
         assert.equal(exitCode, 1);
         assert.deepEqual(requestedPaths, ["/notes/1"]);
         assert.match(
@@ -1239,26 +1245,8 @@ test("runLookup - keeps recursive private contexts blocked", async () => {
     await withRecursiveLookupServer(
       { replyContextPath: "/contexts/reply" },
       async ({ rootUrl, requestedPaths }) => {
-        const originalWrite = process.stderr.write;
-        let stderr = "";
-        process.stderr.write = ((
-          chunk: string | Uint8Array,
-          encodingOrCallback?: unknown,
-          callback?: () => void,
-        ) => {
-          stderr += typeof chunk === "string"
-            ? chunk
-            : Buffer.from(chunk).toString();
-          if (typeof encodingOrCallback === "function") {
-            encodingOrCallback();
-          } else {
-            callback?.();
-          }
-          return true;
-        }) as typeof process.stderr.write;
-        let exitCode: number | null;
-        try {
-          exitCode = await runLookupAndCaptureExitCode(
+        const { result: exitCode, stderr } = await captureStderr(() =>
+          runLookupAndCaptureExitCode(
             createLookupRunCommand({
               urls: [rootUrl.href],
               recurse: "replyTarget",
@@ -1266,10 +1254,8 @@ test("runLookup - keeps recursive private contexts blocked", async () => {
               allowPrivateAddress: true,
               output: testFile,
             }),
-          );
-        } finally {
-          process.stderr.write = originalWrite;
-        }
+          )
+        );
         assert.equal(exitCode, 1);
         assert.deepEqual(requestedPaths, ["/notes/1", "/notes/0"]);
         assert.match(

--- a/packages/cli/src/lookup.test.ts
+++ b/packages/cli/src/lookup.test.ts
@@ -1239,17 +1239,43 @@ test("runLookup - keeps recursive private contexts blocked", async () => {
     await withRecursiveLookupServer(
       { replyContextPath: "/contexts/reply" },
       async ({ rootUrl, requestedPaths }) => {
-        const exitCode = await runLookupAndCaptureExitCode(
-          createLookupRunCommand({
-            urls: [rootUrl.href],
-            recurse: "replyTarget",
-            recurseDepth: 20,
-            allowPrivateAddress: true,
-            output: testFile,
-          }),
-        );
+        const originalWrite = process.stderr.write;
+        let stderr = "";
+        process.stderr.write = ((
+          chunk: string | Uint8Array,
+          encodingOrCallback?: unknown,
+          callback?: () => void,
+        ) => {
+          stderr += typeof chunk === "string"
+            ? chunk
+            : Buffer.from(chunk).toString();
+          if (typeof encodingOrCallback === "function") {
+            encodingOrCallback();
+          } else {
+            callback?.();
+          }
+          return true;
+        }) as typeof process.stderr.write;
+        let exitCode: number | null;
+        try {
+          exitCode = await runLookupAndCaptureExitCode(
+            createLookupRunCommand({
+              urls: [rootUrl.href],
+              recurse: "replyTarget",
+              recurseDepth: 20,
+              allowPrivateAddress: true,
+              output: testFile,
+            }),
+          );
+        } finally {
+          process.stderr.write = originalWrite;
+        }
         assert.equal(exitCode, 1);
         assert.deepEqual(requestedPaths, ["/notes/1", "/notes/0"]);
+        assert.match(
+          stderr,
+          /Recursive JSON-LD context URLs are always blocked/,
+        );
 
         const content = await readFile(testFile, "utf8");
         assert.deepEqual(extractIdsFromRawOutput(content), [rootUrl.href]);

--- a/packages/cli/src/lookup.test.ts
+++ b/packages/cli/src/lookup.test.ts
@@ -22,6 +22,7 @@ import {
   collectRecursiveObjects,
   createTimeoutSignal,
   getLookupFailureHint,
+  getPrivateUrlCandidate,
   getRecursiveTargetId,
   lookupCommand,
   RecursiveLookupError,
@@ -766,6 +767,25 @@ test("getLookupFailureHint - suggests authorized-fetch for non-URL errors", () =
   assert.equal(
     getLookupFailureHint(new Error("401 Unauthorized")),
     "authorized-fetch",
+  );
+});
+
+test("getPrivateUrlCandidate - detects obvious private hosts without DNS", () => {
+  assert.equal(
+    getPrivateUrlCandidate("http://localhost:8080/object")?.href,
+    "http://localhost:8080/object",
+  );
+  assert.equal(
+    getPrivateUrlCandidate("http://127.0.0.1:8080/object")?.href,
+    "http://127.0.0.1:8080/object",
+  );
+  assert.equal(
+    getPrivateUrlCandidate("http://[::1]:8080/object")?.href,
+    "http://[::1]:8080/object",
+  );
+  assert.equal(
+    getPrivateUrlCandidate("https://example.com/object"),
+    null,
   );
 });
 

--- a/packages/cli/src/lookup.test.ts
+++ b/packages/cli/src/lookup.test.ts
@@ -1064,6 +1064,9 @@ function extractIdsFromRawOutput(content: string): string[] {
 }
 
 async function withRecursiveLookupServer<T>(
+  options: {
+    replyContextPath?: string;
+  },
   callback: (server: {
     rootUrl: URL;
     replyUrl: URL;
@@ -1079,6 +1082,9 @@ async function withRecursiveLookupServer<T>(
       const requestUrl = new URL(request.url);
       const rootUrl = new URL("/notes/1", requestUrl.origin);
       const replyUrl = new URL("/notes/0", requestUrl.origin);
+      const replyContextUrl = options.replyContextPath == null
+        ? undefined
+        : new URL(options.replyContextPath, requestUrl.origin);
       requestedPaths.push(requestUrl.pathname);
 
       let body: unknown;
@@ -1092,10 +1098,25 @@ async function withRecursiveLookupServer<T>(
         };
       } else if (requestUrl.pathname === replyUrl.pathname) {
         body = {
-          "@context": "https://www.w3.org/ns/activitystreams",
+          "@context": replyContextUrl == null
+            ? "https://www.w3.org/ns/activitystreams"
+            : [
+              "https://www.w3.org/ns/activitystreams",
+              replyContextUrl.href,
+            ],
           id: replyUrl.href,
           type: "Note",
           content: "reply",
+          ...(replyContextUrl == null ? {} : { fedifyTest: "value" }),
+        };
+      } else if (
+        replyContextUrl != null &&
+        requestUrl.pathname === replyContextUrl.pathname
+      ) {
+        body = {
+          "@context": {
+            fedifyTest: "https://fedify.dev/ns/test#fedifyTest",
+          },
         };
       } else {
         return new Response(null, { status: 404 });
@@ -1128,48 +1149,51 @@ test("runLookup - rejects recursive private targets by default", async () => {
   const testFile = `${testDir}/out.jsonl`;
   await mkdir(testDir, { recursive: true });
   try {
-    await withRecursiveLookupServer(async ({ rootUrl, requestedPaths }) => {
-      const originalWrite = process.stderr.write;
-      let stderr = "";
-      process.stderr.write = ((
-        chunk: string | Uint8Array,
-        encodingOrCallback?: unknown,
-        callback?: () => void,
-      ) => {
-        stderr += typeof chunk === "string"
-          ? chunk
-          : Buffer.from(chunk).toString();
-        if (typeof encodingOrCallback === "function") {
-          encodingOrCallback();
-        } else {
-          callback?.();
+    await withRecursiveLookupServer(
+      {},
+      async ({ rootUrl, requestedPaths }) => {
+        const originalWrite = process.stderr.write;
+        let stderr = "";
+        process.stderr.write = ((
+          chunk: string | Uint8Array,
+          encodingOrCallback?: unknown,
+          callback?: () => void,
+        ) => {
+          stderr += typeof chunk === "string"
+            ? chunk
+            : Buffer.from(chunk).toString();
+          if (typeof encodingOrCallback === "function") {
+            encodingOrCallback();
+          } else {
+            callback?.();
+          }
+          return true;
+        }) as typeof process.stderr.write;
+        let exitCode: number | null;
+        try {
+          exitCode = await runLookupAndCaptureExitCode(
+            createLookupRunCommand({
+              urls: [rootUrl.href],
+              recurse: "replyTarget",
+              recurseDepth: 20,
+              allowPrivateAddress: false,
+              output: testFile,
+            }),
+          );
+        } finally {
+          process.stderr.write = originalWrite;
         }
-        return true;
-      }) as typeof process.stderr.write;
-      let exitCode: number | null;
-      try {
-        exitCode = await runLookupAndCaptureExitCode(
-          createLookupRunCommand({
-            urls: [rootUrl.href],
-            recurse: "replyTarget",
-            recurseDepth: 20,
-            allowPrivateAddress: false,
-            output: testFile,
-          }),
+        assert.equal(exitCode, 1);
+        assert.deepEqual(requestedPaths, ["/notes/1"]);
+        assert.match(
+          stderr,
+          /Try with `-p`\/`--allow-private-address`/,
         );
-      } finally {
-        process.stderr.write = originalWrite;
-      }
-      assert.equal(exitCode, 1);
-      assert.deepEqual(requestedPaths, ["/notes/1"]);
-      assert.match(
-        stderr,
-        /Try with `-p`\/`--allow-private-address`/,
-      );
 
-      const content = await readFile(testFile, "utf8");
-      assert.deepEqual(extractIdsFromRawOutput(content), [rootUrl.href]);
-    });
+        const content = await readFile(testFile, "utf8");
+        assert.deepEqual(extractIdsFromRawOutput(content), [rootUrl.href]);
+      },
+    );
   } finally {
     await rm(testDir, { recursive: true });
   }
@@ -1181,6 +1205,7 @@ test("runLookup - allows recursive private targets with allowPrivateAddress", as
   await mkdir(testDir, { recursive: true });
   try {
     await withRecursiveLookupServer(
+      {},
       async ({ rootUrl, replyUrl, requestedPaths }) => {
         const exitCode = await runLookupAndCaptureExitCode(
           createLookupRunCommand({
@@ -1199,6 +1224,35 @@ test("runLookup - allows recursive private targets with allowPrivateAddress", as
           rootUrl.href,
           replyUrl.href,
         ]);
+      },
+    );
+  } finally {
+    await rm(testDir, { recursive: true });
+  }
+});
+
+test("runLookup - keeps recursive private contexts blocked", async () => {
+  const testDir = "./test_output_runlookup_recurse_private_context";
+  const testFile = `${testDir}/out.jsonl`;
+  await mkdir(testDir, { recursive: true });
+  try {
+    await withRecursiveLookupServer(
+      { replyContextPath: "/contexts/reply" },
+      async ({ rootUrl, requestedPaths }) => {
+        const exitCode = await runLookupAndCaptureExitCode(
+          createLookupRunCommand({
+            urls: [rootUrl.href],
+            recurse: "replyTarget",
+            recurseDepth: 20,
+            allowPrivateAddress: true,
+            output: testFile,
+          }),
+        );
+        assert.equal(exitCode, 1);
+        assert.deepEqual(requestedPaths, ["/notes/1", "/notes/0"]);
+
+        const content = await readFile(testFile, "utf8");
+        assert.deepEqual(extractIdsFromRawOutput(content), [rootUrl.href]);
       },
     );
   } finally {

--- a/packages/cli/src/lookup.test.ts
+++ b/packages/cli/src/lookup.test.ts
@@ -11,6 +11,7 @@ import { join } from "node:path";
 import process from "node:process";
 import { Writable } from "node:stream";
 import test from "node:test";
+import { serve } from "srvx";
 import { configContext } from "./config.ts";
 import { getContextLoader } from "./docloader.ts";
 import { runCli } from "./runner.ts";
@@ -1061,6 +1062,149 @@ function extractIdsFromRawOutput(content: string): string[] {
     match[1]
   );
 }
+
+async function withRecursiveLookupServer<T>(
+  callback: (server: {
+    rootUrl: URL;
+    replyUrl: URL;
+    requestedPaths: string[];
+  }) => Promise<T>,
+): Promise<T> {
+  const requestedPaths: string[] = [];
+  const server = serve({
+    port: 0,
+    hostname: "127.0.0.1",
+    silent: true,
+    fetch(request) {
+      const requestUrl = new URL(request.url);
+      const rootUrl = new URL("/notes/1", requestUrl.origin);
+      const replyUrl = new URL("/notes/0", requestUrl.origin);
+      requestedPaths.push(requestUrl.pathname);
+
+      let body: unknown;
+      if (requestUrl.pathname === rootUrl.pathname) {
+        body = {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          id: rootUrl.href,
+          type: "Note",
+          content: "root",
+          inReplyTo: replyUrl.href,
+        };
+      } else if (requestUrl.pathname === replyUrl.pathname) {
+        body = {
+          "@context": "https://www.w3.org/ns/activitystreams",
+          id: replyUrl.href,
+          type: "Note",
+          content: "reply",
+        };
+      } else {
+        return new Response(null, { status: 404 });
+      }
+
+      return Response.json(body, {
+        headers: {
+          "Content-Type": "application/activity+json",
+        },
+      });
+    },
+  });
+
+  await server.ready();
+  assert.ok(server.url != null);
+  const origin = new URL(server.url).origin;
+  try {
+    return await callback({
+      rootUrl: new URL("/notes/1", origin),
+      replyUrl: new URL("/notes/0", origin),
+      requestedPaths,
+    });
+  } finally {
+    await server.close(true);
+  }
+}
+
+test("runLookup - rejects recursive private targets by default", async () => {
+  const testDir = "./test_output_runlookup_recurse_private_default";
+  const testFile = `${testDir}/out.jsonl`;
+  await mkdir(testDir, { recursive: true });
+  try {
+    await withRecursiveLookupServer(async ({ rootUrl, requestedPaths }) => {
+      const originalWrite = process.stderr.write;
+      let stderr = "";
+      process.stderr.write = ((
+        chunk: string | Uint8Array,
+        encodingOrCallback?: unknown,
+        callback?: () => void,
+      ) => {
+        stderr += typeof chunk === "string"
+          ? chunk
+          : Buffer.from(chunk).toString();
+        if (typeof encodingOrCallback === "function") {
+          encodingOrCallback();
+        } else {
+          callback?.();
+        }
+        return true;
+      }) as typeof process.stderr.write;
+      let exitCode: number | null;
+      try {
+        exitCode = await runLookupAndCaptureExitCode(
+          createLookupRunCommand({
+            urls: [rootUrl.href],
+            recurse: "replyTarget",
+            recurseDepth: 20,
+            allowPrivateAddress: false,
+            output: testFile,
+          }),
+        );
+      } finally {
+        process.stderr.write = originalWrite;
+      }
+      assert.equal(exitCode, 1);
+      assert.deepEqual(requestedPaths, ["/notes/1"]);
+      assert.match(
+        stderr,
+        /Try with `-p`\/`--allow-private-address`/,
+      );
+
+      const content = await readFile(testFile, "utf8");
+      assert.deepEqual(extractIdsFromRawOutput(content), [rootUrl.href]);
+    });
+  } finally {
+    await rm(testDir, { recursive: true });
+  }
+});
+
+test("runLookup - allows recursive private targets with allowPrivateAddress", async () => {
+  const testDir = "./test_output_runlookup_recurse_private_allowed";
+  const testFile = `${testDir}/out.jsonl`;
+  await mkdir(testDir, { recursive: true });
+  try {
+    await withRecursiveLookupServer(
+      async ({ rootUrl, replyUrl, requestedPaths }) => {
+        const exitCode = await runLookupAndCaptureExitCode(
+          createLookupRunCommand({
+            urls: [rootUrl.href],
+            recurse: "replyTarget",
+            recurseDepth: 20,
+            allowPrivateAddress: true,
+            output: testFile,
+          }),
+        );
+        assert.equal(exitCode, 0);
+        assert.deepEqual(requestedPaths, ["/notes/1", "/notes/0"]);
+
+        const content = await readFile(testFile, "utf8");
+        assert.deepEqual(extractIdsFromRawOutput(content), [
+          rootUrl.href,
+          replyUrl.href,
+        ]);
+      },
+    );
+  } finally {
+    await rm(testDir, { recursive: true });
+  }
+});
 
 test("runLookup - reverses output order in default multi-input mode", async () => {
   const testDir = "./test_output_runlookup_default_reverse";

--- a/packages/cli/src/lookup.test.ts
+++ b/packages/cli/src/lookup.test.ts
@@ -1193,7 +1193,7 @@ test("runLookup - rejects recursive private targets by default", async () => {
         assert.deepEqual(requestedPaths, ["/notes/1"]);
         assert.match(
           stderr,
-          /Try with `-p`\/`--allow-private-address`/,
+          /--allow-private-address/,
         );
 
         const content = await readFile(testFile, "utf8");
@@ -1260,7 +1260,7 @@ test("runLookup - keeps recursive private contexts blocked", async () => {
         assert.deepEqual(requestedPaths, ["/notes/1", "/notes/0"]);
         assert.match(
           stderr,
-          /Recursive JSON-LD context URLs are always blocked/,
+          /Recursive JSON-LD context URL .* is always blocked/,
         );
 
         const content = await readFile(testFile, "utf8");

--- a/packages/cli/src/lookup.ts
+++ b/packages/cli/src/lookup.ts
@@ -46,6 +46,7 @@ import {
 import { url as messageUrl } from "@optique/core/message";
 import { path, printError } from "@optique/run";
 import { createWriteStream, type WriteStream } from "node:fs";
+import { isIP } from "node:net";
 import process from "node:process";
 import ora from "ora";
 import { configContext } from "./config.ts";
@@ -565,14 +566,14 @@ export function getPrivateUrlCandidate(
     const hostname = url.hostname;
     if (hostname === "localhost") return url;
 
-    if (/^\d+\.\d+\.\d+\.\d+$/.test(hostname)) {
-      return isValidPublicIPv4Address(hostname) ? null : url;
-    }
-
     const normalized = hostname.startsWith("[") && hostname.endsWith("]")
       ? hostname.slice(1, -1)
       : hostname;
-    if (normalized.includes(":")) {
+    const ipVersion = isIP(normalized);
+    if (ipVersion === 4) {
+      return isValidPublicIPv4Address(normalized) ? null : url;
+    }
+    if (ipVersion === 6) {
       const expanded = expandIPv6Address(normalized);
       return isValidPublicIPv6Address(expanded) ? null : url;
     }

--- a/packages/cli/src/lookup.ts
+++ b/packages/cli/src/lookup.ts
@@ -560,6 +560,31 @@ async function isPrivateAddressTarget(target: string): Promise<boolean> {
   return false;
 }
 
+async function getPrivateContextUrl(error: unknown): Promise<URL | null> {
+  const errorMessage = error instanceof Error ? error.message : String(error);
+  if (
+    !(error instanceof Error) ||
+    (error.name !== "jsonld.InvalidUrl" &&
+      !errorMessage.includes("valid JSON-LD object"))
+  ) {
+    return null;
+  }
+  const match = errorMessage.match(/URL:\s*"([^"]+)"/);
+  if (match == null) return null;
+
+  try {
+    const url = new URL(match[1]);
+    try {
+      await validatePublicUrl(url.href);
+      return null;
+    } catch (validationError) {
+      return isPrivateAddressError(validationError) ? url : null;
+    }
+  } catch {
+    return null;
+  }
+}
+
 export function getLookupFailureHint(
   error: unknown,
   options: { recursive?: boolean } = {},
@@ -1058,6 +1083,18 @@ export async function runLookup(
           }
         } else {
           spinner.fail("Failed to recursively fetch object.");
+          const privateContextUrl = await getPrivateContextUrl(error);
+          if (privateContextUrl != null) {
+            printError(
+              message`Recursive JSON-LD context URLs are always blocked, even with ${
+                optionNames(["-p", "--allow-private-address"])
+              }.  Use ${
+                optionNames(["-S", "--suppress-errors"])
+              } to skip blocked steps.`,
+            );
+            await finalizeAndExit(1);
+            return;
+          }
           const hint = getLookupFailureHint(error, { recursive: true });
           if (shouldSuggestSuppressErrorsForLookupFailure(authLoader, hint)) {
             printError(

--- a/packages/cli/src/lookup.ts
+++ b/packages/cli/src/lookup.ts
@@ -41,6 +41,7 @@ import {
   string,
   withDefault,
 } from "@optique/core";
+import { url as messageUrl } from "@optique/core/message";
 import { path, printError } from "@optique/run";
 import { createWriteStream, type WriteStream } from "node:fs";
 import process from "node:process";
@@ -552,13 +553,24 @@ function isPrivateAddressError(error: unknown): boolean {
   );
 }
 
-async function isPrivateAddressTarget(target: string): Promise<boolean> {
+async function getPrivateUrlCandidate(candidate: unknown): Promise<URL | null> {
+  if (typeof candidate !== "string" && !(candidate instanceof URL)) return null;
+
   try {
-    await validatePublicUrl(target);
-  } catch (error) {
-    return isPrivateAddressError(error);
+    const url = new URL(candidate);
+    try {
+      await validatePublicUrl(url.href);
+      return null;
+    } catch (validationError) {
+      return isPrivateAddressError(validationError) ? url : null;
+    }
+  } catch {
+    return null;
   }
-  return false;
+}
+
+async function isPrivateAddressTarget(target: string): Promise<boolean> {
+  return await getPrivateUrlCandidate(target) != null;
 }
 
 async function getPrivateContextUrl(error: unknown): Promise<URL | null> {
@@ -575,20 +587,39 @@ async function getPrivateContextUrl(error: unknown): Promise<URL | null> {
   ) {
     return null;
   }
+
+  const structuredError = error as {
+    details?: { url?: unknown };
+    url?: unknown;
+  };
+  const structuredUrl =
+    await getPrivateUrlCandidate(structuredError.details?.url) ??
+      await getPrivateUrlCandidate(structuredError.url);
+  if (structuredUrl != null) return structuredUrl;
+
   const match = errorMessage.match(/URL:\s*"([^"]+)"/);
   if (match == null) return null;
+  return await getPrivateUrlCandidate(match[1]);
+}
 
-  try {
-    const url = new URL(match[1]);
-    try {
-      await validatePublicUrl(url.href);
-      return null;
-    } catch (validationError) {
-      return isPrivateAddressError(validationError) ? url : null;
-    }
-  } catch {
-    return null;
-  }
+function printRecursivePrivateAddressHint(): void {
+  printError(
+    message`The recursive target appears to be private or localhost.  Try with ${
+      optionNames(["-p", "--allow-private-address"])
+    }, or use ${
+      optionNames(["-S", "--suppress-errors"])
+    } to skip blocked steps.`,
+  );
+}
+
+function printRecursivePrivateContextHint(privateContextUrl: URL): void {
+  printError(
+    message`Recursive JSON-LD context URL ${
+      messageUrl(privateContextUrl)
+    } is always blocked, even with ${
+      optionNames(["-p", "--allow-private-address"])
+    }.  Use ${optionNames(["-S", "--suppress-errors"])} to skip blocked steps.`,
+  );
 }
 
 export function getLookupFailureHint(
@@ -631,13 +662,7 @@ function printLookupFailureHint(
       );
       return;
     case "recursive-private-address":
-      printError(
-        message`The recursive target appears to be private or localhost.  Try with ${
-          optionNames(["-p", "--allow-private-address"])
-        }, or use ${
-          optionNames(["-S", "--suppress-errors"])
-        } to skip blocked steps.`,
-      );
+      printRecursivePrivateAddressHint();
       return;
     case "authorized-fetch":
       printError(
@@ -1075,11 +1100,7 @@ export async function runLookup(
             !command.allowPrivateAddress &&
             await isPrivateAddressTarget(error.target)
           ) {
-            printLookupFailureHint(
-              authLoader,
-              new UrlError("Invalid or private address"),
-              { recursive: true },
-            );
+            printRecursivePrivateAddressHint();
           } else if (authLoader == null) {
             printError(
               message`It may be a private object.  Try with ${
@@ -1091,13 +1112,7 @@ export async function runLookup(
           spinner.fail("Failed to recursively fetch object.");
           const privateContextUrl = await getPrivateContextUrl(error);
           if (privateContextUrl != null) {
-            printError(
-              message`Recursive JSON-LD context URLs are always blocked, even with ${
-                optionNames(["-p", "--allow-private-address"])
-              }.  Use ${
-                optionNames(["-S", "--suppress-errors"])
-              } to skip blocked steps.`,
-            );
+            printRecursivePrivateContextHint(privateContextUrl);
             await finalizeAndExit(1);
             return;
           }

--- a/packages/cli/src/lookup.ts
+++ b/packages/cli/src/lookup.ts
@@ -564,13 +564,14 @@ async function isPrivateAddressTarget(target: string): Promise<boolean> {
 async function getPrivateContextUrl(error: unknown): Promise<URL | null> {
   // This detection intentionally depends on jsonld's current error shape:
   // name === "jsonld.InvalidUrl", the "valid JSON-LD object" substring, and
-  // a trailing `URL: "..."` segment. If jsonld changes those details, this
-  // helper and the related lookup tests need to be updated together.
+  // a trailing `URL: "..."` segment all at once. If jsonld changes those
+  // details, this helper and the related lookup tests need to be updated
+  // together.
   const errorMessage = error instanceof Error ? error.message : String(error);
   if (
     !(error instanceof Error) ||
-    (error.name !== "jsonld.InvalidUrl" &&
-      !errorMessage.includes("valid JSON-LD object"))
+    error.name !== "jsonld.InvalidUrl" ||
+    !errorMessage.includes("valid JSON-LD object")
   ) {
     return null;
   }

--- a/packages/cli/src/lookup.ts
+++ b/packages/cli/src/lookup.ts
@@ -916,7 +916,14 @@ export async function runLookup(
       initialDocumentLoader;
     const recursiveLookupDocumentLoader: DocumentLoader = authLoader ??
       documentLoader;
-    const recursiveContextLoader = contextLoader;
+    const recursiveBaseContextLoader = await getContextLoader({
+      userAgent: command.userAgent,
+      allowPrivateAddress: false,
+    });
+    const recursiveContextLoader = wrapDocumentLoaderWithTimeout(
+      recursiveBaseContextLoader,
+      command.timeout,
+    );
     let totalObjects = 0;
     const recurseDepth = command.recurseDepth!;
 

--- a/packages/cli/src/lookup.ts
+++ b/packages/cli/src/lookup.ts
@@ -12,7 +12,11 @@ import {
   Object as APObject,
   traverseCollection,
 } from "@fedify/vocab";
-import { type DocumentLoader, UrlError } from "@fedify/vocab-runtime";
+import {
+  type DocumentLoader,
+  UrlError,
+  validatePublicUrl,
+} from "@fedify/vocab-runtime";
 import type { ResourceDescriptor } from "@fedify/webfinger";
 import { getLogger } from "@logtape/logtape";
 import { bindConfig } from "@optique/config";
@@ -87,11 +91,8 @@ const suppressErrorsOption = bindConfig(
 const allowPrivateAddressOption = bindConfig(
   flag("-p", "--allow-private-address", {
     description: message`Allow private IP addresses for URLs discovered \
-during traversal. This option only has an effect when used together \
-with ${optionNames(["-t", "--traverse"])}, since URLs explicitly \
-provided on the command line always allow private addresses and \
-recursive fetches via ${optionNames(["--recurse"])} always disallow \
-them.`,
+during traversal or recursion. URLs explicitly provided on the \
+command line always allow private addresses.`,
   }),
   {
     context: configContext,
@@ -527,7 +528,9 @@ function handleTimeoutError(
   const urlText = url ? ` for: ${colors.red(url)}` : "";
   spinner.fail(`Request timed out after ${timeoutSeconds} seconds${urlText}.`);
   printError(
-    message`Try increasing the timeout with -T/--timeout option or check network connectivity.`,
+    message`Try increasing the timeout with ${
+      optionNames(["-T", "--timeout"])
+    } option or check network connectivity.`,
   );
 }
 
@@ -546,6 +549,15 @@ function isPrivateAddressError(error: unknown): boolean {
     lowerMessage.includes("localhost") ||
     lowerMessage.includes("loopback")
   );
+}
+
+async function isPrivateAddressTarget(target: string): Promise<boolean> {
+  try {
+    await validatePublicUrl(target);
+  } catch (error) {
+    return isPrivateAddressError(error);
+  }
+  return false;
 }
 
 export function getLookupFailureHint(
@@ -582,17 +594,25 @@ function printLookupFailureHint(
   switch (hint) {
     case "private-address":
       printError(
-        message`The URL appears to be private or localhost.  Try with -p/--allow-private-address.`,
+        message`The URL appears to be private or localhost.  Try with ${
+          optionNames(["-p", "--allow-private-address"])
+        }.`,
       );
       return;
     case "recursive-private-address":
       printError(
-        message`Recursive fetches do not allow private/localhost URLs.  Use -S/--suppress-errors to skip blocked steps, or fetch those targets explicitly without --recurse.`,
+        message`The recursive target appears to be private or localhost.  Try with ${
+          optionNames(["-p", "--allow-private-address"])
+        }, or use ${
+          optionNames(["-S", "--suppress-errors"])
+        } to skip blocked steps.`,
       );
       return;
     case "authorized-fetch":
       printError(
-        message`It may be a private object.  Try with -a/--authorized-fetch.`,
+        message`It may be a private object.  Try with ${
+          optionNames(["-a", "--authorized-fetch"])
+        }.`,
       );
       return;
   }
@@ -730,10 +750,8 @@ export async function runLookup(
   let server: TemporaryServer | undefined = undefined;
   // URLs explicitly provided by the user always allow private addresses,
   // so that local servers can be looked up without -p/--allow-private-address.
-  // URLs discovered during traversal follow the option to mitigate SSRF
-  // against private addresses, while recursive fetches always disallow
-  // private addresses regardless of the option (see the --recurse branch
-  // below, which hardcodes `allowPrivateAddress: false`).
+  // URLs discovered during traversal or recursion follow the option to
+  // mitigate SSRF against private addresses.
   const initialBaseDocumentLoader = await getDocumentLoader({
     userAgent: command.userAgent,
     allowPrivateAddress: true,
@@ -894,46 +912,11 @@ export async function runLookup(
   }...`;
 
   if (command.recurse != null) {
-    const recursiveBaseDocumentLoader = await getDocumentLoader({
-      userAgent: command.userAgent,
-      allowPrivateAddress: false,
-    });
-    const recursiveDocumentLoader = wrapDocumentLoaderWithTimeout(
-      recursiveBaseDocumentLoader,
-      command.timeout,
-    );
-    const recursiveBaseContextLoader = await getContextLoader({
-      userAgent: command.userAgent,
-      allowPrivateAddress: false,
-    });
-    const recursiveContextLoader = wrapDocumentLoaderWithTimeout(
-      recursiveBaseContextLoader,
-      command.timeout,
-    );
-    const recursiveAuthLoader = command.authorizedFetch &&
-        authIdentity != null
-      ? wrapDocumentLoaderWithTimeout(
-        getAuthenticatedDocumentLoader(
-          authIdentity,
-          {
-            allowPrivateAddress: false,
-            userAgent: command.userAgent,
-            specDeterminer: {
-              determineSpec() {
-                return command.firstKnock;
-              },
-              rememberSpec() {
-              },
-            },
-          },
-        ),
-        command.timeout,
-      )
-      : undefined;
     const initialLookupDocumentLoader: DocumentLoader = initialAuthLoader ??
       initialDocumentLoader;
-    const recursiveLookupDocumentLoader: DocumentLoader = recursiveAuthLoader ??
-      recursiveDocumentLoader;
+    const recursiveLookupDocumentLoader: DocumentLoader = authLoader ??
+      documentLoader;
+    const recursiveContextLoader = contextLoader;
     let totalObjects = 0;
     const recurseDepth = command.recurseDepth!;
 
@@ -966,7 +949,9 @@ export async function runLookup(
         spinner.fail(`Failed to fetch object: ${colors.red(url)}.`);
         if (authLoader == null) {
           printError(
-            message`It may be a private object.  Try with -a/--authorized-fetch.`,
+            message`It may be a private object.  Try with ${
+              optionNames(["-a", "--authorized-fetch"])
+            }.`,
           );
         }
         await finalizeAndExit(1);
@@ -1048,9 +1033,20 @@ export async function runLookup(
           spinner.fail(
             `Failed to recursively fetch object: ${colors.red(error.target)}.`,
           );
-          if (authLoader == null) {
+          if (
+            !command.allowPrivateAddress &&
+            await isPrivateAddressTarget(error.target)
+          ) {
+            printLookupFailureHint(
+              authLoader,
+              new UrlError("Invalid or private address"),
+              { recursive: true },
+            );
+          } else if (authLoader == null) {
             printError(
-              message`It may be a private object.  Try with -a/--authorized-fetch.`,
+              message`It may be a private object.  Try with ${
+                optionNames(["-a", "--authorized-fetch"])
+              }.`,
             );
           }
         } else {
@@ -1058,7 +1054,9 @@ export async function runLookup(
           const hint = getLookupFailureHint(error, { recursive: true });
           if (shouldSuggestSuppressErrorsForLookupFailure(authLoader, hint)) {
             printError(
-              message`Use the -S/--suppress-errors option to suppress partial errors.`,
+              message`Use the ${
+                optionNames(["-S", "--suppress-errors"])
+              } option to suppress partial errors.`,
             );
           } else {
             printLookupFailureHint(authLoader, error, { recursive: true });
@@ -1172,7 +1170,9 @@ export async function runLookup(
         spinner.fail(`Failed to fetch object: ${colors.red(url)}.`);
         if (authLoader == null) {
           printError(
-            message`It may be a private object.  Try with -a/--authorized-fetch.`,
+            message`It may be a private object.  Try with ${
+              optionNames(["-a", "--authorized-fetch"])
+            }.`,
           );
         }
         await finalizeAndExit(1);
@@ -1272,7 +1272,9 @@ export async function runLookup(
           const hint = getLookupFailureHint(error);
           if (shouldSuggestSuppressErrorsForLookupFailure(authLoader, hint)) {
             printError(
-              message`Use the -S/--suppress-errors option to suppress partial errors.`,
+              message`Use the ${
+                optionNames(["-S", "--suppress-errors"])
+              } option to suppress partial errors.`,
             );
           } else {
             printLookupFailureHint(authLoader, error);
@@ -1323,7 +1325,9 @@ export async function runLookup(
       spinner.fail(`Failed to fetch ${colors.red(url)}`);
       if (authLoader == null) {
         printError(
-          message`It may be a private object.  Try with -a/--authorized-fetch.`,
+          message`It may be a private object.  Try with ${
+            optionNames(["-a", "--authorized-fetch"])
+          }.`,
         );
       }
       success = false;

--- a/packages/cli/src/lookup.ts
+++ b/packages/cli/src/lookup.ts
@@ -559,6 +559,9 @@ function isPrivateAddressError(error: unknown): boolean {
 export function getPrivateUrlCandidate(
   candidate: unknown,
 ): URL | null {
+  // This helper is only for post-failure hinting. It intentionally does a
+  // cheap hostname/IP check so we can recognize obvious private targets
+  // without re-running the full document-loader validation path.
   if (typeof candidate !== "string" && !(candidate instanceof URL)) return null;
 
   try {
@@ -588,6 +591,12 @@ function isPrivateAddressTarget(target: string): boolean {
 }
 
 function getPrivateContextUrl(error: unknown): URL | null {
+  // Recursive object fetches and recursive JSON-LD context fetches use
+  // different loader policies. When the strict context loader rejects a
+  // private @context URL, the underlying UrlError is often surfaced as a
+  // jsonld parsing error instead of the original loader error. This helper
+  // reconstructs the blocked private context URL so the CLI can show a
+  // recurse-specific hint instead of the generic authorized-fetch hint.
   // This detection intentionally depends on jsonld's current error shape:
   // name === "jsonld.InvalidUrl", the "valid JSON-LD object" substring, and
   // a trailing `URL: "..."` segment all at once. If jsonld changes those
@@ -985,6 +994,10 @@ export async function runLookup(
       initialDocumentLoader;
     const recursiveLookupDocumentLoader: DocumentLoader = authLoader ??
       documentLoader;
+    // `-p/--allow-private-address` only changes the follow-up object fetches
+    // that recurse explicitly performs. JSON-LD context loads stay on the
+    // strict loader so a remote object cannot implicitly expand the trust
+    // boundary via private @context URLs.
     const recursiveBaseContextLoader = await getContextLoader({
       userAgent: command.userAgent,
       allowPrivateAddress: false,

--- a/packages/cli/src/lookup.ts
+++ b/packages/cli/src/lookup.ts
@@ -91,7 +91,8 @@ const suppressErrorsOption = bindConfig(
 const allowPrivateAddressOption = bindConfig(
   flag("-p", "--allow-private-address", {
     description: message`Allow private IP addresses for URLs discovered \
-during traversal or recursion. URLs explicitly provided on the \
+during traversal or recursive object fetches. Recursive JSON-LD \
+context URLs always remain blocked. URLs explicitly provided on the \
 command line always allow private addresses.`,
   }),
   {
@@ -561,6 +562,10 @@ async function isPrivateAddressTarget(target: string): Promise<boolean> {
 }
 
 async function getPrivateContextUrl(error: unknown): Promise<URL | null> {
+  // This detection intentionally depends on jsonld's current error shape:
+  // name === "jsonld.InvalidUrl", the "valid JSON-LD object" substring, and
+  // a trailing `URL: "..."` segment. If jsonld changes those details, this
+  // helper and the related lookup tests need to be updated together.
   const errorMessage = error instanceof Error ? error.message : String(error);
   if (
     !(error instanceof Error) ||

--- a/packages/cli/src/lookup.ts
+++ b/packages/cli/src/lookup.ts
@@ -14,8 +14,10 @@ import {
 } from "@fedify/vocab";
 import {
   type DocumentLoader,
+  expandIPv6Address,
+  isValidPublicIPv4Address,
+  isValidPublicIPv6Address,
   UrlError,
-  validatePublicUrl,
 } from "@fedify/vocab-runtime";
 import type { ResourceDescriptor } from "@fedify/webfinger";
 import { getLogger } from "@logtape/logtape";
@@ -553,27 +555,38 @@ function isPrivateAddressError(error: unknown): boolean {
   );
 }
 
-async function getPrivateUrlCandidate(candidate: unknown): Promise<URL | null> {
+export function getPrivateUrlCandidate(
+  candidate: unknown,
+): URL | null {
   if (typeof candidate !== "string" && !(candidate instanceof URL)) return null;
 
   try {
     const url = new URL(candidate);
-    try {
-      await validatePublicUrl(url.href);
-      return null;
-    } catch (validationError) {
-      return isPrivateAddressError(validationError) ? url : null;
+    const hostname = url.hostname;
+    if (hostname === "localhost") return url;
+
+    if (/^\d+\.\d+\.\d+\.\d+$/.test(hostname)) {
+      return isValidPublicIPv4Address(hostname) ? null : url;
     }
+
+    const normalized = hostname.startsWith("[") && hostname.endsWith("]")
+      ? hostname.slice(1, -1)
+      : hostname;
+    if (normalized.includes(":")) {
+      const expanded = expandIPv6Address(normalized);
+      return isValidPublicIPv6Address(expanded) ? null : url;
+    }
+    return null;
   } catch {
     return null;
   }
 }
 
-async function isPrivateAddressTarget(target: string): Promise<boolean> {
-  return await getPrivateUrlCandidate(target) != null;
+function isPrivateAddressTarget(target: string): boolean {
+  return getPrivateUrlCandidate(target) != null;
 }
 
-async function getPrivateContextUrl(error: unknown): Promise<URL | null> {
+function getPrivateContextUrl(error: unknown): URL | null {
   // This detection intentionally depends on jsonld's current error shape:
   // name === "jsonld.InvalidUrl", the "valid JSON-LD object" substring, and
   // a trailing `URL: "..."` segment all at once. If jsonld changes those
@@ -592,14 +605,13 @@ async function getPrivateContextUrl(error: unknown): Promise<URL | null> {
     details?: { url?: unknown };
     url?: unknown;
   };
-  const structuredUrl =
-    await getPrivateUrlCandidate(structuredError.details?.url) ??
-      await getPrivateUrlCandidate(structuredError.url);
+  const structuredUrl = getPrivateUrlCandidate(structuredError.details?.url) ??
+    getPrivateUrlCandidate(structuredError.url);
   if (structuredUrl != null) return structuredUrl;
 
   const match = errorMessage.match(/URL:\s*"([^"]+)"/);
   if (match == null) return null;
-  return await getPrivateUrlCandidate(match[1]);
+  return getPrivateUrlCandidate(match[1]);
 }
 
 function printRecursivePrivateAddressHint(): void {
@@ -1098,7 +1110,7 @@ export async function runLookup(
           );
           if (
             !command.allowPrivateAddress &&
-            await isPrivateAddressTarget(error.target)
+            isPrivateAddressTarget(error.target)
           ) {
             printRecursivePrivateAddressHint();
           } else if (authLoader == null) {
@@ -1110,7 +1122,7 @@ export async function runLookup(
           }
         } else {
           spinner.fail("Failed to recursively fetch object.");
-          const privateContextUrl = await getPrivateContextUrl(error);
+          const privateContextUrl = getPrivateContextUrl(error);
           if (privateContextUrl != null) {
             printRecursivePrivateContextHint(privateContextUrl);
             await finalizeAndExit(1);


### PR DESCRIPTION
Summary
-------

Fixes #700.

`fedify lookup` already lets `-p`/`--allow-private-address` opt into private-address access for URLs discovered by `--traverse`, but recursive fetches triggered by `--recurse` still rejected those targets unconditionally. That made the option feel tied to one mode instead of expressing a consistent policy for discovered URLs.

This change makes recursive follow-up fetches honor the same explicit opt-in while keeping the default behavior strict. Private and localhost targets discovered through recursion are still blocked unless the user passes `-p`/`--allow-private-address`.

Changes
-------

- Updated *packages/cli/src/lookup.ts* so recursive object fetches reuse loaders configured with `allowPrivateAddress` instead of hardcoding recursive fetches to deny private addresses.
- Updated recursive lookup failure hints to point users at `-p`/`--allow-private-address` and render option names with Optique message markup.
- Added regression coverage in *packages/cli/src/lookup.test.ts* for both the default blocked case and the explicit opt-in case, using `srvx` for the local recursive test server.
- Updated *docs/cli.md* and *CHANGES.md* to describe the new recursive behavior.

Testing
-------

- `pnpm --dir packages/cli exec node --test --experimental-transform-types src/lookup.test.ts`
- `pnpm --dir packages/cli test`
- `mise run check-each cli`
- `mise run check:md`