### PR TITLE
Wire Nuxt init logging

### DIFF
--- a/packages/init/src/action/configs.test.ts
+++ b/packages/init/src/action/configs.test.ts
@@ -7,6 +7,7 @@ import { message } from "@optique/core";
 import { kvStores, messageQueues } from "../lib.ts";
 import type { InitCommandData } from "../types.ts";
 import bareBonesDescription from "../webframeworks/bare-bones.ts";
+import nuxtDescription from "../webframeworks/nuxt.ts";
 import { loadDenoConfig } from "./configs.ts";
 import { patchFiles } from "./patch.ts";
 
@@ -133,6 +134,28 @@ test("patchFiles creates a Biome config matching the npm package version", async
   }
 });
 
+test("patchFiles wires Nuxt logging through a Nitro plugin", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "fedify-init-nuxt-"));
+
+  try {
+    const data = await createNuxtNpmInitData(dir);
+    await patchFiles(data);
+
+    const logging = await readFile(join(dir, "server/logging.ts"), "utf8");
+    const plugin = await readFile(
+      join(dir, "server/plugins/logging.ts"),
+      "utf8",
+    );
+
+    assert.match(logging, /export default configure\(/);
+    assert.doesNotMatch(logging, /await configure\(/);
+    assert.match(plugin, /import loggingConfigured from "\.\.\/logging";/);
+    assert.match(plugin, /await loggingConfigured;/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 async function createNpmInitData(dir: string): Promise<InitCommandData> {
   const initializer = await bareBonesDescription.init({
     command: "init",
@@ -152,6 +175,39 @@ async function createNpmInitData(dir: string): Promise<InitCommandData> {
     projectName: "example",
     packageManager: "npm",
     webFramework: "bare-bones",
+    kvStore: "in-memory",
+    messageQueue: "in-process",
+    dryRun: false,
+    allowNonEmpty: false,
+    testMode: false,
+    dir,
+    initializer,
+    kv: kvStores["in-memory"],
+    mq: messageQueues["in-process"],
+    env: {},
+  } satisfies InitCommandData;
+  return data;
+}
+
+async function createNuxtNpmInitData(dir: string): Promise<InitCommandData> {
+  const initializer = await nuxtDescription.init({
+    command: "init",
+    projectName: "example",
+    packageManager: "npm",
+    webFramework: "nuxt",
+    kvStore: "in-memory",
+    messageQueue: "in-process",
+    dryRun: false,
+    allowNonEmpty: false,
+    testMode: false,
+    dir,
+  });
+
+  const data = {
+    command: "init",
+    projectName: "example",
+    packageManager: "npm",
+    webFramework: "nuxt",
     kvStore: "in-memory",
     messageQueue: "in-process",
     dryRun: false,

--- a/packages/init/src/action/templates.ts
+++ b/packages/init/src/action/templates.ts
@@ -38,9 +38,11 @@ export const loadFederation = async (
  * @param param0 - Destructured object containing the project name
  * @returns The complete logging configuration file content as a string
  */
-export const loadLogging = async ({ projectName }: InitCommandData) =>
+export const loadLogging = async (
+  { projectName, initializer }: InitCommandData,
+) =>
   pipe(
-    await readTemplate("defaults/logging.ts"),
+    await readTemplate(initializer.loggingTemplate ?? "defaults/logging.ts"),
     replace(/\/\* project name \*\//, JSON.stringify(projectName)),
   );
 

--- a/packages/init/src/templates/nuxt/server/logging.ts.tpl
+++ b/packages/init/src/templates/nuxt/server/logging.ts.tpl
@@ -1,0 +1,23 @@
+import { configure, getConsoleSink } from "@logtape/logtape";
+import { AsyncLocalStorage } from "node:async_hooks";
+
+export default configure({
+  contextLocalStorage: new AsyncLocalStorage(),
+  sinks: {
+    console: getConsoleSink(),
+  },
+  filters: {},
+  loggers: [
+    {
+      category: /* project name */,
+      lowestLevel: "debug",
+      sinks: ["console"],
+    },
+    { category: "fedify", lowestLevel: "info", sinks: ["console"] },
+    {
+      category: ["logtape", "meta"],
+      lowestLevel: "warning",
+      sinks: ["console"],
+    },
+  ],
+});

--- a/packages/init/src/templates/nuxt/server/plugins/logging.ts.tpl
+++ b/packages/init/src/templates/nuxt/server/plugins/logging.ts.tpl
@@ -1,0 +1,5 @@
+import loggingConfigured from "../logging";
+
+export default defineNitroPlugin(async () => {
+  await loggingConfigured;
+});

--- a/packages/init/src/types.ts
+++ b/packages/init/src/types.ts
@@ -78,6 +78,8 @@ export interface WebFrameworkInitializer {
   federationFile: string;
   /** Relative path where the logging configuration file will be created. */
   loggingFile: string;
+  /** Optional template path for the logging configuration file. */
+  loggingTemplate?: string;
   /**
    * Additional files to create, keyed by relative path to file content.
    * Do not use `".env"` as a key — use the {@link env} property instead so

--- a/packages/init/src/webframeworks/nuxt.ts
+++ b/packages/init/src/webframeworks/nuxt.ts
@@ -19,9 +19,13 @@ const nuxtDescription: WebFrameworkDescription = {
     },
     federationFile: "server/federation.ts",
     loggingFile: "server/logging.ts",
+    loggingTemplate: "nuxt/server/logging.ts",
     env: testMode ? { HOST: "127.0.0.1" } : {} as Record<string, string>,
     files: {
       "nuxt.config.ts": await readTemplate("nuxt/nuxt.config.ts"),
+      "server/plugins/logging.ts": await readTemplate(
+        "nuxt/server/plugins/logging.ts",
+      ),
       ...(pm !== "deno" && {
         "eslint.config.ts": await readTemplate("defaults/eslint.config.ts"),
       }),


### PR DESCRIPTION
## Summary

This fixes #724 by wiring the logging configuration generated by `fedify init -w nuxt` into the generated Nuxt/Nitro runtime.

Previously, *server/logging.ts* was generated but never imported, so LogTape configuration did not run and Fedify logs stayed silent in generated Nuxt apps. The Nuxt template now generates a Nitro server plugin at *server/plugins/logging.ts* that imports and awaits the logging setup during Nitro startup.

## Changes

- Added a Nuxt-specific logging template at *packages/init/src/templates/nuxt/server/logging.ts.tpl*.
- Changed that template to default-export the `configure(...)` promise instead of using top-level `await`.
- Added *packages/init/src/templates/nuxt/server/plugins/logging.ts.tpl* to await the logging setup from a Nitro plugin.
- Allowed framework initializers to override the default logging template.
- Added a regression test that verifies generated Nuxt projects include the logging plugin and avoid top-level `await configure(...)`.

## Verification

- `deno test -A packages/init/src/action/configs.test.ts`
- `deno task -f @fedify/init check`
- `mise run test:init -- -w nuxt -p npm -k in-memory -m in-process --no-dry-run`