### PR TITLE
Support fixed-path actor dispatchers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,12 @@ To be released.
 
 ### @fedify/fedify
 
+ -  Added `mapActorAlias()` method to `ActorCallbackSetters` interface to
+    support fixed-path actor dispatchers.  This is useful for exposing a
+    single, instance-level actor at a fixed path, such as `/actor` for a relay
+    or `/bot` for a bot, without leaking a sentinel identifier into the actor's
+    URI. [[#752], [#753]]
+
  -  Added optional `MessageQueue.getDepth()` support, using the new
     `MessageQueueDepth` return type, for reporting queue backlog depth.
     `InProcessMessageQueue` can now report queued messages, including ready
@@ -18,6 +24,8 @@ To be released.
 
 [#735]: https://github.com/fedify-dev/fedify/issues/735
 [#748]: https://github.com/fedify-dev/fedify/pull/748
+[#752]: https://github.com/fedify-dev/fedify/issues/752
+[#753]: https://github.com/fedify-dev/fedify/pull/753
 
 ### @fedify/amqp
 

--- a/docs/manual/actor.md
+++ b/docs/manual/actor.md
@@ -456,6 +456,49 @@ ctx.getActorUri("2bd304f9-36b3-44f0-bf0b-29124aafcbb4")
 > the argument is a valid identifier before calling the method.
 
 
+Fixed-path actor URIs
+---------------------
+
+*This API is available since Fedify 2.3.0.*
+
+In some cases, you may want to expose a single, instance-level actor at a fixed
+path, such as `/actor` for a relay or `/bot` for a bot, without leaking a
+sentinel identifier like `__instance__` into the actor's URI.
+
+You can alias a fixed path to a sentinel identifier by calling
+the `~ActorCallbackSetters.mapActorAlias()` method:
+
+~~~~ typescript
+// @noErrors: 2345 2391
+import { type Federation } from "@fedify/fedify";
+import { Person } from "@fedify/vocab";
+const federation = null as unknown as Federation<void>;
+// ---cut-before---
+federation
+  .setActorDispatcher("/users/{identifier}", async (ctx, identifier) => {
+    if (identifier === "bot") {
+      return new Person({
+        id: ctx.getActorUri(identifier),
+        preferredUsername: "bot",
+        // ...
+      });
+    }
+    // ...
+  })
+  .mapActorAlias("/bot", "bot");
+~~~~
+
+Once the alias is registered, `Context.getActorUri("bot")` will return
+`https://example.com/bot` rather than `https://example.com/users/bot`.
+Incoming requests to `/bot` will also correctly resolve the identifier to
+`"bot"` and trigger the actor dispatcher.  WebFinger responses for the actor
+will also use the fixed path for the `self` link and the aliases.
+
+> [!TIP]
+> You can map multiple fixed paths to different sentinel identifiers by calling
+> the `~ActorCallbackSetters.mapActorAlias()` method multiple times.
+
+
 Decoupling actor URIs from WebFinger usernames
 ----------------------------------------------
 

--- a/packages/fedify/src/federation/builder.test.ts
+++ b/packages/fedify/src/federation/builder.test.ts
@@ -53,6 +53,14 @@ test("FederationBuilder", async (t) => {
         RouterError,
         'Actor alias path "/actor" conflicts with existing route "actorAlias:instance".',
       );
+      assertThrows(
+        () =>
+          createFederationBuilder<string>()
+            .setActorDispatcher("/users/{identifier}", actorDispatcher)
+            .mapActorAlias("/actor", ""),
+        RouterError,
+        "Identifier cannot be empty.",
+      );
       builder.setActorDispatcher("/users/{identifier}", actorDispatcher)
         .mapActorAlias("/actor", "instance");
 

--- a/packages/fedify/src/federation/builder.test.ts
+++ b/packages/fedify/src/federation/builder.test.ts
@@ -44,6 +44,15 @@ test("FederationBuilder", async (t) => {
         RouterError,
         'Actor alias for "instance" already set.',
       );
+      assertThrows(
+        () =>
+          createFederationBuilder<string>()
+            .setActorDispatcher("/users/{identifier}", actorDispatcher)
+            .mapActorAlias("/actor", "instance")
+            .mapActorAlias("/actor", "bot"),
+        RouterError,
+        'Actor alias path "/actor" conflicts with existing route "actorAlias:instance".',
+      );
       builder.setActorDispatcher("/users/{identifier}", actorDispatcher)
         .mapActorAlias("/actor", "instance");
 

--- a/packages/fedify/src/federation/builder.test.ts
+++ b/packages/fedify/src/federation/builder.test.ts
@@ -25,7 +25,18 @@ test("FederationBuilder", async (t) => {
       const actorDispatcher: ActorDispatcher<string> = (_ctx, _identifier) => {
         return null;
       };
-      builder.setActorDispatcher("/users/{identifier}", actorDispatcher);
+      assertThrows(
+        () =>
+          createFederationBuilder<string>().setActorDispatcher(
+            "/users/{identifier}",
+            actorDispatcher,
+          )
+            .mapActorAlias("/actor/{id}", "instance"),
+        RouterError,
+        "Path for actor alias must have no variables.",
+      );
+      builder.setActorDispatcher("/users/{identifier}", actorDispatcher)
+        .mapActorAlias("/actor", "instance");
 
       const inboxListener: InboxListener<string, Activity> = (
         _ctx,
@@ -83,6 +94,7 @@ test("FederationBuilder", async (t) => {
         "webfinger",
       );
       assertEquals(impl.router.route("/users/test123")?.name, "actor");
+      assertEquals(impl.router.route("/actor")?.name, "actorAlias:instance");
       assertEquals(impl.router.route("/users/test123/inbox")?.name, "inbox");
       assertEquals(impl.router.route("/users/test123/outbox")?.name, "outbox");
       assertEquals(

--- a/packages/fedify/src/federation/builder.test.ts
+++ b/packages/fedify/src/federation/builder.test.ts
@@ -35,6 +35,15 @@ test("FederationBuilder", async (t) => {
         RouterError,
         "Path for actor alias must have no variables.",
       );
+      assertThrows(
+        () =>
+          createFederationBuilder<string>()
+            .setActorDispatcher("/users/{identifier}", actorDispatcher)
+            .mapActorAlias("/actor", "instance")
+            .mapActorAlias("/bot", "instance"),
+        RouterError,
+        'Actor alias for "instance" already set.',
+      );
       builder.setActorDispatcher("/users/{identifier}", actorDispatcher)
         .mapActorAlias("/actor", "instance");
 

--- a/packages/fedify/src/federation/builder.ts
+++ b/packages/fedify/src/federation/builder.ts
@@ -522,6 +522,16 @@ export class FederationBuilderImpl<TContextData>
         callbacks.aliasMapper = mapper;
         return setters;
       },
+      mapActorAlias: (path: string, identifier: string) => {
+        const variables = new Router().add(path, "temp");
+        if (variables.size > 0) {
+          throw new RouterError(
+            "Path for actor alias must have no variables.",
+          );
+        }
+        this.router.add(path, `actorAlias:${identifier}`);
+        return setters;
+      },
       authorize(predicate: AuthorizePredicate<TContextData>) {
         callbacks.authorizePredicate = predicate;
         return setters;

--- a/packages/fedify/src/federation/builder.ts
+++ b/packages/fedify/src/federation/builder.ts
@@ -63,6 +63,8 @@ import type {
 } from "./handler.ts";
 import { Router, RouterError } from "./router.ts";
 
+const ACTOR_ALIAS_PREFIX = "actorAlias:";
+
 function validateSingleIdentifierVariablePath(
   path: string,
   errorMessage: string,
@@ -523,13 +525,18 @@ export class FederationBuilderImpl<TContextData>
         return setters;
       },
       mapActorAlias: (path: string, identifier: string) => {
+        if (this.router.has(`${ACTOR_ALIAS_PREFIX}${identifier}`)) {
+          throw new RouterError(
+            `Actor alias for "${identifier}" already set.`,
+          );
+        }
         const variables = new Router().add(path, "temp");
         if (variables.size > 0) {
           throw new RouterError(
             "Path for actor alias must have no variables.",
           );
         }
-        this.router.add(path, `actorAlias:${identifier}`);
+        this.router.add(path, `${ACTOR_ALIAS_PREFIX}${identifier}`);
         return setters;
       },
       authorize(predicate: AuthorizePredicate<TContextData>) {

--- a/packages/fedify/src/federation/builder.ts
+++ b/packages/fedify/src/federation/builder.ts
@@ -63,7 +63,7 @@ import type {
 } from "./handler.ts";
 import { Router, RouterError } from "./router.ts";
 
-const ACTOR_ALIAS_PREFIX = "actorAlias:";
+export const ACTOR_ALIAS_PREFIX = "actorAlias:";
 
 function validateSingleIdentifierVariablePath(
   path: string,
@@ -524,7 +524,7 @@ export class FederationBuilderImpl<TContextData>
         callbacks.aliasMapper = mapper;
         return setters;
       },
-      mapActorAlias: (path: string, identifier: string) => {
+      mapActorAlias: (path: `/${string}`, identifier: string) => {
         if (this.router.has(`${ACTOR_ALIAS_PREFIX}${identifier}`)) {
           throw new RouterError(
             `Actor alias for "${identifier}" already set.`,
@@ -534,6 +534,12 @@ export class FederationBuilderImpl<TContextData>
         if (variables.size > 0) {
           throw new RouterError(
             "Path for actor alias must have no variables.",
+          );
+        }
+        const existingRoute = this.router.route(path);
+        if (existingRoute != null) {
+          throw new RouterError(
+            `Actor alias path "${path}" conflicts with existing route "${existingRoute.name}".`,
           );
         }
         this.router.add(path, `${ACTOR_ALIAS_PREFIX}${identifier}`);

--- a/packages/fedify/src/federation/builder.ts
+++ b/packages/fedify/src/federation/builder.ts
@@ -525,6 +525,9 @@ export class FederationBuilderImpl<TContextData>
         return setters;
       },
       mapActorAlias: (path: `/${string}`, identifier: string) => {
+        if (identifier === "") {
+          throw new RouterError("Identifier cannot be empty.");
+        }
         if (this.router.has(`${ACTOR_ALIAS_PREFIX}${identifier}`)) {
           throw new RouterError(
             `Actor alias for "${identifier}" already set.`,

--- a/packages/fedify/src/federation/federation.ts
+++ b/packages/fedify/src/federation/federation.ts
@@ -1120,7 +1120,7 @@ export interface ActorCallbackSetters<TContextData> {
    * @since 2.3.0
    */
   mapActorAlias(
-    path: string,
+    path: `/${string}`,
     identifier: string,
   ): ActorCallbackSetters<TContextData>;
 

--- a/packages/fedify/src/federation/federation.ts
+++ b/packages/fedify/src/federation/federation.ts
@@ -1115,6 +1115,8 @@ export interface ActorCallbackSetters<TContextData> {
    * @param path The fixed path to map to the identifier.
    * @param identifier The sentinel identifier to map the path to.
    * @returns The setters object so that settings can be chained.
+   * @throws {RouterError} If the provided path or identifier is invalid or fails
+   *                       runtime validation.
    * @since 2.3.0
    */
   mapActorAlias(

--- a/packages/fedify/src/federation/federation.ts
+++ b/packages/fedify/src/federation/federation.ts
@@ -1109,6 +1109,20 @@ export interface ActorCallbackSetters<TContextData> {
   ): ActorCallbackSetters<TContextData>;
 
   /**
+   * Maps a fixed path to a sentinel identifier.  It is useful for exposing
+   * a single, instance-level actor at a fixed path, such as `/actor` for
+   * a relay or `/bot` for a bot.
+   * @param path The fixed path to map to the identifier.
+   * @param identifier The sentinel identifier to map the path to.
+   * @returns The setters object so that settings can be chained.
+   * @since 2.3.0
+   */
+  mapActorAlias(
+    path: string,
+    identifier: string,
+  ): ActorCallbackSetters<TContextData>;
+
+  /**
    * Specifies the conditions under which requests are authorized.
    * @param predicate A callback that returns whether a request is authorized.
    * @returns The setters object so that settings can be chained.

--- a/packages/fedify/src/federation/middleware.test.ts
+++ b/packages/fedify/src/federation/middleware.test.ts
@@ -300,6 +300,16 @@ test({
         new URL("https://example.com/nodeinfo/2.1"),
       );
 
+      assertThrows(
+        () =>
+          createFederation<number>({
+            kv: new MemoryKvStore(),
+          }).setActorDispatcher("/users/{identifier}", () => null)
+            .mapActorAlias("/actor/{id}" as `/${string}`, "instance"),
+        RouterError,
+        "Path for actor alias must have no variables.",
+      );
+
       federation
         .setActorDispatcher("/users/{identifier}", () => new vocab.Person({}))
         .mapActorAlias("/bot", "bot")

--- a/packages/fedify/src/federation/middleware.test.ts
+++ b/packages/fedify/src/federation/middleware.test.ts
@@ -1224,6 +1224,8 @@ test("Federation.fetch()", async (t) => {
     assertEquals(response.status, 200);
     const body = await response.json() as Record<string, unknown>;
     assertEquals(body.subject, "acct:bot@example.com");
+    assertExists(body.links);
+    assert(Array.isArray(body.links));
     const selfLink = (body.links as Record<string, unknown>[]).find((l) =>
       l.rel === "self"
     );

--- a/packages/fedify/src/federation/middleware.test.ts
+++ b/packages/fedify/src/federation/middleware.test.ts
@@ -1219,6 +1219,7 @@ test("Federation.fetch()", async (t) => {
     );
     assertExists(selfLink);
     assertEquals(selfLink.href, "https://example.com/bot");
+    assertExists(body.aliases);
     assert((body.aliases as string[]).includes("https://example.com/bot"));
   });
 

--- a/packages/fedify/src/federation/middleware.test.ts
+++ b/packages/fedify/src/federation/middleware.test.ts
@@ -9,6 +9,7 @@ import { getTypeId, lookupObject } from "@fedify/vocab";
 import {
   assert,
   assertEquals,
+  assertExists,
   assertFalse,
   assertInstanceOf,
   assertNotEquals,
@@ -301,6 +302,7 @@ test({
 
       federation
         .setActorDispatcher("/users/{identifier}", () => new vocab.Person({}))
+        .mapActorAlias("/bot", "bot")
         .setKeyPairsDispatcher(() => [
           {
             privateKey: rsaPrivateKey2,
@@ -317,10 +319,18 @@ test({
         ctx.getActorUri("handle"),
         new URL("https://example.com/users/handle"),
       );
+      assertEquals(
+        ctx.getActorUri("bot"),
+        new URL("https://example.com/bot"),
+      );
       assertEquals(ctx.parseUri(new URL("https://example.com/")), null);
       assertEquals(
         ctx.parseUri(new URL("https://example.com/users/handle")),
         { type: "actor", identifier: "handle" },
+      );
+      assertEquals(
+        ctx.parseUri(new URL("https://example.com/bot")),
+        { type: "actor", identifier: "bot" },
       );
       assertEquals(ctx.parseUri(null), null);
       assertEquals(
@@ -1132,6 +1142,7 @@ test("Federation.fetch()", async (t) => {
         });
       },
     )
+      .mapActorAlias("/bot", "bot")
       .setKeyPairsDispatcher(() => {
         return [
           { privateKey: rsaPrivateKey2, publicKey: rsaPublicKey2.publicKey! },
@@ -1168,6 +1179,47 @@ test("Federation.fetch()", async (t) => {
 
     assertEquals(dispatches, []);
     assertEquals(response.status, 406);
+  });
+
+  await t.step("GET actor alias", async () => {
+    const { federation, dispatches } = createTestContext();
+
+    const response = await federation.fetch(
+      new Request("https://example.com/bot", {
+        method: "GET",
+        headers: {
+          "Accept": "application/activity+json",
+        },
+      }),
+      { contextData: undefined },
+    );
+
+    assertEquals(dispatches, ["bot"]);
+    assertEquals(response.status, 200);
+    const body = await response.json() as Record<string, unknown>;
+    assertEquals(body.id, "https://example.com/bot");
+    assertEquals(body.preferredUsername, "bot");
+  });
+
+  await t.step("WebFinger for actor alias", async () => {
+    const { federation } = createTestContext();
+
+    const response = await federation.fetch(
+      new Request(
+        "https://example.com/.well-known/webfinger?resource=acct:bot@example.com",
+      ),
+      { contextData: undefined },
+    );
+
+    assertEquals(response.status, 200);
+    const body = await response.json() as Record<string, unknown>;
+    assertEquals(body.subject, "acct:bot@example.com");
+    const selfLink = (body.links as Record<string, unknown>[]).find((l) =>
+      l.rel === "self"
+    );
+    assertExists(selfLink);
+    assertEquals(selfLink.href, "https://example.com/bot");
+    assert((body.aliases as string[]).includes("https://example.com/bot"));
   });
 
   await t.step("POST with application/json", async () => {

--- a/packages/fedify/src/federation/middleware.ts
+++ b/packages/fedify/src/federation/middleware.ts
@@ -112,6 +112,8 @@ import type {
 } from "./queue.ts";
 import { createExponentialBackoffPolicy, type RetryPolicy } from "./retry.ts";
 import { RouterError } from "./router.ts";
+
+const ACTOR_ALIAS_PREFIX = "actorAlias:";
 import {
   extractInboxes,
   sendActivity,
@@ -1437,8 +1439,8 @@ export class FederationImpl<TContextData>
     switch (routeName) {
       case "actor":
       case "actorAlias": {
-        const identifier = route.name.startsWith("actorAlias:")
-          ? route.name.substring("actorAlias:".length)
+        const identifier = route.name.startsWith(ACTOR_ALIAS_PREFIX)
+          ? route.name.substring(ACTOR_ALIAS_PREFIX.length)
           : route.values.identifier;
         context = this.#createContext(request, contextData, {
           invokedFromActorDispatcher: { identifier },
@@ -1793,7 +1795,7 @@ export class ContextImpl<TContextData> implements Context<TContextData> {
 
   getActorUri(identifier: string): URL {
     let path = this.federation.router.build(
-      `actorAlias:${identifier}`,
+      `${ACTOR_ALIAS_PREFIX}${identifier}`,
       {},
     );
     if (path == null) {
@@ -1947,10 +1949,10 @@ export class ContextImpl<TContextData> implements Context<TContextData> {
         identifier: undefined,
       };
     }
-    const identifier = route.name.startsWith("actorAlias:")
-      ? route.name.substring("actorAlias:".length)
+    const identifier = route.name.startsWith(ACTOR_ALIAS_PREFIX)
+      ? route.name.substring(ACTOR_ALIAS_PREFIX.length)
       : route.values.identifier;
-    if (route.name === "actor" || route.name.startsWith("actorAlias:")) {
+    if (route.name === "actor" || route.name.startsWith(ACTOR_ALIAS_PREFIX)) {
       return {
         type: "actor",
         identifier,

--- a/packages/fedify/src/federation/middleware.ts
+++ b/packages/fedify/src/federation/middleware.ts
@@ -1436,19 +1436,22 @@ export class FederationImpl<TContextData>
     }
     switch (routeName) {
       case "actor":
+      case "actorAlias": {
+        const identifier = route.name.startsWith("actorAlias:")
+          ? route.name.substring("actorAlias:".length)
+          : route.values.identifier;
         context = this.#createContext(request, contextData, {
-          invokedFromActorDispatcher: {
-            identifier: route.values.identifier,
-          },
+          invokedFromActorDispatcher: { identifier },
         });
         return await handleActor(request, {
-          identifier: route.values.identifier,
+          identifier,
           context,
           actorDispatcher: this.actorCallbacks?.dispatcher,
           authorizePredicate: this.actorCallbacks?.authorizePredicate,
           onUnauthorized,
           onNotFound,
         });
+      }
       case "object": {
         const typeId = route.name.replace(/^object:/, "");
         const callbacks = this.objectCallbacks[typeId];
@@ -1789,10 +1792,16 @@ export class ContextImpl<TContextData> implements Context<TContextData> {
   }
 
   getActorUri(identifier: string): URL {
-    const path = this.federation.router.build(
-      "actor",
-      { identifier },
+    let path = this.federation.router.build(
+      `actorAlias:${identifier}`,
+      {},
     );
+    if (path == null) {
+      path = this.federation.router.build(
+        "actor",
+        { identifier },
+      );
+    }
     if (path == null) {
       throw new RouterError("No actor dispatcher registered.");
     }
@@ -1938,8 +1947,10 @@ export class ContextImpl<TContextData> implements Context<TContextData> {
         identifier: undefined,
       };
     }
-    const identifier = route.values.identifier;
-    if (route.name === "actor") {
+    const identifier = route.name.startsWith("actorAlias:")
+      ? route.name.substring("actorAlias:".length)
+      : route.values.identifier;
+    if (route.name === "actor" || route.name.startsWith("actorAlias:")) {
       return {
         type: "actor",
         identifier,

--- a/packages/fedify/src/federation/middleware.ts
+++ b/packages/fedify/src/federation/middleware.ts
@@ -112,8 +112,8 @@ import type {
 } from "./queue.ts";
 import { createExponentialBackoffPolicy, type RetryPolicy } from "./retry.ts";
 import { RouterError } from "./router.ts";
+import { ACTOR_ALIAS_PREFIX } from "./builder.ts";
 
-const ACTOR_ALIAS_PREFIX = "actorAlias:";
 import {
   extractInboxes,
   sendActivity,
@@ -1794,16 +1794,13 @@ export class ContextImpl<TContextData> implements Context<TContextData> {
   }
 
   getActorUri(identifier: string): URL {
-    let path = this.federation.router.build(
+    const path = this.federation.router.build(
       `${ACTOR_ALIAS_PREFIX}${identifier}`,
       {},
+    ) ?? this.federation.router.build(
+      "actor",
+      { identifier },
     );
-    if (path == null) {
-      path = this.federation.router.build(
-        "actor",
-        { identifier },
-      );
-    }
     if (path == null) {
       throw new RouterError("No actor dispatcher registered.");
     }


### PR DESCRIPTION
This PR adds `mapActorAlias()` to `ActorCallbackSetters`. An actor dispatcher can now map a fixed path, such as `/actor` or `/bot`, to an internal sentinel identifier.

Some applications expose a single instance-level actor at a fixed path. Before this change, they had to use a sentinel identifier such as `__instance__`, and that identifier became part of the actor URI.

`mapActorAlias()` keeps the sentinel internal. Incoming actor requests resolve through the alias map. `Context.getActorUri()` uses the same map when building outbound actor URIs.

Implementation details:

 -  Aliases register a router route named `actorAlias:{identifier}`.
 -  Alias paths must be fixed. Paths containing route variables are rejected.
 -  `Context.getActorUri()` tries the `actorAlias:{identifier}` route first, then falls back to the standard `actor` route.
 -  `Context.parseUri()` and `fetch()` routing now recognize `actorAlias:` route names and read the identifier from the route name instead of route values.

Resolves #752.