### PR TITLE
Load SolidStart init logging

### DIFF
--- a/packages/init/src/templates/solidstart/src/middleware/index.ts.tpl
+++ b/packages/init/src/templates/solidstart/src/middleware/index.ts.tpl
@@ -1,3 +1,4 @@
+import "../logging";
 import { fedifyMiddleware } from "@fedify/solidstart";
 import federation from "../federation";
 

--- a/packages/init/src/webframeworks.test.ts
+++ b/packages/init/src/webframeworks.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 import astroDescription from "./webframeworks/astro.ts";
 import nextDescription from "./webframeworks/next.ts";
 import nitroDescription from "./webframeworks/nitro.ts";
+import solidstartDescription from "./webframeworks/solidstart.ts";
 
 test("Nitro template loads LogTape during server startup", async () => {
   const { files } = await nitroDescription.init({
@@ -66,4 +67,24 @@ test("Astro template loads LogTape through middleware", async () => {
   const middleware = files["src/middleware.ts"];
   ok(middleware);
   ok(middleware.includes('import "./logging.ts";'));
+});
+
+test("SolidStart template loads LogTape through middleware", async () => {
+  const { files } = await solidstartDescription.init({
+    projectName: "test-app",
+    dir: ".",
+    command: "init",
+    packageManager: "npm",
+    kvStore: "in-memory",
+    messageQueue: "in-process",
+    webFramework: "solidstart",
+    testMode: false,
+    dryRun: true,
+    allowNonEmpty: false,
+  });
+
+  ok(files);
+  const middleware = files["src/middleware/index.ts"];
+  ok(middleware);
+  ok(middleware.includes('import "../logging";'));
 });


### PR DESCRIPTION
## Summary

This fixes the SolidStart `fedify init` template so the generated *src/logging.ts* module is loaded from *src/middleware/index.ts* before Fedify handles requests.

The PR also adds a focused regression test in *packages/init/src/webframeworks.test.ts* to check that the generated SolidStart middleware imports the logging module.

Fixes https://github.com/fedify-dev/fedify/issues/725

## Tests

- `deno check packages/init/src/webframeworks.test.ts`
- `hongdown --check CHANGES.md`
- `pnpm --filter @fedify/init test`
- `deno run -A packages/init/src/test/execute.ts init /tmp/fedify-init-725-solidstart -w solidstart -p npm -k in-memory -m in-process --dry-run`
- `mise run check:types`
- `git diff --check`
