### PR TITLE
Link docs refs across Fedify packages

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,4 +1,9 @@
 .jsr-cache.json
+.jsr-debugger-cache.json
+.jsr-testing-cache.json
+.jsr-vocab-cache.json
+.jsr-vocab-runtime-cache.json
+.jsr-webfinger-cache.json
 .vitepress/cache/
 .vitepress/dist/
 node_modules/

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,9 +1,5 @@
 .jsr-cache.json
-.jsr-debugger-cache.json
-.jsr-testing-cache.json
-.jsr-vocab-cache.json
-.jsr-vocab-runtime-cache.json
-.jsr-webfinger-cache.json
+.jsr-*-cache.json
 .vitepress/cache/
 .vitepress/dist/
 node_modules/

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -15,11 +15,24 @@ import {
 import llmstxt from "vitepress-plugin-llms";
 import { withMermaid } from "vitepress-plugin-mermaid";
 
-const jsrRefPlugin = await jsrRef({
-  package: "@fedify/fedify",
-  version: process.env.JSR_REF_VERSION ?? "unstable",
-  cachePath: ".jsr-cache.json",
-});
+const jsrRefVersion = process.env.JSR_REF_VERSION ?? "unstable";
+const jsrRefPackages = [
+  ["@fedify/fedify", ".jsr-cache.json"],
+  ["@fedify/vocab", ".jsr-vocab-cache.json"],
+  ["@fedify/vocab-runtime", ".jsr-vocab-runtime-cache.json"],
+  ["@fedify/webfinger", ".jsr-webfinger-cache.json"],
+  ["@fedify/debugger", ".jsr-debugger-cache.json"],
+  ["@fedify/testing", ".jsr-testing-cache.json"],
+] as const;
+const jsrRefPlugins = await Promise.all(
+  jsrRefPackages.map(([packageName, cachePath]) =>
+    jsrRef({
+      package: packageName,
+      version: jsrRefVersion,
+      cachePath,
+    })
+  ),
+);
 
 let extraNav: { text: string; link: string }[] = [];
 if (process.env.EXTRA_NAV_TEXT && process.env.EXTRA_NAV_LINK) {
@@ -300,7 +313,9 @@ export default withMermaid(defineConfig({
       md.use(footnote);
       md.use(taskLists);
       md.use(groupIconMdPlugin);
-      md.use(jsrRefPlugin);
+      for (const jsrRefPlugin of jsrRefPlugins) {
+        md.use(jsrRefPlugin);
+      }
     },
   },
   sitemap: {

--- a/docs/package.json
+++ b/docs/package.json
@@ -56,7 +56,7 @@
     "markdown-it-abbr": "^2.0.0",
     "markdown-it-deflist": "^3.0.0",
     "markdown-it-footnote": "^4.0.0",
-    "markdown-it-jsr-ref": "0.4.1",
+    "markdown-it-jsr-ref": "0.4.4",
     "mermaid": "^11.4.1",
     "postgres": "catalog:",
     "srvx": "^0.11.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,12 @@ catalogs:
     '@nestjs/common':
       specifier: ^11.0.1
       version: 11.1.4
+    '@nuxt/kit':
+      specifier: ^4.4.2
+      version: 4.4.2
+    '@nuxt/schema':
+      specifier: ^4.4.2
+      version: 4.4.2
     '@opentelemetry/api':
       specifier: ^1.9.0
       version: 1.9.0
@@ -332,8 +338,8 @@ importers:
         specifier: ^4.0.0
         version: 4.0.0
       markdown-it-jsr-ref:
-        specifier: 0.4.1
-        version: 0.4.1
+        specifier: 0.4.4
+        version: 0.4.4
       mermaid:
         specifier: ^11.4.1
         version: 11.7.0
@@ -7427,9 +7433,6 @@ packages:
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
 
-  confbox@0.2.2:
-    resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
-
   confbox@0.2.4:
     resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
 
@@ -9589,8 +9592,8 @@ packages:
   markdown-it-footnote@4.0.0:
     resolution: {integrity: sha512-WYJ7urf+khJYl3DqofQpYfEYkZKbmXmwxQV8c8mO/hGIhgZ1wOe7R4HLFNwqx7TjILbnC98fuyeSsin19JdFcQ==}
 
-  markdown-it-jsr-ref@0.4.1:
-    resolution: {integrity: sha512-EuMR+I+4vvCZ3dP+78IAEeDfjf2ykcbbIJGt1smAoYL8JkjXKu41hQiy4uQ6VpMBSCEVdcvNJWKSj5WC7jEwhg==}
+  markdown-it-jsr-ref@0.4.4:
+    resolution: {integrity: sha512-z6abJJXW0vNHaLC9fxVvT9iaHw2pGjiQDn+rFlQKV3+JgfmNH6bwF8uzWGh1d5Wo7UUAx1w7drmyQFG0OWwh8g==}
 
   markdown-it@14.1.0:
     resolution: {integrity: sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==}
@@ -15132,7 +15135,7 @@ snapshots:
       rc9: 3.0.1
       scule: 1.3.0
       semver: 7.7.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       ufo: 1.6.3
       unctx: 2.5.0
       untyped: 2.0.0
@@ -16911,7 +16914,7 @@ snapshots:
       babel-dead-code-elimination: 1.0.12
       diff: 8.0.4
       pathe: 2.0.3
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
     transitivePeerDependencies:
       - supports-color
 
@@ -17597,7 +17600,7 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
-      semver: 7.7.2
+      semver: 7.7.4
       ts-api-utils: 1.4.3(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
@@ -17614,7 +17617,7 @@ snapshots:
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
-      semver: 7.7.2
+      semver: 7.7.4
       ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -17676,7 +17679,7 @@ snapshots:
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       ts-api-utils: 2.5.0(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -19024,8 +19027,6 @@ snapshots:
   concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
-
-  confbox@0.2.2: {}
 
   confbox@0.2.4: {}
 
@@ -21207,7 +21208,7 @@ snapshots:
 
   is-bun-module@2.0.0:
     dependencies:
-      semver: 7.7.2
+      semver: 7.7.4
 
   is-callable@1.2.7: {}
 
@@ -21784,7 +21785,7 @@ snapshots:
 
   markdown-it-footnote@4.0.0: {}
 
-  markdown-it-jsr-ref@0.4.1:
+  markdown-it-jsr-ref@0.4.4:
     dependencies:
       '@deno/shim-deno': 0.18.2
       markdown-it: 14.1.0
@@ -23221,18 +23222,18 @@ snapshots:
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
-      mlly: 1.7.4
+      mlly: 1.8.2
       pathe: 2.0.3
 
   pkg-types@2.2.0:
     dependencies:
-      confbox: 0.2.2
-      exsolve: 1.0.7
+      confbox: 0.2.4
+      exsolve: 1.0.8
       pathe: 2.0.3
 
   pkg-types@2.3.0:
     dependencies:
-      confbox: 0.2.2
+      confbox: 0.2.4
       exsolve: 1.0.8
       pathe: 2.0.3
 
@@ -25134,7 +25135,7 @@ snapshots:
   unenv@2.0.0-rc.21:
     dependencies:
       defu: 6.1.7
-      exsolve: 1.0.7
+      exsolve: 1.0.8
       ohash: 2.0.11
       pathe: 2.0.3
       ufo: 1.6.3
@@ -25536,7 +25537,7 @@ snapshots:
       picocolors: 1.1.1
       picomatch: 4.0.4
       tiny-invariant: 1.3.3
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
       vite: 7.3.2(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.3)
       vscode-uri: 3.1.0
     optionalDependencies:
@@ -25635,7 +25636,7 @@ snapshots:
       picomatch: 4.0.4
       postcss: 8.5.10
       rollup: 4.44.1
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 22.19.1
       fsevents: 2.3.3
@@ -25652,7 +25653,7 @@ snapshots:
       picomatch: 4.0.4
       postcss: 8.5.10
       rollup: 4.44.1
-      tinyglobby: 0.2.15
+      tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 24.3.0
       fsevents: 2.3.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,12 +27,6 @@ catalogs:
     '@nestjs/common':
       specifier: ^11.0.1
       version: 11.1.4
-    '@nuxt/kit':
-      specifier: ^4.4.2
-      version: 4.4.2
-    '@nuxt/schema':
-      specifier: ^4.4.2
-      version: 4.4.2
     '@opentelemetry/api':
       specifier: ^1.9.0
       version: 1.9.0
@@ -7432,6 +7426,9 @@ packages:
 
   confbox@0.1.8:
     resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
+
+  confbox@0.2.2:
+    resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
 
   confbox@0.2.4:
     resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
@@ -15135,7 +15132,7 @@ snapshots:
       rc9: 3.0.1
       scule: 1.3.0
       semver: 7.7.4
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.15
       ufo: 1.6.3
       unctx: 2.5.0
       untyped: 2.0.0
@@ -16914,7 +16911,7 @@ snapshots:
       babel-dead-code-elimination: 1.0.12
       diff: 8.0.4
       pathe: 2.0.3
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.15
     transitivePeerDependencies:
       - supports-color
 
@@ -17600,7 +17597,7 @@ snapshots:
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
-      semver: 7.7.4
+      semver: 7.7.2
       ts-api-utils: 1.4.3(typescript@5.9.3)
     optionalDependencies:
       typescript: 5.9.3
@@ -17617,7 +17614,7 @@ snapshots:
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
-      semver: 7.7.4
+      semver: 7.7.2
       ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -17679,7 +17676,7 @@ snapshots:
       debug: 4.4.3
       minimatch: 10.2.5
       semver: 7.7.4
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.15
       ts-api-utils: 2.5.0(typescript@5.9.2)
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -19027,6 +19024,8 @@ snapshots:
   concat-map@0.0.1: {}
 
   confbox@0.1.8: {}
+
+  confbox@0.2.2: {}
 
   confbox@0.2.4: {}
 
@@ -21208,7 +21207,7 @@ snapshots:
 
   is-bun-module@2.0.0:
     dependencies:
-      semver: 7.7.4
+      semver: 7.7.2
 
   is-callable@1.2.7: {}
 
@@ -23222,18 +23221,18 @@ snapshots:
   pkg-types@1.3.1:
     dependencies:
       confbox: 0.1.8
-      mlly: 1.8.2
+      mlly: 1.7.4
       pathe: 2.0.3
 
   pkg-types@2.2.0:
     dependencies:
-      confbox: 0.2.4
-      exsolve: 1.0.8
+      confbox: 0.2.2
+      exsolve: 1.0.7
       pathe: 2.0.3
 
   pkg-types@2.3.0:
     dependencies:
-      confbox: 0.2.4
+      confbox: 0.2.2
       exsolve: 1.0.8
       pathe: 2.0.3
 
@@ -25135,7 +25134,7 @@ snapshots:
   unenv@2.0.0-rc.21:
     dependencies:
       defu: 6.1.7
-      exsolve: 1.0.8
+      exsolve: 1.0.7
       ohash: 2.0.11
       pathe: 2.0.3
       ufo: 1.6.3
@@ -25537,7 +25536,7 @@ snapshots:
       picocolors: 1.1.1
       picomatch: 4.0.4
       tiny-invariant: 1.3.3
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.15
       vite: 7.3.2(@types/node@22.19.1)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.46.1)(tsx@4.20.3)(yaml@2.8.3)
       vscode-uri: 3.1.0
     optionalDependencies:
@@ -25636,7 +25635,7 @@ snapshots:
       picomatch: 4.0.4
       postcss: 8.5.10
       rollup: 4.44.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 22.19.1
       fsevents: 2.3.3
@@ -25653,7 +25652,7 @@ snapshots:
       picomatch: 4.0.4
       postcss: 8.5.10
       rollup: 4.44.1
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 24.3.0
       fsevents: 2.3.3


### PR DESCRIPTION
## What changed

This updates the VitePress Markdown-It setup in *docs/.vitepress/config.mts* so `markdown-it-jsr-ref` loads API indexes for the Fedify packages that are referenced across the docs: `@fedify/fedify`, `@fedify/vocab`, `@fedify/vocab-runtime`, `@fedify/webfinger`, `@fedify/debugger`, and `@fedify/testing`.

Each package now gets its own cache file, and those generated cache files are ignored in *docs/.gitignore*.

This also updates `markdown-it-jsr-ref` from 0.4.1 to 0.4.4 in *docs/package.json* and *pnpm-lock.yaml*. The newer version chains inline code renderers correctly, so multiple JSR reference indexes can be active at the same time.

## Why

The docs had inline code references such as `Create`, `Object.published`, `Object.name`, `~Activity.getObject()`, and `Activity.fromJsonLd()` that should link to JSR API pages but no longer did. Some of those symbols live in `@fedify/vocab`, not `@fedify/fedify`, and `markdown-it-jsr-ref` 0.4.1 could not safely compose multiple package indexes because each plugin instance replaced the previous inline code renderer.

## Verification

I checked that `Create`, `Object.published`, `Object.name`, `~Object.names`, `Activity.fromJsonLd()`, and `Context.sendActivity()` all render as JSR links when the configured package indexes are loaded together.

I also verified the rendered *docs/manual/vocab.md* page in a fresh VitePress dev server and confirmed that the affected inline code references link to the expected JSR API pages.

The commit hook ran `deno fmt --check`, `hongdown --check`, `deno check`, `deno lint`, and the workspace protocol check successfully.