### PR TITLE
Add `get-reviews` agent skill

### DIFF
--- a/.agents/skills/get-reviews/SKILL.md
+++ b/.agents/skills/get-reviews/SKILL.md
@@ -37,6 +37,12 @@ and save them in a JSON file:
     `first: $NUMBER_OF_THREADS` to fetch new reviews.
  -  Use `jq` to filter the reviews and information if necessary.
 
+The fetched JSON files in *plans/{PR\_NUMBER}/fetched/* contain the raw data
+of PR comments, reviews, and review threads (with `pullRequestReview`
+back-references on thread comments). When more context is needed later
+(e.g., to resolve which review a thread belongs to, or to check the original
+body of a comment), refer back to these files instead of re-fetching.
+
 [gh]: https://cli.github.com/
 
 

--- a/.agents/skills/get-reviews/SKILL.md
+++ b/.agents/skills/get-reviews/SKILL.md
@@ -33,8 +33,9 @@ Check [fetch\_reviews.sh](./fetch_reviews.sh) to fetch the reviews
 and save them in a JSON file:
 
  -  Replace `$VARIABLES` with the actual values or variables in the command.
- -  If already saved reviews existed, use `after: $LAST_REVIEW_ID` instead of
-    `first: $NUMBER_OF_THREADS` to fetch new reviews.
+ -  For incremental fetches, save `pageInfo.endCursor` from the previous
+    fetch and pass it as `after: $LAST_CURSOR` (a base64 cursor, not a
+    review thread node ID) so the query returns only new review threads.
  -  Use `jq` to filter the reviews and information if necessary.
 
 The fetched JSON files in *plans/{PR\_NUMBER}/fetched/* contain the raw data
@@ -59,7 +60,7 @@ After fetching the PR and its reviews, organize the reviews.
      -  After applying or dismissing the review, move the file to
         *plans/{PR\_NUMBER}/reviews/resolved/{REVIEW\_ID}.md*.
      -  If the review file is too long, move the content to
-        \**plans/{PR\_NUMBER}/reviews/{REVIEW\_ID}/index.md*, and separate the
+        *plans/{PR\_NUMBER}/reviews/{REVIEW\_ID}/index.md*, and separate the
         content into multiple files in the same directory. In this case, after
         resolving the review, move the whole directory to
         *plans/{PR\_NUMBER}/reviews/resolved/{REVIEW\_ID}/*.
@@ -95,7 +96,7 @@ reviews based on the files.
 Categorize the reviews and the plans, and apply them at once by category.
 After applying the review, use [`/commit` skill](../commit/SKILL.md) to commit
 the changes. The commit message should include the related review links.
-`https://github.com/fedify-dev/fedify/pull/{PR_NUMBER}#discussion_r{REVIEW_THREAD.COMMENTS[0].DATABASE_ID})`
+`https://github.com/fedify-dev/fedify/pull/{PR_NUMBER}#discussion_r{REVIEW_THREAD.COMMENTS[0].DATABASE_ID}`
 
 After committing the changes, update the review file to include the commit hash
 and the comment section. If the review is dismissed, update the review file to
@@ -107,5 +108,5 @@ both languages, check for any discrepancies between the two. If differences
 exist between the two versions, review them based on the facts and revise
 the English version to match the content in the contributor's language.
 
-Post all of the review in English, even if the file written in the contributor's
-native language. The comments should be polite and constructive.
+Post all review comments in English, even if the file written in the
+contributor's native language. The comments should be polite and constructive.

--- a/.agents/skills/get-reviews/SKILL.md
+++ b/.agents/skills/get-reviews/SKILL.md
@@ -66,11 +66,22 @@ After fetching the PR and its reviews, organize the reviews.
  -  *plans/{PR\_NUMBER}/reviews/resolved/{REVIEW\_ID}.md*: The file for each
     review which is resolved.
 
+**Don't use the first comment of the review thread as the review ID.**
+The ID of the review thread starts with “PRRT\_”.
+Use the first comment ID of the review thread only on the link.
+
 The format of review files should be as [review.md](./review.md).
+The files should be written in the contributor's language. But the title of
+the item in the file (e.g., “Summary”, “Judgement”, “Plans”) should be in
+English for consistency.
+
+Empty the space between the “Title” and the “Summary” sections.
 
 All related information with the review should be stored in
 *plans/{PR\_NUMBER}/reviews/{REVIEW\_ID}.md* or the files in
 *plans/{PR\_NUMBER}/reviews/{REVIEW\_ID}/*.
+
+After organizing the reviews, show the links to the files to the contributor.
 
 
 Resolve the reviews

--- a/.agents/skills/get-reviews/SKILL.md
+++ b/.agents/skills/get-reviews/SKILL.md
@@ -89,6 +89,7 @@ naming rules:
     the file so the context is preserved.
 
 The format of review files should be as [review.md](./review.md).
+Read the reviews and fill the format as a draft with the related information.
 The files should be written in the contributor's language. But the title of
 the item in the file (e.g., “Summary”, “Judgement”, “Plans”) should be in
 English for consistency.

--- a/.agents/skills/get-reviews/SKILL.md
+++ b/.agents/skills/get-reviews/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: get-reviews
+description: >-
+  This skill is utilized when requesting reviews from GitHub pull requests.
+  Get the reviews, organize, and resolve them by applying or dismissing.
+argument-hint: "Provide the number of the pull request to get the reviews."
+---
+
+<!-- deno-fmt-ignore-file -->
+
+Get reviews from GitHub pull requests
+=====================================
+
+This skill is utilized when requesting reviews from GitHub pull requests.
+
+1.  Get the reviews.
+2.  Organize the reviews.
+3.  Resolve the reviews by applying or dismissing them.
+
+
+Get the reviews
+---------------
+
+To get the reviews from a GitHub pull request, you can use the GitHub API.
+Check the [`gh` CLI tool][gh] is installed and authenticated.
+`gh auth status` can be used to check the authentication status.
+If `gh` isn't installed, try installing it by `apt install gh`.
+If authentication is not set up, tell the contributor to run `gh auth login`
+to authenticate with GitHub.
+
+Use the GraphQL API to fetch the reviews for a specific pull request.
+Check [fetch\_reviews.sh](./fetch_reviews.sh) to fetch the reviews
+and save them in a JSON file:
+
+ -  Replace `$VARIABLES` with the actual values or variables in the command.
+ -  If already saved reviews existed, use `after: $LAST_REVIEW_ID` instead of
+    `first: $NUMBER_OF_THREADS` to fetch new reviews.
+ -  Use `jq` to filter the reviews and information if necessary.
+
+[gh]: https://cli.github.com/
+
+
+Organize the reviews
+--------------------
+
+After fetching the PR and its reviews, organize the reviews.
+[*plans* directory in the root](../../../plans/) is a good place to store them.
+
+ -  *plans/{PR\_NUMBER}/index.md*: The main file for the PR.
+     -  The body of the PR
+ -  *plans/{PR\_NUMBER}/reviews/{REVIEW\_ID}.md*: The file for each review
+    which is not resolved.
+     -  After applying or dismissing the review, move the file to
+        *plans/{PR\_NUMBER}/reviews/resolved/{REVIEW\_ID}.md*.
+     -  If the review file is too long, move the content to
+        \**plans/{PR\_NUMBER}/reviews/{REVIEW\_ID}/index.md*, and separate the
+        content into multiple files in the same directory. In this case, after
+        resolving the review, move the whole directory to
+        *plans/{PR\_NUMBER}/reviews/resolved/{REVIEW\_ID}/*.
+ -  *plans/{PR\_NUMBER}/reviews/resolved/{REVIEW\_ID}.md*: The file for each
+    review which is resolved.
+
+The format of review files should be as [review.md](./review.md).
+
+All related information with the review should be stored in
+*plans/{PR\_NUMBER}/reviews/{REVIEW\_ID}.md* or the files in
+*plans/{PR\_NUMBER}/reviews/{REVIEW\_ID}/*.
+
+
+Resolve the reviews
+-------------------
+
+Let the contributor read the review files, decide the judgement and the plans
+for each review, and let them update the review files if necessary.
+After the contributor decides the judgement and the plans, apply or dismiss the
+reviews based on the files.
+
+Categorize the reviews and the plans, and apply them at once by category.
+After applying the review, use [`/commit` skill](../commit/SKILL.md) to commit
+the changes. The commit message should include the related review links.
+`https://github.com/fedify-dev/fedify/pull/{PR_NUMBER}#discussion_r{REVIEW_THREAD.COMMENTS[0].DATABASE_ID})`
+
+After committing the changes, update the review file to include the commit hash
+and the comment section. If the review is dismissed, update the review file to
+include the reason for dismissing and the comment section.
+
+If the `Comments` are written only in the contributor's language, provide an
+English translation and have the contributor review it. If they are written in
+both languages, check for any discrepancies between the two. If differences
+exist between the two versions, review them based on the facts and revise
+the English version to match the content in the contributor's language.
+
+Post all of the review in English, even if the file written in the contributor's
+native language. The comments should be polite and constructive.

--- a/.agents/skills/get-reviews/SKILL.md
+++ b/.agents/skills/get-reviews/SKILL.md
@@ -32,10 +32,28 @@ Use the GraphQL API to fetch the reviews for a specific pull request.
 Check [fetch\_reviews.sh](./fetch_reviews.sh) to fetch the reviews
 and save them in a JSON file:
 
- -  Replace `$VARIABLES` with the actual values or variables in the command.
+ -  Fill the variables in the command and run the command to fetch the reviews:
+
+    ~~~~ bash
+    # Omit the new lines
+    PR_NUMBER= NUMBER_OF_PR_COMMENTS= NUMBER_OF_REVIEWS= \
+    NUMBER_OF_THREADS= NUMBER_OF_COMMENTS_PER_THREAD= LAST_CURSOR= \
+    bash .agents/skills/get-reviews/fetch_reviews.sh
+    ~~~~
+
+
+     -  `PR_NUMBER`: The number of the pull request to fetch reviews from.
+     -  `NUMBER_OF_PR_COMMENTS`: The number of PR comments to fetch.
+     -  `NUMBER_OF_REVIEWS`: The number of reviews to fetch.
+     -  `NUMBER_OF_THREADS`: The number of review threads to fetch.
+     -  `NUMBER_OF_COMMENTS_PER_THREAD`:
+        The number of comments per review thread to fetch.
+     -  `LAST_CURSOR`: The cursor for incremental fetches. Optional.
+
  -  For incremental fetches, save `pageInfo.endCursor` from the previous
     fetch and pass it as `after: $LAST_CURSOR` (a base64 cursor, not a
     review thread node ID) so the query returns only new review threads.
+
  -  Use `jq` to filter the reviews and information if necessary.
 
 The fetched JSON files in *plans/{PR\_NUMBER}/fetched/* contain the raw data

--- a/.agents/skills/get-reviews/SKILL.md
+++ b/.agents/skills/get-reviews/SKILL.md
@@ -71,6 +71,23 @@ After fetching the PR and its reviews, organize the reviews.
 The ID of the review thread starts with “PRRT\_”.
 Use the first comment ID of the review thread only on the link.
 
+Review threads aren't the only place that asks for changes. A PR-level
+comment (in `comments` of the fetched JSON, whose ID starts with “IC\_”)
+or the body of a review (in `reviews` of the fetched JSON, whose ID starts
+with “PRR\_”) can also point out things to fix. When such a comment or
+review body requests modifications, organize it as its own review file
+alongside the review-thread files, using the same directory layout and
+naming rules:
+
+ -  Use the node ID of the PR comment (“IC\_…”) or the review (“PRR\_…”)
+    as the `{REVIEW\_ID}` in the file path.
+ -  If a PR comment or review body only contains approval, general
+    impressions, questions without a modification request, or other content
+    with nothing to fix, skip it and do not create a file for it.
+ -  If only a part of a longer PR comment or review body requests changes,
+    create a file only for that request and quote the relevant excerpt in
+    the file so the context is preserved.
+
 The format of review files should be as [review.md](./review.md).
 The files should be written in the contributor's language. But the title of
 the item in the file (e.g., “Summary”, “Judgement”, “Plans”) should be in

--- a/.agents/skills/get-reviews/SKILL.md
+++ b/.agents/skills/get-reviews/SKILL.md
@@ -110,3 +110,10 @@ the English version to match the content in the contributor's language.
 
 Post all review comments in English, even if the file written in the
 contributor's native language. The comments should be polite and constructive.
+
+After resolving the reviews, pushing commits, posting comments, and updating
+the reviews as resolved, move the review files to
+*plans/{PR\_NUMBER}/reviews/resolved*. Before moving the files, check status and
+comments of the PR from GitHub. Use [fetch\_reviews.sh](./fetch_reviews.sh),
+but instead of fetching all reviews and attributes, fetch only the necessary
+attributes to check the review status and comments.

--- a/.agents/skills/get-reviews/SKILL.md
+++ b/.agents/skills/get-reviews/SKILL.md
@@ -70,6 +70,7 @@ Organize the reviews
 
 After fetching the PR and its reviews, organize the reviews.
 [*plans* directory in the root](../../../plans/) is a good place to store them.
+*plans/* is already ignored in `.gitignore`, so don't check that it is ignored.
 
  -  *plans/{PR\_NUMBER}/index.md*: The main file for the PR.
      -  The body of the PR
@@ -107,7 +108,7 @@ naming rules:
     the file so the context is preserved.
 
 The format of review files should be as [review.md](./review.md).
-Read the reviews and fill the format as a draft with the related information.
+Read the review and draft the format based on the relevant information.
 The files should be written in the contributor's language. But the title of
 the item in the file (e.g., “Summary”, “Judgement”, “Plans”) should be in
 English for consistency.

--- a/.agents/skills/get-reviews/SKILL.md
+++ b/.agents/skills/get-reviews/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: get-reviews
 description: >-
-  This skill is utilized when requesting reviews from GitHub pull requests.
-  Get the reviews, organize, and resolve them by applying or dismissing.
+  This skill is utilized when fetching reviews from GitHub pull requests.
+  Get the reviews, organize, and help to resolve them.
 argument-hint: "Provide the number of the pull request to get the reviews."
 ---
 
@@ -15,7 +15,7 @@ This skill is utilized when requesting reviews from GitHub pull requests.
 
 1.  Get the reviews.
 2.  Organize the reviews.
-3.  Resolve the reviews by applying or dismissing them.
+3.  Help to resolve the reviews.
 
 
 Get the reviews
@@ -122,18 +122,38 @@ All related information with the review should be stored in
 After organizing the reviews, show the links to the files to the contributor.
 
 
-Resolve the reviews
--------------------
+Help to resolve the reviews
+---------------------------
+
+The agent's role in this step is to *help* the contributor resolve the reviews,
+not to resolve them on the agent's own authority. The final judgement always
+belongs to the contributor; the agent's job is to surface the information needed
+to decide, and then to carry out whatever the contributor decides.
+
+For each unresolved review, give the contributor what they need to judge it,
+rather than judging on their behalf:
+
+ -  Add relative links to the code or documentation the review points at.
+ -  Summarize the relevant facts, the trade-offs, and any available options.
+ -  Where the facts are clear, the agent may include a *suggested* judgement,
+    but it must be clearly marked as a suggestion and never substitute for the
+    contributor's decision.
 
 Let the contributor read the review files, decide the judgement and the plans
-for each review, and let them update the review files if necessary.
-After the contributor decides the judgement and the plans, apply or dismiss the
-reviews based on the files.
+for each review, and update the review files if necessary. Do not apply or
+dismiss anything until the contributor has decided. After the contributor
+decides the judgement and the plans, apply or dismiss the reviews based on the
+files.
 
 Categorize the reviews and the plans, and apply them at once by category.
 After applying the review, use [`/commit` skill](../commit/SKILL.md) to commit
-the changes. The commit message should include the related review links.
+the changes. The commit message should include the related review links:
+
 `https://github.com/fedify-dev/fedify/pull/{PR_NUMBER}#discussion_r{REVIEW_THREAD.COMMENTS[0].DATABASE_ID}`
+
+Because these changes are produced with agent assistance, the commit message
+must also carry the `Assisted-by: AGENT_NAME:MODEL_VERSION` trailer required by
+[*AI_POLICY.md*](../../../AI_POLICY.md), in addition to the review links.
 
 After committing the changes, update the review file to include the commit hash
 and the comment section. If the review is dismissed, update the review file to
@@ -147,6 +167,14 @@ the English version to match the content in the contributor's language.
 
 Post all review comments in English, even if the file written in the
 contributor's native language. The comments should be polite and constructive.
+
+Before pushing commits, posting comments, or marking any review as resolved,
+the contributor must verify the actual applied changes and the relevant
+test/check results (e.g., `mise run check` and the related tests). Per
+[*AI_POLICY.md*](../../../AI_POLICY.md), AI-created work must be fully verified
+with human use; do not post comments or mark reviews resolved for changes whose
+correctness is only hypothetical. The agent prepares everything for this
+verification but leaves the verification itself to the contributor.
 
 After resolving the reviews, pushing commits, posting comments, and updating
 the reviews as resolved, move the review files to

--- a/.agents/skills/get-reviews/fetch_reviews.sh
+++ b/.agents/skills/get-reviews/fetch_reviews.sh
@@ -85,4 +85,4 @@ gh api graphql -f query='query(
   ${LAST_CURSOR:+-F after="$LAST_CURSOR"} \
   | jq . > "$FETCHED_FILE"
 
-# cspell: ignore MMDDHHMM
+echo "Fetched reviews and comments are saved to $FETCHED_FILE"

--- a/.agents/skills/get-reviews/fetch_reviews.sh
+++ b/.agents/skills/get-reviews/fetch_reviews.sh
@@ -1,4 +1,8 @@
-mkdir -p 'plans/$PR_NUMBER/fetched'
+PR_PATH="plans/$PR_NUMBER"
+FETCHED_PATH="$PR_PATH/fetched"
+mkdir -p "$FETCHED_PATH"
+TIMESTAMP=$(date +"%m%d%H%M")
+FETCHED_FILE="$FETCHED_PATH/$TIMESTAMP.json"
 gh api graphql -f query='query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $number) {
@@ -49,6 +53,6 @@ gh api graphql -f query='query($owner: String!, $repo: String!, $number: Int!) {
     }
   }
 }' -F owner=fedify-dev -F repo=fedify -F number=$PR_NUMBER \
-> 'plans/$PR_NUMBER/fetched/$CURRENT_TIMESTAMP_MMDDHHMM.json'
+| jq . > "$FETCHED_FILE"
 
 # cspell: ignore MMDDHHMM

--- a/.agents/skills/get-reviews/fetch_reviews.sh
+++ b/.agents/skills/get-reviews/fetch_reviews.sh
@@ -11,7 +11,8 @@ gh api graphql -f query='query(
   $prComments: Int!,
   $reviews: Int!,
   $threads: Int!,
-  $comments: Int!
+  $comments: Int!,
+  $after: String
 ) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $number) {
@@ -36,7 +37,11 @@ gh api graphql -f query='query(
           createdAt
         }
       }
-      reviewThreads(first: $threads) {
+      reviewThreads(first: $threads, after: $after) {
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
         nodes {
           id
           isResolved
@@ -69,6 +74,7 @@ gh api graphql -f query='query(
   -F reviews="$NUMBER_OF_REVIEWS" \
   -F threads="$NUMBER_OF_THREADS" \
   -F comments="$NUMBER_OF_COMMENTS_PER_THREAD" \
+  ${LAST_CURSOR:+-F after="$LAST_CURSOR"} \
   | jq . > "$FETCHED_FILE"
 
 # cspell: ignore MMDDHHMM

--- a/.agents/skills/get-reviews/fetch_reviews.sh
+++ b/.agents/skills/get-reviews/fetch_reviews.sh
@@ -2,6 +2,27 @@ mkdir -p 'plans/$PR_NUMBER/fetched'
 gh api graphql -f query='query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $number) {
+      comments(first: $NUMBER_OF_PR_COMMENTS) {
+        nodes {
+          id
+          databaseId
+          author { login }
+          body
+          url
+          createdAt
+        }
+      }
+      reviews(first: $NUMBER_OF_REVIEWS) {
+        nodes {
+          id
+          databaseId
+          author { login }
+          body
+          state
+          url
+          createdAt
+        }
+      }
       reviewThreads(first: $NUMBER_OF_THREADS) {
         nodes {
           id
@@ -17,6 +38,10 @@ gh api graphql -f query='query($owner: String!, $repo: String!, $number: Int!) {
               body
               url
               createdAt
+              pullRequestReview {
+                id
+                databaseId
+              }
             }
           }
         }

--- a/.agents/skills/get-reviews/fetch_reviews.sh
+++ b/.agents/skills/get-reviews/fetch_reviews.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+set -euo pipefail
+
+: "${PR_NUMBER:?PR_NUMBER is required}"
+: "${NUMBER_OF_PR_COMMENTS:?NUMBER_OF_PR_COMMENTS is required}"
+: "${NUMBER_OF_REVIEWS:?NUMBER_OF_REVIEWS is required}"
+: "${NUMBER_OF_THREADS:?NUMBER_OF_THREADS is required}"
+: "${NUMBER_OF_COMMENTS_PER_THREAD:?NUMBER_OF_COMMENTS_PER_THREAD is required}"
+
 PR_PATH="plans/$PR_NUMBER"
 FETCHED_PATH="$PR_PATH/fetched"
 mkdir -p "$FETCHED_PATH"

--- a/.agents/skills/get-reviews/fetch_reviews.sh
+++ b/.agents/skills/get-reviews/fetch_reviews.sh
@@ -1,12 +1,21 @@
+#!/usr/bin/env bash
 PR_PATH="plans/$PR_NUMBER"
 FETCHED_PATH="$PR_PATH/fetched"
 mkdir -p "$FETCHED_PATH"
 TIMESTAMP=$(date +"%m%d%H%M")
 FETCHED_FILE="$FETCHED_PATH/$TIMESTAMP.json"
-gh api graphql -f query='query($owner: String!, $repo: String!, $number: Int!) {
+gh api graphql -f query='query(
+  $owner: String!,
+  $repo: String!,
+  $number: Int!,
+  $prComments: Int!,
+  $reviews: Int!,
+  $threads: Int!,
+  $comments: Int!
+) {
   repository(owner: $owner, name: $repo) {
     pullRequest(number: $number) {
-      comments(first: $NUMBER_OF_PR_COMMENTS) {
+      comments(first: $prComments) {
         nodes {
           id
           databaseId
@@ -16,7 +25,7 @@ gh api graphql -f query='query($owner: String!, $repo: String!, $number: Int!) {
           createdAt
         }
       }
-      reviews(first: $NUMBER_OF_REVIEWS) {
+      reviews(first: $reviews) {
         nodes {
           id
           databaseId
@@ -27,14 +36,14 @@ gh api graphql -f query='query($owner: String!, $repo: String!, $number: Int!) {
           createdAt
         }
       }
-      reviewThreads(first: $NUMBER_OF_THREADS) {
+      reviewThreads(first: $threads) {
         nodes {
           id
           isResolved
           isOutdated
           path
           line
-          comments(first: $NUMBER_OF_COMMENTS_PER_THREAD) {
+          comments(first: $comments) {
             nodes {
               id
               databaseId
@@ -52,7 +61,14 @@ gh api graphql -f query='query($owner: String!, $repo: String!, $number: Int!) {
       }
     }
   }
-}' -F owner=fedify-dev -F repo=fedify -F number=$PR_NUMBER \
-| jq . > "$FETCHED_FILE"
+}' \
+  -F owner=fedify-dev \
+  -F repo=fedify \
+  -F number="$PR_NUMBER" \
+  -F prComments="$NUMBER_OF_PR_COMMENTS" \
+  -F reviews="$NUMBER_OF_REVIEWS" \
+  -F threads="$NUMBER_OF_THREADS" \
+  -F comments="$NUMBER_OF_COMMENTS_PER_THREAD" \
+  | jq . > "$FETCHED_FILE"
 
 # cspell: ignore MMDDHHMM

--- a/.agents/skills/get-reviews/fetch_reviews.sh
+++ b/.agents/skills/get-reviews/fetch_reviews.sh
@@ -1,0 +1,29 @@
+mkdir -p 'plans/$PR_NUMBER/fetched'
+gh api graphql -f query='query($owner: String!, $repo: String!, $number: Int!) {
+  repository(owner: $owner, name: $repo) {
+    pullRequest(number: $number) {
+      reviewThreads(first: $NUMBER_OF_THREADS) {
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          comments(first: $NUMBER_OF_COMMENTS_PER_THREAD) {
+            nodes {
+              id
+              databaseId
+              author { login }
+              body
+              url
+              createdAt
+            }
+          }
+        }
+      }
+    }
+  }
+}' -F owner=fedify-dev -F repo=fedify -F number=$PR_NUMBER \
+> 'plans/$PR_NUMBER/fetched/$CURRENT_TIMESTAMP_MMDDHHMM.json'
+
+# cspell: ignore MMDDHHMM

--- a/.agents/skills/get-reviews/review.md
+++ b/.agents/skills/get-reviews/review.md
@@ -1,15 +1,14 @@
 ---
 id: REVIEW_ID
 description: summary of the review
-link: the link to the review on GitHub
+link: The link to the review on GitHub
 links:
- -  If there are multiple links related to the review,
- -  list all the links.
+ -  If there are multiple links related to the review, list all the links.
  -  Include links to related PR comments (issue comments) and review thread
  -  replies that provide additional context for this review. Use the `url`
  -  field of each comment from the fetched JSON.
  - `link`–`links` are mutually exclusive.
-commit: the hash of commit after applying the review to add the comment
+commit: The hash of commit after applying the review to add the comment
 commits:
  -  If the review applies to multiple commits, list the hashes of the commits
  -  after applying the review, update the list to include the new commit hash

--- a/.agents/skills/get-reviews/review.md
+++ b/.agents/skills/get-reviews/review.md
@@ -5,6 +5,9 @@ link: the link to the review on GitHub
 links:
  -  If there are multiple links related to the review,
  -  list all the links.
+ -  Include links to related PR comments (issue comments) and review thread
+ -  replies that provide additional context for this review. Use the `url`
+ -  field of each comment from the fetched JSON.
  - `link`–`links` are mutually exclusive.
 commit: the hash of commit after applying the review to add the comment
 commits:

--- a/.agents/skills/get-reviews/review.md
+++ b/.agents/skills/get-reviews/review.md
@@ -1,0 +1,125 @@
+---
+id: REVIEW_ID
+description: summary of the review
+link: the link to the review on GitHub
+links:
+ -  If there are multiple links related to the review,
+ -  list all the links.
+ - `link`–`links` are mutually exclusive.
+commit: the hash of commit after applying the review to add the comment
+commits:
+ -  If the review applies to multiple commits, list the hashes of the commits
+ -  after applying the review, update the list to include the new commit hash
+ - `commit`–`commits` are mutually exclusive. `commit` and `commits` are
+ - optional, and only used when the review is applied.
+---
+
+<!-- deno-fmt-ignore-file -->
+
+Title
+=====
+
+<!-- One line summary of the review -->
+
+
+Summary
+-------
+
+<!--
+  The summary of the review, but in little more detail
+  If the review is too short even enough with the title, omit this section.
+-->
+
+
+Judgement
+---------
+
+<!--
+  The judgement about the review.
+
+  The first line should be one of the following:
+  - **CORRECT**: If the review is correct and should be applied.
+  - **WRONG**: If the review is wrong and should be dismissed.
+  - **PARTIAL**: If the review is partially correct and should be applied with
+    some modifications.
+  - **NEEDS EVALUATION**: If the review requires testing or evaluation,
+    such as a review pointing out efficiency issues.
+  - **NEEDS DISCUSSION**: If the review needs further discussion,
+    such as about direction of the project or design choices.
+  Try to use these words to indicate judgement status whenever possible,
+  but if you feel they are truly insufficient,use an appropriate word
+  and then update this part of *SKILL.md*.
+
+  After the first line, explain the judgement in more detail.
+  - The reasons for the judgement.
+  - The key factors that influence the judgement.
+-->
+
+
+Plans
+-----
+
+<!--
+  If the review is judged as **WRONG**, omit this section or write the plans
+  to add comments explaining the code to prevent similar misunderstandings.
+
+  If the review is judged as **CORRECT** or **PARTIAL**,
+  write the plans to apply the review.
+  - How to apply the review?
+  - If the review is judged as **PARTIAL**, what are the modifications to apply?
+  - Why the plans can apply the review correctly?
+
+  If the review is judged as **NEEDS EVALUATION**,
+  write the plans to evaluate the review, such as testing plans.
+  - How to test or evaluate?
+  - What are the criteria for success or failure?
+  - Why the tests or evaluation can determine the correctness of the review?
+  And after the evaluation, write the plans to apply or dismiss the review
+  based on the evaluation results.
+
+  If the review is judged as **NEEDS DISCUSSION**,
+  write the plans to discuss the review, such as topics to discuss and
+  potential options.
+  - What are the topics to discuss?
+  - What are the potential options and their pros and cons?
+  - What is the most reasonable option and why?
+-->
+
+
+Comments
+--------
+
+<!--
+  Prepare the response comments in advance after applying the review or
+  judging the review as wrong. The comments should be polite and constructive.
+
+  If the contributor don't use English, separate this section into two parts,
+  - the language of the contributor using
+  - English, ready to be posted as a response
+
+  If the review is judged as **CORRECT**, write comments to apply the review
+  to explain how to apply the review and why it is correct. The comments to
+  applied reviews should be started with "Addressed in {COMMIT_HASH}.".
+
+  If the review is judged as **WRONG**, write comments to dismiss the review
+  to explain why the review is wrong and should be dismissed.
+
+  If the review is judged as **PARTIAL**, write comments to partially apply the
+  review to explain how to apply the review with modifications and why it is
+  partially correct. Referring to the above, write the incorrect parts based
+  on the **WRONG** part, and the correct parts based on the **CORRECT** part.
+
+  If the review is judged as **NEEDS EVALUATION**, write the comments to
+  evaluate the review explain how to evaluate the review, the test results,
+  and the resulting application/rejection details.
+  - If the results of the evaluation are the review is correct,
+    write comments referring to the **CORRECT** part.
+  - If the results of the evaluation are the review is wrong,
+    write comments referring to the **WRONG** part.
+
+  If the review is judged as **NEEDS DISCUSSION**,
+  write the comments to discuss the review.
+  - The comments should explain what to discuss
+    about the review and why it needs discussion.
+  - The comments should be polite and constructive.
+-->

--- a/.agents/skills/get-reviews/review.md
+++ b/.agents/skills/get-reviews/review.md
@@ -2,18 +2,19 @@
 id: REVIEW_ID
 description: summary of the review
 link: The link to the review on GitHub
-links:
- -  If there are multiple links related to the review, list all the links.
- -  Include links to related PR comments (issue comments) and review thread
- -  replies that provide additional context for this review. Use the `url`
- -  field of each comment from the fetched JSON.
- - `link`–`links` are mutually exclusive.
+# If more than one URL is relevant — related PR comments or review-thread
+# replies that provide additional context — use `links` instead of `link`.
+# Use the `url` field of each comment from the fetched JSON.
+# links:
+#  -  https://github.com/.../pull/123#discussion_r4567
+#  -  https://github.com/.../pull/123#discussion_r4568
 commit: The hash of commit after applying the review to add the comment
-commits:
- -  If the review applies to multiple commits, list the hashes of the commits
- -  after applying the review, update the list to include the new commit hash
- - `commit`–`commits` are mutually exclusive. `commit` and `commits` are
- - optional, and only used when the review is applied.
+# If the review was applied across multiple commits, use `commits` instead
+# of `commit`. Both fields are optional and only set after the review is
+# applied.
+# commits:
+#  -  abc1234
+#  -  def5678
 ---
 
 <!-- deno-fmt-ignore-file -->
@@ -49,7 +50,7 @@ Judgement
   - **NEEDS DISCUSSION**: If the review needs further discussion,
     such as about direction of the project or design choices.
   Try to use these words to indicate judgement status whenever possible,
-  but if you feel they are truly insufficient,use an appropriate word
+  but if you feel they are truly insufficient, use an appropriate word
   and then update this part of *SKILL.md*.
 
   After the first line, explain the judgement in more detail.
@@ -112,7 +113,7 @@ Comments
   on the **WRONG** part, and the correct parts based on the **CORRECT** part.
 
   If the review is judged as **NEEDS EVALUATION**, write the comments to
-  evaluate the review explain how to evaluate the review, the test results,
+  evaluate the review to explain how to evaluate the review, the test results,
   and the resulting application/rejection details.
   - If the results of the evaluation are the review is correct,
     write comments referring to the **CORRECT** part.

--- a/.agents/skills/get-reviews/review.md
+++ b/.agents/skills/get-reviews/review.md
@@ -19,10 +19,20 @@ commit: The hash of commit after applying the review to add the comment
 
 <!-- deno-fmt-ignore-file -->
 
+<!--
+  From this point forward, there are instructions within comments as well as
+  instructions outside of comments.
+  Instructions outside of comments are intended for contributors. Please copy
+  them verbatim or translate them into the user's language.
+  (Don't translate `Judgement` section keywords: **CORRECT**, **WRONG**, etc.)
+  Instructions within comments are intended for the agent, not the
+  contributors.
+  Adhere strictly to these directives, ensuring all comments are purged so
+  they remain concealed from the user.
+-->
+
 Title
 =====
-
-<!-- One line summary of the review -->
 
 
 Summary
@@ -39,105 +49,110 @@ Judgement
 
 <!--
   The judgement about the review.
-
-  The first line should be one of the following:
-  - **CORRECT**: If the review is correct and should be applied.
-  - **WRONG**: If the review is wrong and should be dismissed.
-  - **PARTIAL**: If the review is partially correct and should be applied with
-    some modifications.
-  - **NEEDS EVALUATION**: If the review requires testing or evaluation,
-    such as a review pointing out efficiency issues.
-  - **NEEDS DISCUSSION**: If the review needs further discussion,
-    such as about direction of the project or design choices.
-  Try to use these words to indicate judgement status whenever possible,
-  but if you feel they are truly insufficient, use an appropriate word
-  and then update this part of *SKILL.md*.
-
-  After the first line, explain the judgement in more detail.
-  - The reasons for the judgement.
-  - The key factors that influence the judgement.
 -->
 
+Choose your judgement(remain only one item also, delete this line):
+  - **CORRECT**
+      If the review is correct and should be applied.
+  - **WRONG**
+      If the review is wrong and should be dismissed.
+  - **PARTIAL**
+      If the review is partially correct and should be applied with some
+      modifications.
+  - **NEEDS EVALUATION**
+      If the review can be settled by empirical, mechanical verification of a
+      factual claim rather than human judgement—for example, whether the code
+      really cannot handle a certain error or whether some package is actually more efficient than the previously used package.
+  - **NEEDS DISCUSSION**
+      If the review needs further discussion, such as about direction of the
+      project or design choices.
+
+<!--
+ The AI agent's mission is to help the contributor extract context to decide
+ whether or not to apply a review. Include relative links to the code file or
+ documentation pointed out by the review, along with information to aid in the
+ decision-making process. While agent can make simple suggestions for reviews
+ where the facts are clear, the final judgment must be made by the user.
+-->
 
 Plans
 -----
 
-<!--
-  If the review is judged as **WRONG**, omit this section or write the plans
-  to add comments explaining the code to prevent similar misunderstandings.
+If the review is judged as **WRONG**, omit this section or write the plans
+to add comments explaining the code to prevent similar misunderstandings.
 
-  If the review is judged as **CORRECT** or **PARTIAL**,
-  write the plans to apply the review.
+If the review is judged as **CORRECT** or **PARTIAL**,
+write the plans to apply the review.
   - How to apply the review?
-  - If the review is judged as **PARTIAL**, what are the modifications to apply?
+  - If the review is judged as **PARTIAL**, what are the modifications to
+    apply?
   - Why the plans can apply the review correctly?
 
-  If the review is judged as **WRONG**, write plans to why the reviewer
-  misunderstood the code and how to prevent similar misunderstandings
-  in the future.
+If the review is judged as **WRONG**, write plans to why the reviewer
+misunderstood the code and how to prevent similar misunderstandings
+in the future.
   - What are the reasons for the misunderstanding?
   - How to prevent similar misunderstandings in the future?
   - Consider adding comments to the code, improving documentation,
     renaming variables or functions for clarity,
     or refactoring the code to make it more understandable.
 
-  If the review is judged as **NEEDS EVALUATION**,
-  write the plans to evaluate the review, such as testing plans.
+If the review is judged as **NEEDS EVALUATION**,
+write the plans to evaluate the review, such as testing plans.
   - How to test or evaluate?
   - What are the criteria for success or failure?
   - Why the tests or evaluation can determine the correctness of the review?
-  And after the evaluation, write the plans to apply or dismiss the review
-  based on the evaluation results.
+  - After the evaluation, write the plans to apply or dismiss the review
+    based on the evaluation results.
+  - Record the verification method, the pass/fail criteria, and the measured
+    result as evidence.
 
-  If the review is judged as **NEEDS DISCUSSION**,
-  write the plans to discuss the review, such as topics to discuss and
-  potential options.
+If the review is judged as **NEEDS DISCUSSION**,
+write the plans to discuss the review, such as topics to discuss and
+potential options.
   - What are the topics to discuss?
   - What are the potential options and their pros and cons?
   - What is the most reasonable option and why?
--->
 
 
 Comments
 --------
 
-<!--
-  Prepare the response comments in advance after applying the review or
-  judging the review as wrong. The comments should be polite and constructive.
-  Do not use conversational fillers (e.g. "You're right.") Avoid using personal
-  pronouns such as "I," "we," or "you." Focus on describing how the code has
-  changed rather than stating "I did something."
+Prepare the response comments in advance after applying the review or
+judging the review as wrong. The comments should be polite and constructive.
+Do not use conversational fillers (e.g. "You're right.") Avoid using personal
+pronouns such as "I," "we," or "you." Focus on describing how the code has
+changed rather than stating "I did something."
 
-  If there is a language that the contributor is more comfortable using than
-  English, separate this section into two parts,
-  - the language of the contributor using
+If your comfortable language is not English, consider to separate this section into two parts,
+  - the language you use
   - English, ready to be posted as a response
+This will be help when posting comments all at once using the `gh` CLI tool.
 
-  Even if it's not what the review requested, if the related code has changed,
-  start with: "Addressed in {COMMIT_HASH}."
+If you want to notify about modifications, add the commit hash at the first.
+Consider to start with: "Addressed in {COMMIT_HASH}."
 
-  If the review is judged as **CORRECT**, write comments to apply the review
-  to explain how to apply the review.
+If the review is judged as **CORRECT**, write comments to apply the review
+to explain how to apply the review.
 
-  If the review is judged as **WRONG**, write comments to dismiss the review
-  to explain why the review is wrong and should be dismissed.
+If the review is judged as **WRONG**, write comments to dismiss the review
+to explain why the review is wrong and should be dismissed.
 
-  If the review is judged as **PARTIAL**, write comments to partially apply the
-  review to explain how to apply the review with modifications and why it is
-  partially correct. Referring to the above, write the incorrect parts based
-  on the **WRONG** part, and the correct parts based on the **CORRECT** part.
+If the review is judged as **PARTIAL**, write comments to partially apply the
+review to explain how to apply the review with modifications and why it is
+partially correct. Referring to the above, write the incorrect parts based
+on the **WRONG** part, and the correct parts based on the **CORRECT** part.
 
-  If the review is judged as **NEEDS EVALUATION**, write the comments to
-  evaluate the review to explain how to evaluate the review, the test results,
-  and the resulting application/rejection details.
+If the review is judged as **NEEDS EVALUATION**, write the comments to
+evaluate the review to explain how to evaluate the review, the test results,
+and the resulting application/rejection details.
   - If the results of the evaluation are the review is correct,
     write comments referring to the **CORRECT** part.
   - If the results of the evaluation are the review is wrong,
     write comments referring to the **WRONG** part.
 
-  If the review is judged as **NEEDS DISCUSSION**,
-  write the comments to discuss the review.
+If the review is judged as **NEEDS DISCUSSION**,
+write the comments to discuss the review.
   - The comments should explain what to discuss
     about the review and why it needs discussion.
   - The comments should be polite and constructive.
--->

--- a/.agents/skills/get-reviews/review.md
+++ b/.agents/skills/get-reviews/review.md
@@ -72,6 +72,15 @@ Plans
   - If the review is judged as **PARTIAL**, what are the modifications to apply?
   - Why the plans can apply the review correctly?
 
+  If the review is judged as **WRONG**, write plans to why the reviewer
+  misunderstood the code and how to prevent similar misunderstandings
+  in the future.
+  - What are the reasons for the misunderstanding?
+  - How to prevent similar misunderstandings in the future?
+  - Consider adding comments to the code, improving documentation,
+    renaming variables or functions for clarity,
+    or refactoring the code to make it more understandable.
+
   If the review is judged as **NEEDS EVALUATION**,
   write the plans to evaluate the review, such as testing plans.
   - How to test or evaluate?
@@ -95,14 +104,20 @@ Comments
 <!--
   Prepare the response comments in advance after applying the review or
   judging the review as wrong. The comments should be polite and constructive.
+  Do not use conversational fillers (e.g. "You're right.") Avoid using personal
+  pronouns such as "I," "we," or "you." Focus on describing how the code has
+  changed rather than stating "I did something."
 
-  If the contributor don't use English, separate this section into two parts,
+  If there is a language that the contributor is more comfortable using than
+  English, separate this section into two parts,
   - the language of the contributor using
   - English, ready to be posted as a response
 
+  Even if it's not what the review requested, if the related code has changed,
+  start with: "Addressed in {COMMIT_HASH}."
+
   If the review is judged as **CORRECT**, write comments to apply the review
-  to explain how to apply the review and why it is correct. The comments to
-  applied reviews should be started with "Addressed in {COMMIT_HASH}.".
+  to explain how to apply the review.
 
   If the review is judged as **WRONG**, write comments to dismiss the review
   to explain why the review is wrong and should be dismissed.


### PR DESCRIPTION
This PR adds a new agent skill at *.agents/skills/get-reviews/* that gives AI agents an end-to-end workflow for handling GitHub PR reviews on this repository, with explicit checkpoints that keep authoritative judgement with the contributor.

The motivation, design principles, and out-of-scope items are described in detail in #764. In short:

 -  Each review thread is materialized as a local file under *plans/{PR_NUMBER}/reviews/{REVIEW_ID}.md* with stable frontmatter and fixed sections, so review state survives across agent sessions and the contributor can navigate it independently of the agent.
 -  A focused GraphQL query (*fetch_reviews.sh*) extracts only the fields the agent needs (thread state, file/line, comment bodies, author, permalink), avoiding the context overload of dumping the whole PR conversation into the prompt.
 -  The Judgement step (`CORRECT` / `WRONG` / `PARTIAL` / `NEEDS EVALUATION` / `NEEDS DISCUSSION`) and any non-English review's translated response are gated behind a mandatory contributor checkpoint, so the agent proposes but does not unilaterally decide or post.

## Files

 -  *.agents/skills/get-reviews/SKILL.md* — the workflow document.
 -  *.agents/skills/get-reviews/fetch_reviews.sh* — the GraphQL fetch script with pagination support.
 -  *.agents/skills/get-reviews/review.md* — the per-review file template.

Closes #764.

Assisted-by: Claude Code:claude-opus-4-7