### PR TITLE
Load init logging on Fedify 2.1 templates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,11 +10,12 @@ To be released.
 
 ### @fedify/init
 
- -  Fixed the Nitro and Next.js project templates so their generated
+ -  Fixed the Astro, Nitro, and Next.js project templates so their generated
     *logging.ts* files are loaded during server startup.  Nitro projects now
-    get a server plugin that imports the LogTape configuration, and Next.js
+    get a server plugin that imports the LogTape configuration, Next.js
     projects get an *instrumentation.ts* `register()` hook that imports it in
-    the Node.js runtime before Fedify handles requests.  [[#725], [#727]]
+    the Node.js runtime, and Astro projects import it from *src/middleware.ts*
+    before Fedify handles requests.  [[#725], [#727]]
 
 [#725]: https://github.com/fedify-dev/fedify/issues/725
 [#727]: https://github.com/fedify-dev/fedify/pull/727

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,11 +11,11 @@ To be released.
 ### @fedify/init
 
  -  Fixed the Astro, Nitro, and Next.js project templates so their generated
-    *logging.ts* files are loaded during server startup.  Nitro projects now
-    get a server plugin that imports the LogTape configuration, Next.js
-    projects get an *instrumentation.ts* `register()` hook that imports it in
-    the Node.js runtime, and Astro projects import it from *src/middleware.ts*
-    before Fedify handles requests.  [[#725], [#727]]
+    *logging.ts* files are loaded during server startup before Fedify handles
+    requests.  Nitro projects now get a server plugin that imports the LogTape
+    configuration, Next.js projects get an *instrumentation.ts* `register()`
+    hook that imports it in the Node.js runtime, and Astro projects import it
+    in *src/middleware.ts*.  [[#725], [#727]]
 
 [#725]: https://github.com/fedify-dev/fedify/issues/725
 [#727]: https://github.com/fedify-dev/fedify/pull/727

--- a/packages/init/src/templates/astro/src/middleware.ts.tpl
+++ b/packages/init/src/templates/astro/src/middleware.ts.tpl
@@ -1,3 +1,4 @@
+import "./logging.ts";
 import { fedifyMiddleware } from "@fedify/astro";
 import federation from "./federation.ts";
 

--- a/packages/init/src/webframeworks.test.ts
+++ b/packages/init/src/webframeworks.test.ts
@@ -1,5 +1,6 @@
 import { ok } from "node:assert/strict";
 import test from "node:test";
+import astroDescription from "./webframeworks/astro.ts";
 import nextDescription from "./webframeworks/next.ts";
 import nitroDescription from "./webframeworks/nitro.ts";
 
@@ -43,4 +44,23 @@ test("Next.js template loads LogTape through instrumentation", async () => {
   ok(instrumentation.includes("export async function register()"));
   ok(instrumentation.includes("process.env.NEXT_RUNTIME"));
   ok(instrumentation.includes('await import("./logging")'));
+});
+
+test("Astro template loads LogTape through middleware", async () => {
+  const { files } = await astroDescription.init({
+    projectName: "test-app",
+    dir: ".",
+    command: "init",
+    packageManager: "npm",
+    kvStore: "in-memory",
+    messageQueue: "in-process",
+    webFramework: "astro",
+    testMode: false,
+    dryRun: true,
+  });
+
+  ok(files);
+  const middleware = files["src/middleware.ts"];
+  ok(middleware);
+  ok(middleware.includes('import "./logging.ts";'));
 });


### PR DESCRIPTION
## Summary

Fixes <https://github.com/fedify-dev/fedify/issues/725>.

This backports the `fedify init` logging startup fix to *2.1-maintenance* and completes it for the framework template that exists only on the 2.1 line.

The merged 2.0-maintenance change already made generated Nitro projects load *server/logging.ts* through *server/plugins/logging.ts*, and generated Next.js projects load *logging.ts* through *instrumentation.ts*. This PR keeps those changes on *2.1-maintenance* and adds the missing Astro wiring: generated Astro projects now import *src/logging.ts* from *src/middleware.ts* before creating the Fedify middleware.

SolidStart is not changed in this PR because *2.1-maintenance* does not include a `fedify init -w solidstart` option. The SolidStart initializer appears only on the later `main` line.

## Tests

 -  `deno fmt --check packages/init/src/templates/astro/src/middleware.ts.tpl packages/init/src/webframeworks.test.ts CHANGES.md`
 -  `deno check packages/init/src/webframeworks.test.ts`
 -  `pnpm --filter @fedify/init test`
 -  `deno task check` in *packages/init*
 -  `deno run -A packages/init/src/test/execute.ts init /tmp/fedify-init-725-astro -w astro -p npm -k in-memory -m in-process --dry-run`
 -  `git diff --check`
