### PR TITLE
Load logging in init templates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,9 +14,10 @@ To be released.
     *logging.ts* files are loaded during server startup.  Nitro projects now
     get a server plugin that imports the LogTape configuration, and Next.js
     projects get an *instrumentation.ts* `register()` hook that imports it in
-    the Node.js runtime before Fedify handles requests.  [[#725]]
+    the Node.js runtime before Fedify handles requests.  [[#725], [#727]]
 
 [#725]: https://github.com/fedify-dev/fedify/issues/725
+[#727]: https://github.com/fedify-dev/fedify/pull/727
 
 
 Version 2.0.14

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,16 @@ Version 2.0.15
 
 To be released.
 
+### @fedify/init
+
+ -  Fixed the Nitro and Next.js project templates so their generated
+    *logging.ts* files are loaded during server startup.  Nitro projects now
+    get a server plugin that imports the LogTape configuration, and Next.js
+    projects get an *instrumentation.ts* `register()` hook that imports it in
+    the Node.js runtime before Fedify handles requests.  [[#725]]
+
+[#725]: https://github.com/fedify-dev/fedify/issues/725
+
 
 Version 2.0.14
 --------------

--- a/packages/init/src/templates/next/instrumentation.ts.tpl
+++ b/packages/init/src/templates/next/instrumentation.ts.tpl
@@ -1,5 +1,5 @@
 export async function register() {
-  if (globalThis.process?.env.NEXT_RUNTIME === "nodejs") {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
     await import("./logging");
   }
 }

--- a/packages/init/src/templates/next/instrumentation.ts.tpl
+++ b/packages/init/src/templates/next/instrumentation.ts.tpl
@@ -1,0 +1,5 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
+    await import("./logging");
+  }
+}

--- a/packages/init/src/templates/next/instrumentation.ts.tpl
+++ b/packages/init/src/templates/next/instrumentation.ts.tpl
@@ -1,5 +1,5 @@
 export async function register() {
-  if (process.env.NEXT_RUNTIME === "nodejs") {
+  if (globalThis.process?.env.NEXT_RUNTIME === "nodejs") {
     await import("./logging");
   }
 }

--- a/packages/init/src/templates/nitro/server/plugins/logging.ts.tpl
+++ b/packages/init/src/templates/nitro/server/plugins/logging.ts.tpl
@@ -1,0 +1,3 @@
+import "../logging";
+
+export default function setupLogging() {}

--- a/packages/init/src/webframeworks.test.ts
+++ b/packages/init/src/webframeworks.test.ts
@@ -40,6 +40,6 @@ test("Next.js template loads LogTape through instrumentation", async () => {
   const instrumentation = files["instrumentation.ts"];
   ok(instrumentation);
   ok(instrumentation.includes("export async function register()"));
-  ok(instrumentation.includes("globalThis.process?.env.NEXT_RUNTIME"));
+  ok(instrumentation.includes("process.env.NEXT_RUNTIME"));
   ok(instrumentation.includes('await import("./logging")'));
 });

--- a/packages/init/src/webframeworks.test.ts
+++ b/packages/init/src/webframeworks.test.ts
@@ -40,6 +40,6 @@ test("Next.js template loads LogTape through instrumentation", async () => {
   const instrumentation = files["instrumentation.ts"];
   ok(instrumentation);
   ok(instrumentation.includes("export async function register()"));
-  ok(instrumentation.includes("NEXT_RUNTIME"));
+  ok(instrumentation.includes("globalThis.process?.env.NEXT_RUNTIME"));
   ok(instrumentation.includes('await import("./logging")'));
 });

--- a/packages/init/src/webframeworks.test.ts
+++ b/packages/init/src/webframeworks.test.ts
@@ -1,0 +1,45 @@
+import { ok } from "node:assert/strict";
+import test from "node:test";
+import webFrameworks from "./webframeworks.ts";
+
+test("Nitro template loads LogTape during server startup", async () => {
+  const { files } = await webFrameworks.nitro.init({
+    projectName: "test-app",
+    dir: ".",
+    command: "init",
+    packageManager: "npm",
+    kvStore: "in-memory",
+    messageQueue: "in-process",
+    webFramework: "nitro",
+    testMode: false,
+    dryRun: true,
+  });
+
+  ok(files);
+  ok("server/plugins/logging.ts" in files);
+  const plugin = files["server/plugins/logging.ts"];
+  ok(plugin);
+  ok(plugin.includes('import "../logging";'));
+});
+
+test("Next.js template loads LogTape through instrumentation", async () => {
+  const { files } = await webFrameworks.next.init({
+    projectName: "test-app",
+    dir: ".",
+    command: "init",
+    packageManager: "npm",
+    kvStore: "in-memory",
+    messageQueue: "in-process",
+    webFramework: "next",
+    testMode: false,
+    dryRun: true,
+  });
+
+  ok(files);
+  ok("instrumentation.ts" in files);
+  const instrumentation = files["instrumentation.ts"];
+  ok(instrumentation);
+  ok(instrumentation.includes("export async function register()"));
+  ok(instrumentation.includes("NEXT_RUNTIME"));
+  ok(instrumentation.includes('await import("./logging")'));
+});

--- a/packages/init/src/webframeworks.ts
+++ b/packages/init/src/webframeworks.ts
@@ -300,6 +300,9 @@ const webFrameworks: WebFrameworks = {
       federationFile: "server/federation.ts",
       loggingFile: "server/logging.ts",
       files: {
+        "server/plugins/logging.ts": await readTemplate(
+          "nitro/server/plugins/logging.ts",
+        ),
         "server/middleware/federation.ts": await readTemplate(
           "nitro/server/middleware/federation.ts",
         ),
@@ -338,6 +341,7 @@ const webFrameworks: WebFrameworks = {
       federationFile: "federation/index.ts",
       loggingFile: "logging.ts",
       files: {
+        "instrumentation.ts": await readTemplate("next/instrumentation.ts"),
         "middleware.ts": await readTemplate("next/middleware.ts"),
         ...(pm !== "deno"
           ? {


### PR DESCRIPTION
### Summary

Fixes #725.

The Nitro and Next.js `fedify init` templates already generated LogTape configuration files, but those files were not imported by the generated server entrypoints. As a result, Fedify logs used the default LogTape state instead of the scaffolded configuration.

This PR adds *packages/init/src/templates/nitro/server/plugins/logging.ts.tpl*, which imports *server/logging.ts* through Nitro’s server plugin startup path.

This PR also adds *packages/init/src/templates/next/instrumentation.ts.tpl*, which imports *logging.ts* from Next.js' `register()` hook when `NEXT_RUNTIME` is `nodejs`.

Astro and SolidStart are intentionally left out here because they were introduced after the 2.0.x line. This keeps the fix suitable for the 2.0 maintenance branch; the 2.1.x branch can carry the same fix forward and handle those integrations separately.

### Tests

 -  `deno task check` in *packages/init*
 -  `pnpm --filter @fedify/init test`
 -  `deno check packages/init/src/webframeworks.test.ts`
 -  `deno run -A packages/init/src/test/execute.ts init /tmp/fedify-init-725-nitro -w nitro -p npm -k in-memory -m in-process --dry-run`
 -  `deno run -A packages/init/src/test/execute.ts init /tmp/fedify-init-725-next -w next -p npm -k in-memory -m in-process --dry-run`