### PR TITLE
Accept `Temporal` values from any spec-conformant implementation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,33 @@ To be released.
     can import the new `Temporal` type guards without pulling in the rest of
     the runtime.  [[#767]]
 
+### @fedify/postgres
+
+ -  Generated _\*.d.ts_ declarations no longer import from
+    `@js-temporal/polyfill`; they reference the ambient `Temporal` namespace
+    through the `esnext.temporal` lib instead, so `pollInterval` and
+    `handlerTimeout` accept native `Temporal.Duration` values from Node.js
+    26+ without a nominal type mismatch.  TypeScript 6.0 or later is
+    required to consume the type declarations.  [[#767]]
+
+### @fedify/redis
+
+ -  Generated _\*.d.ts_ declarations no longer import from
+    `@js-temporal/polyfill`; they reference the ambient `Temporal` namespace
+    through the `esnext.temporal` lib instead, so `pollInterval` accepts
+    native `Temporal.Duration` values from Node.js 26+ without a nominal type
+    mismatch.  TypeScript 6.0 or later is required to consume the type
+    declarations.  [[#767]]
+
+### @fedify/sqlite
+
+ -  Generated _\*.d.ts_ declarations no longer import from
+    `@js-temporal/polyfill`; they reference the ambient `Temporal` namespace
+    through the `esnext.temporal` lib instead, so `pollInterval` accepts
+    native `Temporal.Duration` values from Node.js 26+ without a nominal type
+    mismatch.  TypeScript 6.0 or later is required to consume the type
+    declarations.  [[#767]]
+
 
 Version 2.0.16
 --------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -24,21 +24,22 @@ To be released.
     import from `@js-temporal/polyfill`; they reference the ambient `Temporal`
     namespace through the `esnext.temporal` lib instead, which removes the
     nominal mismatch with native Temporal types.  TypeScript 6.0 or later is
-    required to consume the type declarations.  [[#767]]
+    required to consume the type declarations.  [[#767], [#768]]
 
 [#762]: https://github.com/fedify-dev/fedify/issues/762
 [#763]: https://github.com/fedify-dev/fedify/pull/763
 [#767]: https://github.com/fedify-dev/fedify/issues/767
+[#768]: https://github.com/fedify-dev/fedify/pull/768
 
 ### @fedify/vocab-runtime
 
  -  Added `isTemporalInstant()` and `isTemporalDuration()` type guards that
     accept both polyfill and native `Temporal` values via `Symbol.toStringTag`.
-    [[#767]]
+    [[#767], [#768]]
 
  -  Added the `@fedify/vocab-runtime/temporal` subpath export so consumers
     can import the new `Temporal` type guards without pulling in the rest of
-    the runtime.  [[#767]]
+    the runtime.  [[#767], [#768]]
 
 ### @fedify/postgres
 
@@ -47,7 +48,7 @@ To be released.
     through the `esnext.temporal` lib instead, so `pollInterval` and
     `handlerTimeout` accept native `Temporal.Duration` values from Node.js
     26+ without a nominal type mismatch.  TypeScript 6.0 or later is
-    required to consume the type declarations.  [[#767]]
+    required to consume the type declarations.  [[#767], [#768]]
 
 ### @fedify/redis
 
@@ -56,7 +57,7 @@ To be released.
     through the `esnext.temporal` lib instead, so `pollInterval` accepts
     native `Temporal.Duration` values from Node.js 26+ without a nominal type
     mismatch.  TypeScript 6.0 or later is required to consume the type
-    declarations.  [[#767]]
+    declarations.  [[#767], [#768]]
 
 ### @fedify/sqlite
 
@@ -65,7 +66,7 @@ To be released.
     through the `esnext.temporal` lib instead, so `pollInterval` accepts
     native `Temporal.Duration` values from Node.js 26+ without a nominal type
     mismatch.  TypeScript 6.0 or later is required to consume the type
-    declarations.  [[#767]]
+    declarations.  [[#767], [#768]]
 
 
 Version 2.0.16

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,8 +15,26 @@ To be released.
     fetches are retried once, and remaining transport failures are reported as
     `FetchError` with the original error as the cause.  [[#762], [#763]]
 
+ -  Fixed a `TypeError` thrown when Activity Vocabulary constructors received
+    a `Temporal.Instant` or `Temporal.Duration` produced by an implementation
+    other than the bundled `@js-temporal/polyfill` (for example, the native
+    `Temporal` shipped with Node.js 26+).  Internal `instanceof` checks have
+    been replaced with `Symbol.toStringTag`-based guards so any spec-conformant
+    Temporal value is accepted.  Generated _\*.d.ts_ declarations no longer
+    import from `@js-temporal/polyfill`; they reference the ambient `Temporal`
+    namespace through the `esnext.temporal` lib instead, which removes the
+    nominal mismatch with native Temporal types.  TypeScript 6.0 or later is
+    required to consume the type declarations.  [[#767]]
+
 [#762]: https://github.com/fedify-dev/fedify/issues/762
 [#763]: https://github.com/fedify-dev/fedify/pull/763
+[#767]: https://github.com/fedify-dev/fedify/issues/767
+
+### @fedify/vocab-runtime
+
+ -  Added `isTemporalInstant()` and `isTemporalDuration()` type guards that
+    accept both polyfill and native `Temporal` values via `Symbol.toStringTag`.
+    [[#767]]
 
 
 Version 2.0.16

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,6 +36,10 @@ To be released.
     accept both polyfill and native `Temporal` values via `Symbol.toStringTag`.
     [[#767]]
 
+ -  Added the `@fedify/vocab-runtime/temporal` subpath export so consumers
+    can import the new `Temporal` type guards without pulling in the rest of
+    the runtime.  [[#767]]
+
 
 Version 2.0.16
 --------------

--- a/deno.lock
+++ b/deno.lock
@@ -2676,7 +2676,8 @@
       ]
     },
     "@ungap/structured-clone@1.3.0": {
-      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "deprecated": true
     },
     "@vitest/expect@3.2.4": {
       "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
@@ -6065,6 +6066,7 @@
       },
       "packages/vocab-runtime": {
         "dependencies": [
+          "npm:@js-temporal/polyfill@~0.5.1",
           "npm:@multiformats/base-x@^4.0.1",
           "npm:asn1js@^3.0.6",
           "npm:byte-encodings@^1.0.11",

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -249,6 +249,10 @@ export default withMermaid(defineConfig({
             target: ScriptTarget.ESNext,
             experimentalDecorators: true, // For @fedify/nestjs
             emitDecoratorMetadata: true, // For @fedify/nestjs
+            // Silences TS5101 about the `baseUrl` injected by @typescript/vfs
+            // when Twoslash spins up its virtual TS environment; the option
+            // is deprecated in TypeScript 6.0 and removed in 7.0.
+            ignoreDeprecations: "6.0",
             lib: ["dom", "dom.iterable", "esnext"],
             types: [
               "dom",

--- a/docs/manual/federation.md
+++ b/docs/manual/federation.md
@@ -540,7 +540,7 @@ Deno.serve(
 ~~~~
 
 ~~~~ typescript twoslash [Bun]
-import "@types/bun";
+import "bun";
 import { type Federation } from "@fedify/fedify";
 const federation = null as unknown as Federation<void>;
 const request = new Request("");
@@ -665,7 +665,7 @@ serve({
 ~~~~
 
 ~~~~ typescript{1,4} twoslash [Bun]
-import "@types/bun";
+import "bun";
 import { type Federation } from "@fedify/fedify";
 const federation = null as unknown as Federation<void>;
 // ---cut-before---

--- a/docs/manual/pragmatics.md
+++ b/docs/manual/pragmatics.md
@@ -158,7 +158,6 @@ The date joined is displayed in the profile page of the actor.
 
 ~~~~ typescript twoslash
 import { Person } from "@fedify/vocab";
-import { Temporal } from "@js-temporal/polyfill";
 // ---cut-before---
 new Person({
   name: "Fedify Demo",

--- a/docs/manual/relay.md
+++ b/docs/manual/relay.md
@@ -67,7 +67,7 @@ Deno.serve((request) => relay.fetch(request));
 ~~~~
 
 ~~~~ typescript twoslash [Bun]
-import "@types/bun";
+import "bun";
 // ---cut-before---
 import { createRelay } from "@fedify/relay";
 import { MemoryKvStore } from "@fedify/fedify";

--- a/docs/manual/vocab.md
+++ b/docs/manual/vocab.md
@@ -92,8 +92,6 @@ that contains the properties of the object.  The following shows an example of
 instantiating a `Create` object:
 
 ~~~~ typescript twoslash
-import { Temporal } from "@js-temporal/polyfill";
-// ---cut-before---
 import { Create, Note } from "@fedify/vocab";
 
 const create = new Create({
@@ -199,7 +197,6 @@ For example, the following two objects are equivalent (where dereferencing URI
 
 ~~~~ typescript twoslash
 import { Create, Note } from "@fedify/vocab";
-import { Temporal } from "@js-temporal/polyfill";
 // ---cut-before---
 const a = new Create({
   id: new URL("https://example.com/activities/123"),
@@ -353,8 +350,6 @@ properties.  The following shows an example of changing the `~Object.content`
 property of a `Note` object:
 
 ~~~~ typescript{8-10} twoslash
-import { Temporal } from "@js-temporal/polyfill";
-// ---cut-before---
 import { Note } from "@fedify/vocab";
 import { LanguageString } from "@fedify/vocab-runtime";
 

--- a/docs/tutorial/basics.md
+++ b/docs/tutorial/basics.md
@@ -168,7 +168,7 @@ Deno.serve(request =>
 ~~~~
 
 ~~~~ typescript twoslash [Bun]
-import "@types/bun";
+import "bun";
 // ---cut-before---
 Bun.serve({
   port: 8000,
@@ -277,7 +277,7 @@ Deno.serve(
 ~~~~
 
 ~~~~ typescript{4} twoslash [Bun]
-import "@types/bun";
+import "bun";
 import type { Federation } from "@fedify/fedify";
 const federation = null as unknown as Federation<void>;
 // ---cut-before---
@@ -407,7 +407,7 @@ Deno.serve(
 ~~~~
 
 ~~~~ typescript{7-16} twoslash [Bun]
-import "@types/bun";
+import "bun";
 // ---cut-before---
 import { createFederation, MemoryKvStore } from "@fedify/fedify";
 import { Person } from "@fedify/vocab";
@@ -654,7 +654,7 @@ Deno.serve(
 ~~~~
 
 ~~~~ typescript{1,5} twoslash [Bun]
-import "@types/bun";
+import "bun";
 import type { Federation } from "@fedify/fedify";
 const federation = null as unknown as Federation<void>;
 // ---cut-before---
@@ -1202,7 +1202,7 @@ Deno.serve(async (request) => {
 ~~~~
 
 ~~~~ typescript{4-18} twoslash [Bun]
-import "@types/bun";
+import "bun";
 import type { Federation } from "@fedify/fedify";
 import { openKv } from "@deno/kv";
 const federation = null as unknown as Federation<void>;

--- a/docs/tutorial/microblog.md
+++ b/docs/tutorial/microblog.md
@@ -3144,7 +3144,7 @@ npm add @js-temporal/polyfill
 
 Open the *src/federation.ts* file and `import` the installed package:
 
-~~~~ typescript twoslash [src/federation.ts]
+~~~~ typescript [src/federation.ts]
 import { Temporal } from "@js-temporal/polyfill";
 ~~~~
 
@@ -3199,7 +3199,6 @@ federation.setObjectDispatcher(
 Let's modify this as follows:
 
 ~~~~ typescript twoslash [src/federation.ts]
-import { Temporal } from "@js-temporal/polyfill";
 import { type Federation } from "@fedify/fedify";
 import { Note, PUBLIC_COLLECTION } from "@fedify/vocab";
 const federation = null as unknown as Federation<void>;

--- a/packages/debugger/tsdown.config.ts
+++ b/packages/debugger/tsdown.config.ts
@@ -23,16 +23,13 @@ export default defineConfig({
       /^hono\//,
     ],
   },
-  outputOptions(outputOptions, format) {
-    if (format === "cjs") {
-      outputOptions.intro = `
-        const { Temporal } = require("@js-temporal/polyfill");
-      `;
-    } else {
-      outputOptions.intro = `
-        import { Temporal } from "@js-temporal/polyfill";
-      `;
-    }
-    return outputOptions;
+  banner({ format }) {
+    const js = format === "cjs"
+      ? `const { Temporal } = require("@js-temporal/polyfill");`
+      : `import { Temporal } from "@js-temporal/polyfill";`;
+    return {
+      js,
+      dts: `/// <reference lib="esnext.temporal" />`,
+    };
   },
 });

--- a/packages/fedify/src/utils/kv-cache.ts
+++ b/packages/fedify/src/utils/kv-cache.ts
@@ -3,7 +3,8 @@ import type {
   DocumentLoaderOptions,
   RemoteDocument,
 } from "@fedify/vocab-runtime";
-import { isTemporalDuration, preloadedContexts } from "@fedify/vocab-runtime";
+import { preloadedContexts } from "@fedify/vocab-runtime";
+import { isTemporalDuration } from "@fedify/vocab-runtime/temporal";
 import { getLogger } from "@logtape/logtape";
 import type {
   KvKey,

--- a/packages/fedify/src/utils/kv-cache.ts
+++ b/packages/fedify/src/utils/kv-cache.ts
@@ -3,7 +3,7 @@ import type {
   DocumentLoaderOptions,
   RemoteDocument,
 } from "@fedify/vocab-runtime";
-import { preloadedContexts } from "@fedify/vocab-runtime";
+import { isTemporalDuration, preloadedContexts } from "@fedify/vocab-runtime";
 import { getLogger } from "@logtape/logtape";
 import type {
   KvKey,
@@ -155,9 +155,7 @@ function matchRule(
   ][],
 ): Temporal.Duration | null {
   for (const [pattern, d] of rules!) {
-    const duration = d instanceof Temporal.Duration
-      ? d
-      : Temporal.Duration.from(d);
+    const duration = isTemporalDuration(d) ? d : Temporal.Duration.from(d);
     if (typeof pattern === "string") {
       if (url === pattern) return duration;
       continue;

--- a/packages/fedify/src/utils/kv-cache.ts
+++ b/packages/fedify/src/utils/kv-cache.ts
@@ -4,7 +4,6 @@ import type {
   RemoteDocument,
 } from "@fedify/vocab-runtime";
 import { preloadedContexts } from "@fedify/vocab-runtime";
-import { isTemporalDuration } from "@fedify/vocab-runtime/temporal";
 import { getLogger } from "@logtape/logtape";
 import type {
   KvKey,
@@ -156,7 +155,7 @@ function matchRule(
   ][],
 ): Temporal.Duration | null {
   for (const [pattern, d] of rules!) {
-    const duration = isTemporalDuration(d) ? d : Temporal.Duration.from(d);
+    const duration = Temporal.Duration.from(d);
     if (typeof pattern === "string") {
       if (url === pattern) return duration;
       continue;

--- a/packages/fedify/tsdown.config.ts
+++ b/packages/fedify/tsdown.config.ts
@@ -19,19 +19,20 @@ export default [
     format: ["esm", "cjs"],
     platform: "neutral",
     deps: { neverBundle: [/^node:/] },
-    outputOptions(outputOptions, format) {
-      if (format === "cjs") {
-        outputOptions.intro = `
-          const { Temporal } = require("@js-temporal/polyfill");
-          const { URLPattern } = require("urlpattern-polyfill");
-        `;
-      } else {
-        outputOptions.intro = `
-          import { Temporal } from "@js-temporal/polyfill";
-          import { URLPattern } from "urlpattern-polyfill";
-        `;
-      }
-      return outputOptions;
+    banner({ format }) {
+      const js = format === "cjs"
+        ? [
+          `const { Temporal } = require("@js-temporal/polyfill");`,
+          `const { URLPattern } = require("urlpattern-polyfill");`,
+        ].join("\n")
+        : [
+          `import { Temporal } from "@js-temporal/polyfill";`,
+          `import { URLPattern } from "urlpattern-polyfill";`,
+        ].join("\n");
+      return {
+        js,
+        dts: `/// <reference lib="esnext.temporal" />`,
+      };
     },
   }),
   defineConfig({

--- a/packages/postgres/tsdown.config.ts
+++ b/packages/postgres/tsdown.config.ts
@@ -12,16 +12,13 @@ export default defineConfig({
       dts: format === "cjs" ? ".d.cts" : ".d.ts",
     };
   },
-  outputOptions(outputOptions, format) {
-    if (format === "cjs") {
-      outputOptions.intro = `
-        const { Temporal } = require("@js-temporal/polyfill");
-      `;
-    } else {
-      outputOptions.intro = `
-        import { Temporal } from "@js-temporal/polyfill";
-      `;
-    }
-    return outputOptions;
+  banner({ format }) {
+    const js = format === "cjs"
+      ? `const { Temporal } = require("@js-temporal/polyfill");`
+      : `import { Temporal } from "@js-temporal/polyfill";`;
+    return {
+      js,
+      dts: `/// <reference lib="esnext.temporal" />`,
+    };
   },
 });

--- a/packages/redis/tsdown.config.ts
+++ b/packages/redis/tsdown.config.ts
@@ -12,16 +12,13 @@ export default defineConfig({
       dts: format === "cjs" ? ".d.cts" : ".d.ts",
     };
   },
-  outputOptions(outputOptions, format) {
-    if (format === "cjs") {
-      outputOptions.intro = `
-        const { Temporal } = require("@js-temporal/polyfill");
-      `;
-    } else {
-      outputOptions.intro = `
-        import { Temporal } from "@js-temporal/polyfill";
-      `;
-    }
-    return outputOptions;
+  banner({ format }) {
+    const js = format === "cjs"
+      ? `const { Temporal } = require("@js-temporal/polyfill");`
+      : `import { Temporal } from "@js-temporal/polyfill";`;
+    return {
+      js,
+      dts: `/// <reference lib="esnext.temporal" />`,
+    };
   },
 });

--- a/packages/relay/tsdown.config.ts
+++ b/packages/relay/tsdown.config.ts
@@ -14,17 +14,14 @@ export default [
         dts: format === "cjs" ? ".d.cts" : ".d.ts",
       };
     },
-    outputOptions(outputOptions, format) {
-      if (format === "cjs") {
-        outputOptions.intro = `
-        const { Temporal } = require("@js-temporal/polyfill");
-      `;
-      } else {
-        outputOptions.intro = `
-        import { Temporal } from "@js-temporal/polyfill";
-      `;
-      }
-      return outputOptions;
+    banner({ format }) {
+      const js = format === "cjs"
+        ? `const { Temporal } = require("@js-temporal/polyfill");`
+        : `import { Temporal } from "@js-temporal/polyfill";`;
+      return {
+        js,
+        dts: `/// <reference lib="esnext.temporal" />`,
+      };
     },
   }),
   defineConfig({

--- a/packages/sqlite/tsdown.config.ts
+++ b/packages/sqlite/tsdown.config.ts
@@ -29,16 +29,13 @@ export default defineConfig({
       defaultHandler(warning);
     },
   },
-  outputOptions(outputOptions, format) {
-    if (format === "cjs") {
-      outputOptions.intro = `
-        const { Temporal } = require("@js-temporal/polyfill");
-      `;
-    } else {
-      outputOptions.intro = `
-        import { Temporal } from "@js-temporal/polyfill";
-      `;
-    }
-    return outputOptions;
+  banner({ format }) {
+    const js = format === "cjs"
+      ? `const { Temporal } = require("@js-temporal/polyfill");`
+      : `import { Temporal } from "@js-temporal/polyfill";`;
+    return {
+      js,
+      dts: `/// <reference lib="esnext.temporal" />`,
+    };
   },
 });

--- a/packages/testing/tsdown.config.ts
+++ b/packages/testing/tsdown.config.ts
@@ -19,16 +19,13 @@ export default defineConfig({
       "@fedify/vocab-runtime",
     ],
   },
-  outputOptions(outputOptions, format) {
-    if (format === "cjs") {
-      outputOptions.intro = `
-        const { Temporal } = require("@js-temporal/polyfill");
-      `;
-    } else {
-      outputOptions.intro = `
-        import { Temporal } from "@js-temporal/polyfill";
-      `;
-    }
-    return outputOptions;
+  banner({ format }) {
+    const js = format === "cjs"
+      ? `const { Temporal } = require("@js-temporal/polyfill");`
+      : `import { Temporal } from "@js-temporal/polyfill";`;
+    return {
+      js,
+      dts: `/// <reference lib="esnext.temporal" />`,
+    };
   },
 });

--- a/packages/vocab-runtime/deno.json
+++ b/packages/vocab-runtime/deno.json
@@ -13,6 +13,7 @@
     "url": "https://hongminhee.org/"
   },
   "imports": {
+    "@js-temporal/polyfill": "npm:@js-temporal/polyfill@^0.5.1",
     "@multiformats/base-x": "npm:@multiformats/base-x@^4.0.1",
     "asn1js": "npm:asn1js@^3.0.6",
     "byte-encodings": "npm:byte-encodings@^1.0.11",

--- a/packages/vocab-runtime/deno.json
+++ b/packages/vocab-runtime/deno.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts",
-    "./jsonld": "./src/jsonld.ts"
+    "./jsonld": "./src/jsonld.ts",
+    "./temporal": "./src/temporal.ts"
   },
   "description": "Runtime library for @fedify/vocab",
   "author": {

--- a/packages/vocab-runtime/package.json
+++ b/packages/vocab-runtime/package.json
@@ -73,6 +73,7 @@
     "typescript": "catalog:"
   },
   "dependencies": {
+    "@js-temporal/polyfill": "catalog:",
     "@logtape/logtape": "catalog:",
     "@multiformats/base-x": "catalog:",
     "@opentelemetry/api": "catalog:",

--- a/packages/vocab-runtime/package.json
+++ b/packages/vocab-runtime/package.json
@@ -45,6 +45,16 @@
       "require": "./dist/jsonld.cjs",
       "default": "./dist/jsonld.js"
     },
+    "./temporal": {
+      "types": {
+        "import": "./dist/temporal.d.ts",
+        "require": "./dist/temporal.d.cts",
+        "default": "./dist/temporal.d.ts"
+      },
+      "import": "./dist/temporal.js",
+      "require": "./dist/temporal.cjs",
+      "default": "./dist/temporal.js"
+    },
     "./package.json": "./package.json"
   },
   "scripts": {

--- a/packages/vocab-runtime/src/mod.ts
+++ b/packages/vocab-runtime/src/mod.ts
@@ -38,7 +38,6 @@ export {
   type GetUserAgentOptions,
   logRequest,
 } from "./request.ts";
-export { isTemporalDuration, isTemporalInstant } from "./temporal.ts";
 export {
   expandIPv6Address,
   isValidPublicIPv4Address,

--- a/packages/vocab-runtime/src/mod.ts
+++ b/packages/vocab-runtime/src/mod.ts
@@ -38,6 +38,7 @@ export {
   type GetUserAgentOptions,
   logRequest,
 } from "./request.ts";
+export { isTemporalDuration, isTemporalInstant } from "./temporal.ts";
 export {
   expandIPv6Address,
   isValidPublicIPv4Address,

--- a/packages/vocab-runtime/src/temporal.test.ts
+++ b/packages/vocab-runtime/src/temporal.test.ts
@@ -1,0 +1,55 @@
+import { Temporal } from "@js-temporal/polyfill";
+import { strictEqual } from "node:assert";
+import { test } from "node:test";
+import { isTemporalDuration, isTemporalInstant } from "./temporal.ts";
+
+test("isTemporalInstant() accepts polyfill instances", () => {
+  strictEqual(
+    isTemporalInstant(Temporal.Instant.from("2026-05-14T00:00:00Z")),
+    true,
+  );
+});
+
+test("isTemporalInstant() accepts spec-compliant non-polyfill objects", () => {
+  // Mimics the shape of a native `Temporal.Instant` from a host that does
+  // not share class identity with the bundled polyfill.
+  const nativeLike = Object.create(null, {
+    [Symbol.toStringTag]: { value: "Temporal.Instant" },
+  });
+  strictEqual(isTemporalInstant(nativeLike), true);
+});
+
+test("isTemporalInstant() rejects unrelated values", () => {
+  strictEqual(isTemporalInstant(null), false);
+  strictEqual(isTemporalInstant(undefined), false);
+  strictEqual(isTemporalInstant("2026-05-14T00:00:00Z"), false);
+  strictEqual(isTemporalInstant(new Date()), false);
+  strictEqual(
+    isTemporalInstant(Temporal.Duration.from({ seconds: 1 })),
+    false,
+  );
+});
+
+test("isTemporalDuration() accepts polyfill instances", () => {
+  strictEqual(
+    isTemporalDuration(Temporal.Duration.from({ hours: 1 })),
+    true,
+  );
+});
+
+test("isTemporalDuration() accepts spec-compliant non-polyfill objects", () => {
+  const nativeLike = Object.create(null, {
+    [Symbol.toStringTag]: { value: "Temporal.Duration" },
+  });
+  strictEqual(isTemporalDuration(nativeLike), true);
+});
+
+test("isTemporalDuration() rejects unrelated values", () => {
+  strictEqual(isTemporalDuration(null), false);
+  strictEqual(isTemporalDuration(undefined), false);
+  strictEqual(isTemporalDuration("PT1H"), false);
+  strictEqual(
+    isTemporalDuration(Temporal.Instant.from("2026-05-14T00:00:00Z")),
+    false,
+  );
+});

--- a/packages/vocab-runtime/src/temporal.test.ts
+++ b/packages/vocab-runtime/src/temporal.test.ts
@@ -15,6 +15,7 @@ test("isTemporalInstant() accepts spec-compliant non-polyfill objects", () => {
   // not share class identity with the bundled polyfill.
   const nativeLike = Object.create(null, {
     [Symbol.toStringTag]: { value: "Temporal.Instant" },
+    epochNanoseconds: { value: 0n },
   });
   strictEqual(isTemporalInstant(nativeLike), true);
 });
@@ -30,6 +31,13 @@ test("isTemporalInstant() rejects unrelated values", () => {
   );
 });
 
+test("isTemporalInstant() rejects bare objects tagged but missing shape", () => {
+  const decoy = Object.create(null, {
+    [Symbol.toStringTag]: { value: "Temporal.Instant" },
+  });
+  strictEqual(isTemporalInstant(decoy), false);
+});
+
 test("isTemporalDuration() accepts polyfill instances", () => {
   strictEqual(
     isTemporalDuration(Temporal.Duration.from({ hours: 1 })),
@@ -40,6 +48,7 @@ test("isTemporalDuration() accepts polyfill instances", () => {
 test("isTemporalDuration() accepts spec-compliant non-polyfill objects", () => {
   const nativeLike = Object.create(null, {
     [Symbol.toStringTag]: { value: "Temporal.Duration" },
+    sign: { value: 0 },
   });
   strictEqual(isTemporalDuration(nativeLike), true);
 });
@@ -52,4 +61,11 @@ test("isTemporalDuration() rejects unrelated values", () => {
     isTemporalDuration(Temporal.Instant.from("2026-05-14T00:00:00Z")),
     false,
   );
+});
+
+test("isTemporalDuration() rejects bare objects tagged but missing shape", () => {
+  const decoy = Object.create(null, {
+    [Symbol.toStringTag]: { value: "Temporal.Duration" },
+  });
+  strictEqual(isTemporalDuration(decoy), false);
 });

--- a/packages/vocab-runtime/src/temporal.test.ts
+++ b/packages/vocab-runtime/src/temporal.test.ts
@@ -101,6 +101,17 @@ test("isTemporalDuration() rejects non-number sign", () => {
   strictEqual(isTemporalDuration(decoy), false);
 });
 
+test("isTemporalDuration() rejects out-of-range sign values", () => {
+  // Real Temporal.Duration#sign is `-1 | 0 | 1` per spec, so anything else
+  // (here, 42) must be rejected even though it is a number.
+  const decoy = Object.create(null, {
+    [Symbol.toStringTag]: { value: "Temporal.Duration" },
+    sign: { value: 42 },
+    toString: { value: () => "PT42S" },
+  });
+  strictEqual(isTemporalDuration(decoy), false);
+});
+
 test("isTemporalDuration() rejects default Object.prototype.toString", () => {
   const decoy = {
     [Symbol.toStringTag]: "Temporal.Duration",

--- a/packages/vocab-runtime/src/temporal.test.ts
+++ b/packages/vocab-runtime/src/temporal.test.ts
@@ -16,6 +16,7 @@ test("isTemporalInstant() accepts spec-compliant non-polyfill objects", () => {
   const nativeLike = Object.create(null, {
     [Symbol.toStringTag]: { value: "Temporal.Instant" },
     epochNanoseconds: { value: 0n },
+    toString: { value: () => "1970-01-01T00:00:00Z" },
   });
   strictEqual(isTemporalInstant(nativeLike), true);
 });
@@ -42,7 +43,19 @@ test("isTemporalInstant() rejects non-bigint epochNanoseconds", () => {
   const decoy = Object.create(null, {
     [Symbol.toStringTag]: { value: "Temporal.Instant" },
     epochNanoseconds: { value: 0 },
+    toString: { value: () => "1970-01-01T00:00:00Z" },
   });
+  strictEqual(isTemporalInstant(decoy), false);
+});
+
+test("isTemporalInstant() rejects default Object.prototype.toString", () => {
+  // A plain object inherits `toString` from `Object.prototype`, so calling
+  // it would produce `"[object Temporal.Instant]"` instead of an RFC 3339
+  // timestamp.  The guard must reject these to keep the serializer honest.
+  const decoy = {
+    [Symbol.toStringTag]: "Temporal.Instant",
+    epochNanoseconds: 0n,
+  };
   strictEqual(isTemporalInstant(decoy), false);
 });
 
@@ -57,6 +70,7 @@ test("isTemporalDuration() accepts spec-compliant non-polyfill objects", () => {
   const nativeLike = Object.create(null, {
     [Symbol.toStringTag]: { value: "Temporal.Duration" },
     sign: { value: 0 },
+    toString: { value: () => "PT0S" },
   });
   strictEqual(isTemporalDuration(nativeLike), true);
 });
@@ -82,6 +96,15 @@ test("isTemporalDuration() rejects non-number sign", () => {
   const decoy = Object.create(null, {
     [Symbol.toStringTag]: { value: "Temporal.Duration" },
     sign: { value: "0" },
+    toString: { value: () => "PT0S" },
   });
+  strictEqual(isTemporalDuration(decoy), false);
+});
+
+test("isTemporalDuration() rejects default Object.prototype.toString", () => {
+  const decoy = {
+    [Symbol.toStringTag]: "Temporal.Duration",
+    sign: 0,
+  };
   strictEqual(isTemporalDuration(decoy), false);
 });

--- a/packages/vocab-runtime/src/temporal.test.ts
+++ b/packages/vocab-runtime/src/temporal.test.ts
@@ -38,6 +38,14 @@ test("isTemporalInstant() rejects bare objects tagged but missing shape", () => 
   strictEqual(isTemporalInstant(decoy), false);
 });
 
+test("isTemporalInstant() rejects non-bigint epochNanoseconds", () => {
+  const decoy = Object.create(null, {
+    [Symbol.toStringTag]: { value: "Temporal.Instant" },
+    epochNanoseconds: { value: 0 },
+  });
+  strictEqual(isTemporalInstant(decoy), false);
+});
+
 test("isTemporalDuration() accepts polyfill instances", () => {
   strictEqual(
     isTemporalDuration(Temporal.Duration.from({ hours: 1 })),
@@ -66,6 +74,14 @@ test("isTemporalDuration() rejects unrelated values", () => {
 test("isTemporalDuration() rejects bare objects tagged but missing shape", () => {
   const decoy = Object.create(null, {
     [Symbol.toStringTag]: { value: "Temporal.Duration" },
+  });
+  strictEqual(isTemporalDuration(decoy), false);
+});
+
+test("isTemporalDuration() rejects non-number sign", () => {
+  const decoy = Object.create(null, {
+    [Symbol.toStringTag]: { value: "Temporal.Duration" },
+    sign: { value: "0" },
   });
   strictEqual(isTemporalDuration(decoy), false);
 });

--- a/packages/vocab-runtime/src/temporal.ts
+++ b/packages/vocab-runtime/src/temporal.ts
@@ -1,0 +1,47 @@
+/// <reference lib="esnext.temporal" />
+/**
+ * Type guards for `Temporal` namespace objects.
+ *
+ * Fedify accepts both runtime polyfills (e.g. `@js-temporal/polyfill`,
+ * `temporal-polyfill`) and the host's native `Temporal` implementation
+ * (Node.js 26+, Bun, Deno). The guards below rely on `Symbol.toStringTag`,
+ * which is mandated by the Temporal specification, so they accept any
+ * spec-conformant implementation regardless of which class produced the
+ * value.
+ *
+ * @module
+ */
+
+/**
+ * Checks whether the given value is a `Temporal.Instant` object, regardless
+ * of whether it came from a polyfill or the host's native implementation.
+ *
+ * @param value The value to test.
+ * @returns `true` if the value reports `Temporal.Instant` via
+ *          `Symbol.toStringTag`; `false` otherwise.
+ */
+export function isTemporalInstant(value: unknown): value is Temporal.Instant {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { [Symbol.toStringTag]?: unknown })[Symbol.toStringTag] ===
+      "Temporal.Instant"
+  );
+}
+
+/**
+ * Checks whether the given value is a `Temporal.Duration` object, regardless
+ * of whether it came from a polyfill or the host's native implementation.
+ *
+ * @param value The value to test.
+ * @returns `true` if the value reports `Temporal.Duration` via
+ *          `Symbol.toStringTag`; `false` otherwise.
+ */
+export function isTemporalDuration(value: unknown): value is Temporal.Duration {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    (value as { [Symbol.toStringTag]?: unknown })[Symbol.toStringTag] ===
+      "Temporal.Duration"
+  );
+}

--- a/packages/vocab-runtime/src/temporal.ts
+++ b/packages/vocab-runtime/src/temporal.ts
@@ -16,16 +16,22 @@
  * Checks whether the given value is a `Temporal.Instant` object, regardless
  * of whether it came from a polyfill or the host's native implementation.
  *
+ * The guard verifies the spec-mandated `Symbol.toStringTag` and the presence
+ * of the `epochNanoseconds` accessor.  The latter rejects bare objects whose
+ * tag was set to `"Temporal.Instant"` without exposing the rest of the shape.
+ *
  * @param value The value to test.
  * @returns `true` if the value reports `Temporal.Instant` via
- *          `Symbol.toStringTag`; `false` otherwise.
+ *          `Symbol.toStringTag` and exposes `epochNanoseconds`; `false`
+ *          otherwise.
  */
 export function isTemporalInstant(value: unknown): value is Temporal.Instant {
   return (
     typeof value === "object" &&
     value !== null &&
     (value as { [Symbol.toStringTag]?: unknown })[Symbol.toStringTag] ===
-      "Temporal.Instant"
+      "Temporal.Instant" &&
+    "epochNanoseconds" in value
   );
 }
 
@@ -33,15 +39,20 @@ export function isTemporalInstant(value: unknown): value is Temporal.Instant {
  * Checks whether the given value is a `Temporal.Duration` object, regardless
  * of whether it came from a polyfill or the host's native implementation.
  *
+ * The guard verifies the spec-mandated `Symbol.toStringTag` and the presence
+ * of the `sign` accessor.  The latter rejects bare objects whose tag was set
+ * to `"Temporal.Duration"` without exposing the rest of the shape.
+ *
  * @param value The value to test.
  * @returns `true` if the value reports `Temporal.Duration` via
- *          `Symbol.toStringTag`; `false` otherwise.
+ *          `Symbol.toStringTag` and exposes `sign`; `false` otherwise.
  */
 export function isTemporalDuration(value: unknown): value is Temporal.Duration {
   return (
     typeof value === "object" &&
     value !== null &&
     (value as { [Symbol.toStringTag]?: unknown })[Symbol.toStringTag] ===
-      "Temporal.Duration"
+      "Temporal.Duration" &&
+    "sign" in value
   );
 }

--- a/packages/vocab-runtime/src/temporal.ts
+++ b/packages/vocab-runtime/src/temporal.ts
@@ -15,21 +15,24 @@
  * Checks whether the given value is a `Temporal.Instant` object, regardless
  * of whether it came from a polyfill or the host's native implementation.
  *
- * The guard verifies the spec-mandated `Symbol.toStringTag` and the presence
- * of the `epochNanoseconds` accessor.  The latter rejects bare objects whose
- * tag was set to `"Temporal.Instant"` without exposing the rest of the shape.
+ * The guard verifies the spec-mandated `Symbol.toStringTag` and that the
+ * `epochNanoseconds` accessor exposes a `bigint`.  Together they reject bare
+ * objects whose tag was set to `"Temporal.Instant"` without exposing the
+ * rest of the shape, including the case where the property exists but holds
+ * a value of the wrong type.
  *
  * @param value The value to test.
  * @returns `true` if the value reports `Temporal.Instant` via
- *          `Symbol.toStringTag` and exposes `epochNanoseconds`; `false`
- *          otherwise.
+ *          `Symbol.toStringTag` and exposes a `bigint`-valued
+ *          `epochNanoseconds`; `false` otherwise.
  */
 export function isTemporalInstant(value: unknown): value is Temporal.Instant {
   return (
     typeof value === "object" &&
     value !== null &&
     Object.prototype.toString.call(value) === "[object Temporal.Instant]" &&
-    "epochNanoseconds" in value
+    "epochNanoseconds" in value &&
+    typeof value.epochNanoseconds === "bigint"
   );
 }
 
@@ -37,19 +40,23 @@ export function isTemporalInstant(value: unknown): value is Temporal.Instant {
  * Checks whether the given value is a `Temporal.Duration` object, regardless
  * of whether it came from a polyfill or the host's native implementation.
  *
- * The guard verifies the spec-mandated `Symbol.toStringTag` and the presence
- * of the `sign` accessor.  The latter rejects bare objects whose tag was set
- * to `"Temporal.Duration"` without exposing the rest of the shape.
+ * The guard verifies the spec-mandated `Symbol.toStringTag` and that the
+ * `sign` accessor exposes a `number`.  Together they reject bare objects
+ * whose tag was set to `"Temporal.Duration"` without exposing the rest of
+ * the shape, including the case where the property exists but holds a
+ * value of the wrong type.
  *
  * @param value The value to test.
  * @returns `true` if the value reports `Temporal.Duration` via
- *          `Symbol.toStringTag` and exposes `sign`; `false` otherwise.
+ *          `Symbol.toStringTag` and exposes a `number`-valued `sign`;
+ *          `false` otherwise.
  */
 export function isTemporalDuration(value: unknown): value is Temporal.Duration {
   return (
     typeof value === "object" &&
     value !== null &&
     Object.prototype.toString.call(value) === "[object Temporal.Duration]" &&
-    "sign" in value
+    "sign" in value &&
+    typeof value.sign === "number"
   );
 }

--- a/packages/vocab-runtime/src/temporal.ts
+++ b/packages/vocab-runtime/src/temporal.ts
@@ -1,4 +1,3 @@
-/// <reference lib="esnext.temporal" />
 /**
  * Type guards for `Temporal` namespace objects.
  *

--- a/packages/vocab-runtime/src/temporal.ts
+++ b/packages/vocab-runtime/src/temporal.ts
@@ -47,17 +47,18 @@ export function isTemporalInstant(value: unknown): value is Temporal.Instant {
  * of whether it came from a polyfill or the host's native implementation.
  *
  * The guard verifies the spec-mandated `Symbol.toStringTag`, that the
- * `sign` accessor exposes a `number`, and that `toString` is not the
- * default inherited from `Object.prototype`.  Together they reject bare
- * objects whose tag was set to `"Temporal.Duration"` without exposing the
- * rest of the shape; the `toString` check in particular prevents a spoof
- * from reaching the JSON-LD serializer (which calls `toString()`) and
- * emitting `"[object Temporal.Duration]"` instead of an ISO 8601 duration.
+ * `sign` accessor returns one of the three spec-valid values (`-1`, `0`,
+ * or `1`), and that `toString` is not the default inherited from
+ * `Object.prototype`.  Together they reject bare objects whose tag was set
+ * to `"Temporal.Duration"` without exposing the rest of the shape; the
+ * `toString` check in particular prevents a spoof from reaching the
+ * JSON-LD serializer (which calls `toString()`) and emitting
+ * `"[object Temporal.Duration]"` instead of an ISO 8601 duration.
  *
  * @param value The value to test.
  * @returns `true` if the value reports `Temporal.Duration` via
- *          `Symbol.toStringTag`, exposes a `number`-valued `sign`, and
- *          overrides `toString`; `false` otherwise.
+ *          `Symbol.toStringTag`, exposes a `sign` of `-1`, `0`, or `1`,
+ *          and overrides `toString`; `false` otherwise.
  */
 export function isTemporalDuration(value: unknown): value is Temporal.Duration {
   return (
@@ -65,7 +66,7 @@ export function isTemporalDuration(value: unknown): value is Temporal.Duration {
     value !== null &&
     Object.prototype.toString.call(value) === "[object Temporal.Duration]" &&
     "sign" in value &&
-    typeof value.sign === "number" &&
+    (value.sign === -1 || value.sign === 0 || value.sign === 1) &&
     "toString" in value &&
     typeof value.toString === "function" &&
     value.toString !== Object.prototype.toString

--- a/packages/vocab-runtime/src/temporal.ts
+++ b/packages/vocab-runtime/src/temporal.ts
@@ -28,8 +28,7 @@ export function isTemporalInstant(value: unknown): value is Temporal.Instant {
   return (
     typeof value === "object" &&
     value !== null &&
-    (value as { [Symbol.toStringTag]?: unknown })[Symbol.toStringTag] ===
-      "Temporal.Instant" &&
+    Object.prototype.toString.call(value) === "[object Temporal.Instant]" &&
     "epochNanoseconds" in value
   );
 }
@@ -50,8 +49,7 @@ export function isTemporalDuration(value: unknown): value is Temporal.Duration {
   return (
     typeof value === "object" &&
     value !== null &&
-    (value as { [Symbol.toStringTag]?: unknown })[Symbol.toStringTag] ===
-      "Temporal.Duration" &&
+    Object.prototype.toString.call(value) === "[object Temporal.Duration]" &&
     "sign" in value
   );
 }

--- a/packages/vocab-runtime/src/temporal.ts
+++ b/packages/vocab-runtime/src/temporal.ts
@@ -15,16 +15,19 @@
  * Checks whether the given value is a `Temporal.Instant` object, regardless
  * of whether it came from a polyfill or the host's native implementation.
  *
- * The guard verifies the spec-mandated `Symbol.toStringTag` and that the
- * `epochNanoseconds` accessor exposes a `bigint`.  Together they reject bare
- * objects whose tag was set to `"Temporal.Instant"` without exposing the
- * rest of the shape, including the case where the property exists but holds
- * a value of the wrong type.
+ * The guard verifies the spec-mandated `Symbol.toStringTag`, that the
+ * `epochNanoseconds` accessor exposes a `bigint`, and that `toString` is
+ * not the default inherited from `Object.prototype`.  Together they reject
+ * bare objects whose tag was set to `"Temporal.Instant"` without exposing
+ * the rest of the shape; the `toString` check in particular prevents a
+ * spoof from reaching the JSON-LD serializer (which calls `toString()`)
+ * and emitting `"[object Temporal.Instant]"` instead of an RFC 3339
+ * timestamp.
  *
  * @param value The value to test.
  * @returns `true` if the value reports `Temporal.Instant` via
- *          `Symbol.toStringTag` and exposes a `bigint`-valued
- *          `epochNanoseconds`; `false` otherwise.
+ *          `Symbol.toStringTag`, exposes a `bigint`-valued
+ *          `epochNanoseconds`, and overrides `toString`; `false` otherwise.
  */
 export function isTemporalInstant(value: unknown): value is Temporal.Instant {
   return (
@@ -32,7 +35,10 @@ export function isTemporalInstant(value: unknown): value is Temporal.Instant {
     value !== null &&
     Object.prototype.toString.call(value) === "[object Temporal.Instant]" &&
     "epochNanoseconds" in value &&
-    typeof value.epochNanoseconds === "bigint"
+    typeof value.epochNanoseconds === "bigint" &&
+    "toString" in value &&
+    typeof value.toString === "function" &&
+    value.toString !== Object.prototype.toString
   );
 }
 
@@ -40,16 +46,18 @@ export function isTemporalInstant(value: unknown): value is Temporal.Instant {
  * Checks whether the given value is a `Temporal.Duration` object, regardless
  * of whether it came from a polyfill or the host's native implementation.
  *
- * The guard verifies the spec-mandated `Symbol.toStringTag` and that the
- * `sign` accessor exposes a `number`.  Together they reject bare objects
- * whose tag was set to `"Temporal.Duration"` without exposing the rest of
- * the shape, including the case where the property exists but holds a
- * value of the wrong type.
+ * The guard verifies the spec-mandated `Symbol.toStringTag`, that the
+ * `sign` accessor exposes a `number`, and that `toString` is not the
+ * default inherited from `Object.prototype`.  Together they reject bare
+ * objects whose tag was set to `"Temporal.Duration"` without exposing the
+ * rest of the shape; the `toString` check in particular prevents a spoof
+ * from reaching the JSON-LD serializer (which calls `toString()`) and
+ * emitting `"[object Temporal.Duration]"` instead of an ISO 8601 duration.
  *
  * @param value The value to test.
  * @returns `true` if the value reports `Temporal.Duration` via
- *          `Symbol.toStringTag` and exposes a `number`-valued `sign`;
- *          `false` otherwise.
+ *          `Symbol.toStringTag`, exposes a `number`-valued `sign`, and
+ *          overrides `toString`; `false` otherwise.
  */
 export function isTemporalDuration(value: unknown): value is Temporal.Duration {
   return (
@@ -57,6 +65,9 @@ export function isTemporalDuration(value: unknown): value is Temporal.Duration {
     value !== null &&
     Object.prototype.toString.call(value) === "[object Temporal.Duration]" &&
     "sign" in value &&
-    typeof value.sign === "number"
+    typeof value.sign === "number" &&
+    "toString" in value &&
+    typeof value.toString === "function" &&
+    value.toString !== Object.prototype.toString
   );
 }

--- a/packages/vocab-runtime/tsdown.config.ts
+++ b/packages/vocab-runtime/tsdown.config.ts
@@ -4,7 +4,7 @@ import { defineConfig } from "tsdown";
 
 export default [
   defineConfig({
-    entry: ["src/mod.ts", "src/jsonld.ts"],
+    entry: ["src/mod.ts", "src/jsonld.ts", "src/temporal.ts"],
     dts: { compilerOptions: { isolatedDeclarations: true, declaration: true } },
     format: ["esm", "cjs"],
     platform: "neutral",

--- a/packages/vocab-runtime/tsdown.config.ts
+++ b/packages/vocab-runtime/tsdown.config.ts
@@ -9,6 +9,9 @@ export default [
     format: ["esm", "cjs"],
     platform: "neutral",
     external: [/^node:/],
+    banner: {
+      dts: `/// <reference lib="esnext.temporal" />`,
+    },
   }),
   defineConfig({
     outDir: "dist/tests",

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -18,6 +18,10 @@ import {
     LanguageString,
     type RemoteDocument,
 } from \\"@fedify/vocab-runtime\\";
+import {
+    isTemporalDuration,
+    isTemporalInstant,
+} from \\"@fedify/vocab-runtime/temporal\\";
 
 
 /** Describes an object of any kind. The Object type serves as the base type for
@@ -388,7 +392,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       
         if (\\"endTime\\" in values &&             values.endTime != null) {
-          if (values.endTime instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.endTime)) {
             // @ts-ignore: type is checked above.
             this.#_219RwDanjScTv5tYCjwGZVCM7KZ9_endTime = [values.endTime];
       
@@ -620,7 +624,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       
         if (\\"published\\" in values &&             values.published != null) {
-          if (values.published instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.published)) {
             // @ts-ignore: type is checked above.
             this.#_5e258TDXtuhaFRPZiGoDfEpjdMr_published = [values.published];
       
@@ -685,7 +689,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       
         if (\\"startTime\\" in values &&             values.startTime != null) {
-          if (values.startTime instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.startTime)) {
             // @ts-ignore: type is checked above.
             this.#_2w3Jmue4up8iVDUA51WZqomEF438_startTime = [values.startTime];
       
@@ -753,7 +757,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       
         if (\\"updated\\" in values &&             values.updated != null) {
-          if (values.updated instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.updated)) {
             // @ts-ignore: type is checked above.
             this.#_385aB7ySixcf5Un6z3VsWmThgCzQ_updated = [values.updated];
       
@@ -975,7 +979,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       
         if (\\"duration\\" in values &&             values.duration != null) {
-          if (values.duration instanceof Temporal.Duration) {
+          if (isTemporalDuration(values.duration)) {
             // @ts-ignore: type is checked above.
             this.#_3bNvLMBN1bCJETiTihM3wvi1B2JX_duration = [values.duration];
       
@@ -1298,7 +1302,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       clone.#_219RwDanjScTv5tYCjwGZVCM7KZ9_endTime = this.#_219RwDanjScTv5tYCjwGZVCM7KZ9_endTime;
         if (\\"endTime\\" in values &&             values.endTime != null) {
-          if (values.endTime instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.endTime)) {
             // @ts-ignore: type is checked above.
             clone.#_219RwDanjScTv5tYCjwGZVCM7KZ9_endTime = [values.endTime];
       
@@ -1536,7 +1540,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       clone.#_5e258TDXtuhaFRPZiGoDfEpjdMr_published = this.#_5e258TDXtuhaFRPZiGoDfEpjdMr_published;
         if (\\"published\\" in values &&             values.published != null) {
-          if (values.published instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.published)) {
             // @ts-ignore: type is checked above.
             clone.#_5e258TDXtuhaFRPZiGoDfEpjdMr_published = [values.published];
       
@@ -1601,7 +1605,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       clone.#_2w3Jmue4up8iVDUA51WZqomEF438_startTime = this.#_2w3Jmue4up8iVDUA51WZqomEF438_startTime;
         if (\\"startTime\\" in values &&             values.startTime != null) {
-          if (values.startTime instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.startTime)) {
             // @ts-ignore: type is checked above.
             clone.#_2w3Jmue4up8iVDUA51WZqomEF438_startTime = [values.startTime];
       
@@ -1670,7 +1674,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       clone.#_385aB7ySixcf5Un6z3VsWmThgCzQ_updated = this.#_385aB7ySixcf5Un6z3VsWmThgCzQ_updated;
         if (\\"updated\\" in values &&             values.updated != null) {
-          if (values.updated instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.updated)) {
             // @ts-ignore: type is checked above.
             clone.#_385aB7ySixcf5Un6z3VsWmThgCzQ_updated = [values.updated];
       
@@ -1896,7 +1900,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       clone.#_3bNvLMBN1bCJETiTihM3wvi1B2JX_duration = this.#_3bNvLMBN1bCJETiTihM3wvi1B2JX_duration;
         if (\\"duration\\" in values &&             values.duration != null) {
-          if (values.duration instanceof Temporal.Duration) {
+          if (isTemporalDuration(values.duration)) {
             // @ts-ignore: type is checked above.
             clone.#_3bNvLMBN1bCJETiTihM3wvi1B2JX_duration = [values.duration];
       
@@ -17191,7 +17195,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         }
       
         if (\\"created\\" in values &&             values.created != null) {
-          if (values.created instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.created)) {
             // @ts-ignore: type is checked above.
             this.#_3qzP3ukEZoUziK5FEiA1RhU4aqac = [values.created];
       
@@ -17292,7 +17296,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         }
       clone.#_3qzP3ukEZoUziK5FEiA1RhU4aqac = this.#_3qzP3ukEZoUziK5FEiA1RhU4aqac;
         if (\\"created\\" in values &&             values.created != null) {
-          if (values.created instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.created)) {
             // @ts-ignore: type is checked above.
             clone.#_3qzP3ukEZoUziK5FEiA1RhU4aqac = [values.created];
       
@@ -67912,7 +67916,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         }
       
         if (\\"closed\\" in values &&             values.closed != null) {
-          if (values.closed instanceof Temporal.Instant || typeof values.closed === \\"boolean\\") {
+          if (isTemporalInstant(values.closed) || typeof values.closed === \\"boolean\\") {
             // @ts-ignore: type is checked above.
             this.#_3KronwL8DiiKBRcJFKQPiEHm8xb6_closed = [values.closed];
       
@@ -68041,7 +68045,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         }
       clone.#_3KronwL8DiiKBRcJFKQPiEHm8xb6_closed = this.#_3KronwL8DiiKBRcJFKQPiEHm8xb6_closed;
         if (\\"closed\\" in values &&             values.closed != null) {
-          if (values.closed instanceof Temporal.Instant || typeof values.closed === \\"boolean\\") {
+          if (isTemporalInstant(values.closed) || typeof values.closed === \\"boolean\\") {
             // @ts-ignore: type is checked above.
             clone.#_3KronwL8DiiKBRcJFKQPiEHm8xb6_closed = [values.closed];
       
@@ -68648,7 +68652,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
     array = [];
     for (const v of this.#_3KronwL8DiiKBRcJFKQPiEHm8xb6_closed) {
       const element = (
-    v instanceof Temporal.Instant ? {
+    isTemporalInstant(v) ? {
         \\"@type\\": \\"http://www.w3.org/2001/XMLSchema#dateTime\\",
         \\"@value\\": v.toString(),
       } : { \\"@value\\": v }
@@ -79727,7 +79731,7 @@ proofs?: (DataIntegrityProof | URL)[];deleted?: Temporal.Instant | null;}
   ) {
   super(values, options);
         if (\\"deleted\\" in values &&             values.deleted != null) {
-          if (values.deleted instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.deleted)) {
             // @ts-ignore: type is checked above.
             this.#_8g8g4LiVMhFTXskuDEqx4ascxUr_deleted = [values.deleted];
       
@@ -79784,7 +79788,7 @@ proofs?: (DataIntegrityProof | URL)[];deleted?: Temporal.Instant | null;}
     }
   const clone = super.clone(values, options) as unknown as Tombstone;clone.#_8g8g4LiVMhFTXskuDEqx4ascxUr_deleted = this.#_8g8g4LiVMhFTXskuDEqx4ascxUr_deleted;
         if (\\"deleted\\" in values &&             values.deleted != null) {
-          if (values.deleted instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.deleted)) {
             // @ts-ignore: type is checked above.
             clone.#_8g8g4LiVMhFTXskuDEqx4ascxUr_deleted = [values.deleted];
       

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
@@ -16,6 +16,10 @@ import {
     LanguageString,
     type RemoteDocument,
 } from \\"@fedify/vocab-runtime\\";
+import {
+    isTemporalDuration,
+    isTemporalInstant,
+} from \\"@fedify/vocab-runtime/temporal\\";
 
 
 /** Describes an object of any kind. The Object type serves as the base type for
@@ -386,7 +390,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       
         if (\\"endTime\\" in values &&             values.endTime != null) {
-          if (values.endTime instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.endTime)) {
             // @ts-ignore: type is checked above.
             this.#_219RwDanjScTv5tYCjwGZVCM7KZ9_endTime = [values.endTime];
       
@@ -618,7 +622,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       
         if (\\"published\\" in values &&             values.published != null) {
-          if (values.published instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.published)) {
             // @ts-ignore: type is checked above.
             this.#_5e258TDXtuhaFRPZiGoDfEpjdMr_published = [values.published];
       
@@ -683,7 +687,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       
         if (\\"startTime\\" in values &&             values.startTime != null) {
-          if (values.startTime instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.startTime)) {
             // @ts-ignore: type is checked above.
             this.#_2w3Jmue4up8iVDUA51WZqomEF438_startTime = [values.startTime];
       
@@ -751,7 +755,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       
         if (\\"updated\\" in values &&             values.updated != null) {
-          if (values.updated instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.updated)) {
             // @ts-ignore: type is checked above.
             this.#_385aB7ySixcf5Un6z3VsWmThgCzQ_updated = [values.updated];
       
@@ -973,7 +977,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       
         if (\\"duration\\" in values &&             values.duration != null) {
-          if (values.duration instanceof Temporal.Duration) {
+          if (isTemporalDuration(values.duration)) {
             // @ts-ignore: type is checked above.
             this.#_3bNvLMBN1bCJETiTihM3wvi1B2JX_duration = [values.duration];
       
@@ -1296,7 +1300,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       clone.#_219RwDanjScTv5tYCjwGZVCM7KZ9_endTime = this.#_219RwDanjScTv5tYCjwGZVCM7KZ9_endTime;
         if (\\"endTime\\" in values &&             values.endTime != null) {
-          if (values.endTime instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.endTime)) {
             // @ts-ignore: type is checked above.
             clone.#_219RwDanjScTv5tYCjwGZVCM7KZ9_endTime = [values.endTime];
       
@@ -1534,7 +1538,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       clone.#_5e258TDXtuhaFRPZiGoDfEpjdMr_published = this.#_5e258TDXtuhaFRPZiGoDfEpjdMr_published;
         if (\\"published\\" in values &&             values.published != null) {
-          if (values.published instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.published)) {
             // @ts-ignore: type is checked above.
             clone.#_5e258TDXtuhaFRPZiGoDfEpjdMr_published = [values.published];
       
@@ -1599,7 +1603,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       clone.#_2w3Jmue4up8iVDUA51WZqomEF438_startTime = this.#_2w3Jmue4up8iVDUA51WZqomEF438_startTime;
         if (\\"startTime\\" in values &&             values.startTime != null) {
-          if (values.startTime instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.startTime)) {
             // @ts-ignore: type is checked above.
             clone.#_2w3Jmue4up8iVDUA51WZqomEF438_startTime = [values.startTime];
       
@@ -1668,7 +1672,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       clone.#_385aB7ySixcf5Un6z3VsWmThgCzQ_updated = this.#_385aB7ySixcf5Un6z3VsWmThgCzQ_updated;
         if (\\"updated\\" in values &&             values.updated != null) {
-          if (values.updated instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.updated)) {
             // @ts-ignore: type is checked above.
             clone.#_385aB7ySixcf5Un6z3VsWmThgCzQ_updated = [values.updated];
       
@@ -1894,7 +1898,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       clone.#_3bNvLMBN1bCJETiTihM3wvi1B2JX_duration = this.#_3bNvLMBN1bCJETiTihM3wvi1B2JX_duration;
         if (\\"duration\\" in values &&             values.duration != null) {
-          if (values.duration instanceof Temporal.Duration) {
+          if (isTemporalDuration(values.duration)) {
             // @ts-ignore: type is checked above.
             clone.#_3bNvLMBN1bCJETiTihM3wvi1B2JX_duration = [values.duration];
       
@@ -17189,7 +17193,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         }
       
         if (\\"created\\" in values &&             values.created != null) {
-          if (values.created instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.created)) {
             // @ts-ignore: type is checked above.
             this.#_3qzP3ukEZoUziK5FEiA1RhU4aqac = [values.created];
       
@@ -17290,7 +17294,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         }
       clone.#_3qzP3ukEZoUziK5FEiA1RhU4aqac = this.#_3qzP3ukEZoUziK5FEiA1RhU4aqac;
         if (\\"created\\" in values &&             values.created != null) {
-          if (values.created instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.created)) {
             // @ts-ignore: type is checked above.
             clone.#_3qzP3ukEZoUziK5FEiA1RhU4aqac = [values.created];
       
@@ -67910,7 +67914,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         }
       
         if (\\"closed\\" in values &&             values.closed != null) {
-          if (values.closed instanceof Temporal.Instant || typeof values.closed === \\"boolean\\") {
+          if (isTemporalInstant(values.closed) || typeof values.closed === \\"boolean\\") {
             // @ts-ignore: type is checked above.
             this.#_3KronwL8DiiKBRcJFKQPiEHm8xb6_closed = [values.closed];
       
@@ -68039,7 +68043,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         }
       clone.#_3KronwL8DiiKBRcJFKQPiEHm8xb6_closed = this.#_3KronwL8DiiKBRcJFKQPiEHm8xb6_closed;
         if (\\"closed\\" in values &&             values.closed != null) {
-          if (values.closed instanceof Temporal.Instant || typeof values.closed === \\"boolean\\") {
+          if (isTemporalInstant(values.closed) || typeof values.closed === \\"boolean\\") {
             // @ts-ignore: type is checked above.
             clone.#_3KronwL8DiiKBRcJFKQPiEHm8xb6_closed = [values.closed];
       
@@ -68646,7 +68650,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
     array = [];
     for (const v of this.#_3KronwL8DiiKBRcJFKQPiEHm8xb6_closed) {
       const element = (
-    v instanceof Temporal.Instant ? {
+    isTemporalInstant(v) ? {
         \\"@type\\": \\"http://www.w3.org/2001/XMLSchema#dateTime\\",
         \\"@value\\": v.toString(),
       } : { \\"@value\\": v }
@@ -79725,7 +79729,7 @@ proofs?: (DataIntegrityProof | URL)[];deleted?: Temporal.Instant | null;}
   ) {
   super(values, options);
         if (\\"deleted\\" in values &&             values.deleted != null) {
-          if (values.deleted instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.deleted)) {
             // @ts-ignore: type is checked above.
             this.#_8g8g4LiVMhFTXskuDEqx4ascxUr_deleted = [values.deleted];
       
@@ -79782,7 +79786,7 @@ proofs?: (DataIntegrityProof | URL)[];deleted?: Temporal.Instant | null;}
     }
   const clone = super.clone(values, options) as unknown as Tombstone;clone.#_8g8g4LiVMhFTXskuDEqx4ascxUr_deleted = this.#_8g8g4LiVMhFTXskuDEqx4ascxUr_deleted;
         if (\\"deleted\\" in values &&             values.deleted != null) {
-          if (values.deleted instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.deleted)) {
             // @ts-ignore: type is checked above.
             clone.#_8g8g4LiVMhFTXskuDEqx4ascxUr_deleted = [values.deleted];
       

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
@@ -18,6 +18,10 @@ import {
     LanguageString,
     type RemoteDocument,
 } from "@fedify/vocab-runtime";
+import {
+    isTemporalDuration,
+    isTemporalInstant,
+} from "@fedify/vocab-runtime/temporal";
 
 
 /** Describes an object of any kind. The Object type serves as the base type for
@@ -388,7 +392,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       
         if ("endTime" in values &&             values.endTime != null) {
-          if (values.endTime instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.endTime)) {
             // @ts-ignore: type is checked above.
             this.#_219RwDanjScTv5tYCjwGZVCM7KZ9_endTime = [values.endTime];
       
@@ -620,7 +624,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       
         if ("published" in values &&             values.published != null) {
-          if (values.published instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.published)) {
             // @ts-ignore: type is checked above.
             this.#_5e258TDXtuhaFRPZiGoDfEpjdMr_published = [values.published];
       
@@ -685,7 +689,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       
         if ("startTime" in values &&             values.startTime != null) {
-          if (values.startTime instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.startTime)) {
             // @ts-ignore: type is checked above.
             this.#_2w3Jmue4up8iVDUA51WZqomEF438_startTime = [values.startTime];
       
@@ -753,7 +757,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       
         if ("updated" in values &&             values.updated != null) {
-          if (values.updated instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.updated)) {
             // @ts-ignore: type is checked above.
             this.#_385aB7ySixcf5Un6z3VsWmThgCzQ_updated = [values.updated];
       
@@ -975,7 +979,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       
         if ("duration" in values &&             values.duration != null) {
-          if (values.duration instanceof Temporal.Duration) {
+          if (isTemporalDuration(values.duration)) {
             // @ts-ignore: type is checked above.
             this.#_3bNvLMBN1bCJETiTihM3wvi1B2JX_duration = [values.duration];
       
@@ -1298,7 +1302,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       clone.#_219RwDanjScTv5tYCjwGZVCM7KZ9_endTime = this.#_219RwDanjScTv5tYCjwGZVCM7KZ9_endTime;
         if ("endTime" in values &&             values.endTime != null) {
-          if (values.endTime instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.endTime)) {
             // @ts-ignore: type is checked above.
             clone.#_219RwDanjScTv5tYCjwGZVCM7KZ9_endTime = [values.endTime];
       
@@ -1536,7 +1540,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       clone.#_5e258TDXtuhaFRPZiGoDfEpjdMr_published = this.#_5e258TDXtuhaFRPZiGoDfEpjdMr_published;
         if ("published" in values &&             values.published != null) {
-          if (values.published instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.published)) {
             // @ts-ignore: type is checked above.
             clone.#_5e258TDXtuhaFRPZiGoDfEpjdMr_published = [values.published];
       
@@ -1601,7 +1605,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       clone.#_2w3Jmue4up8iVDUA51WZqomEF438_startTime = this.#_2w3Jmue4up8iVDUA51WZqomEF438_startTime;
         if ("startTime" in values &&             values.startTime != null) {
-          if (values.startTime instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.startTime)) {
             // @ts-ignore: type is checked above.
             clone.#_2w3Jmue4up8iVDUA51WZqomEF438_startTime = [values.startTime];
       
@@ -1670,7 +1674,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       clone.#_385aB7ySixcf5Un6z3VsWmThgCzQ_updated = this.#_385aB7ySixcf5Un6z3VsWmThgCzQ_updated;
         if ("updated" in values &&             values.updated != null) {
-          if (values.updated instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.updated)) {
             // @ts-ignore: type is checked above.
             clone.#_385aB7ySixcf5Un6z3VsWmThgCzQ_updated = [values.updated];
       
@@ -1896,7 +1900,7 @@ proofs?: (DataIntegrityProof | URL)[];}
         }
       clone.#_3bNvLMBN1bCJETiTihM3wvi1B2JX_duration = this.#_3bNvLMBN1bCJETiTihM3wvi1B2JX_duration;
         if ("duration" in values &&             values.duration != null) {
-          if (values.duration instanceof Temporal.Duration) {
+          if (isTemporalDuration(values.duration)) {
             // @ts-ignore: type is checked above.
             clone.#_3bNvLMBN1bCJETiTihM3wvi1B2JX_duration = [values.duration];
       
@@ -17191,7 +17195,7 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
         }
       
         if ("created" in values &&             values.created != null) {
-          if (values.created instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.created)) {
             // @ts-ignore: type is checked above.
             this.#_3qzP3ukEZoUziK5FEiA1RhU4aqac = [values.created];
       
@@ -17292,7 +17296,7 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
         }
       clone.#_3qzP3ukEZoUziK5FEiA1RhU4aqac = this.#_3qzP3ukEZoUziK5FEiA1RhU4aqac;
         if ("created" in values &&             values.created != null) {
-          if (values.created instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.created)) {
             // @ts-ignore: type is checked above.
             clone.#_3qzP3ukEZoUziK5FEiA1RhU4aqac = [values.created];
       
@@ -67912,7 +67916,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         }
       
         if ("closed" in values &&             values.closed != null) {
-          if (values.closed instanceof Temporal.Instant || typeof values.closed === "boolean") {
+          if (isTemporalInstant(values.closed) || typeof values.closed === "boolean") {
             // @ts-ignore: type is checked above.
             this.#_3KronwL8DiiKBRcJFKQPiEHm8xb6_closed = [values.closed];
       
@@ -68041,7 +68045,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         }
       clone.#_3KronwL8DiiKBRcJFKQPiEHm8xb6_closed = this.#_3KronwL8DiiKBRcJFKQPiEHm8xb6_closed;
         if ("closed" in values &&             values.closed != null) {
-          if (values.closed instanceof Temporal.Instant || typeof values.closed === "boolean") {
+          if (isTemporalInstant(values.closed) || typeof values.closed === "boolean") {
             // @ts-ignore: type is checked above.
             clone.#_3KronwL8DiiKBRcJFKQPiEHm8xb6_closed = [values.closed];
       
@@ -68648,7 +68652,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
     array = [];
     for (const v of this.#_3KronwL8DiiKBRcJFKQPiEHm8xb6_closed) {
       const element = (
-    v instanceof Temporal.Instant ? {
+    isTemporalInstant(v) ? {
         "@type": "http://www.w3.org/2001/XMLSchema#dateTime",
         "@value": v.toString(),
       } : { "@value": v }
@@ -79727,7 +79731,7 @@ proofs?: (DataIntegrityProof | URL)[];deleted?: Temporal.Instant | null;}
   ) {
   super(values, options);
         if ("deleted" in values &&             values.deleted != null) {
-          if (values.deleted instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.deleted)) {
             // @ts-ignore: type is checked above.
             this.#_8g8g4LiVMhFTXskuDEqx4ascxUr_deleted = [values.deleted];
       
@@ -79784,7 +79788,7 @@ proofs?: (DataIntegrityProof | URL)[];deleted?: Temporal.Instant | null;}
     }
   const clone = super.clone(values, options) as unknown as Tombstone;clone.#_8g8g4LiVMhFTXskuDEqx4ascxUr_deleted = this.#_8g8g4LiVMhFTXskuDEqx4ascxUr_deleted;
         if ("deleted" in values &&             values.deleted != null) {
-          if (values.deleted instanceof Temporal.Instant) {
+          if (isTemporalInstant(values.deleted)) {
             // @ts-ignore: type is checked above.
             clone.#_8g8g4LiVMhFTXskuDEqx4ascxUr_deleted = [values.deleted];
       

--- a/packages/vocab-tools/src/class.ts
+++ b/packages/vocab-tools/src/class.ts
@@ -131,11 +131,13 @@ export async function* generateClasses(
     getDocumentLoader,
     importMultibaseKey,
     importPem,
-    isTemporalDuration,
-    isTemporalInstant,
     LanguageString,
     type RemoteDocument,
 } from "@fedify/vocab-runtime";\n`;
+  yield `import {
+    isTemporalDuration,
+    isTemporalInstant,
+} from "@fedify/vocab-runtime/temporal";\n`;
   yield "\n\n";
   const sorted = sortTopologically(types);
   for (const typeUri of sorted) {

--- a/packages/vocab-tools/src/class.ts
+++ b/packages/vocab-tools/src/class.ts
@@ -131,6 +131,8 @@ export async function* generateClasses(
     getDocumentLoader,
     importMultibaseKey,
     importPem,
+    isTemporalDuration,
+    isTemporalInstant,
     LanguageString,
     type RemoteDocument,
 } from "@fedify/vocab-runtime";\n`;

--- a/packages/vocab-tools/src/type.ts
+++ b/packages/vocab-tools/src/type.ts
@@ -185,7 +185,7 @@ const scalarTypes: Record<string, ScalarType> = {
   "http://www.w3.org/2001/XMLSchema#dateTime": {
     name: "Temporal.Instant",
     typeGuard(v) {
-      return `${v} instanceof Temporal.Instant`;
+      return `isTemporalInstant(${v})`;
     },
     encoder(v) {
       return `{
@@ -215,7 +215,7 @@ const scalarTypes: Record<string, ScalarType> = {
   "http://www.w3.org/2001/XMLSchema#duration": {
     name: "Temporal.Duration",
     typeGuard(v) {
-      return `${v} instanceof Temporal.Duration`;
+      return `isTemporalDuration(${v})`;
     },
     encoder(v) {
       return `{

--- a/packages/vocab/src/vocab.test.ts
+++ b/packages/vocab/src/vocab.test.ts
@@ -69,6 +69,35 @@ test("new Object()", () => {
   );
 });
 
+test(
+  // Regression test for
+  // https://github.com/fedify-dev/fedify/issues/767:
+  // values produced by a `Temporal` implementation other than the one bundled
+  // with Fedify (e.g. Node.js 26+ native `Temporal`) must be accepted as
+  // long as they conform to the spec-mandated `Symbol.toStringTag`.
+  "new Object() accepts foreign Temporal.Instant (issue #767)",
+  () => {
+    const foreignInstant = globalThis.Object.create(
+      globalThis.Object.prototype,
+      { [Symbol.toStringTag]: { value: "Temporal.Instant" } },
+    ) as Temporal.Instant;
+    const obj = new Object({ published: foreignInstant });
+    ok(obj.published === foreignInstant);
+  },
+);
+
+test(
+  "Object.clone() accepts foreign Temporal.Instant (issue #767)",
+  () => {
+    const foreignInstant = globalThis.Object.create(
+      globalThis.Object.prototype,
+      { [Symbol.toStringTag]: { value: "Temporal.Instant" } },
+    ) as Temporal.Instant;
+    const obj = new Object({}).clone({ published: foreignInstant });
+    ok(obj.published === foreignInstant);
+  },
+);
+
 test("Object.clone()", () => {
   const obj = new Object({
     id: new URL("https://example.com/"),

--- a/packages/vocab/src/vocab.test.ts
+++ b/packages/vocab/src/vocab.test.ts
@@ -79,7 +79,10 @@ test(
   () => {
     const foreignInstant = globalThis.Object.create(
       globalThis.Object.prototype,
-      { [Symbol.toStringTag]: { value: "Temporal.Instant" } },
+      {
+        [Symbol.toStringTag]: { value: "Temporal.Instant" },
+        epochNanoseconds: { value: 0n },
+      },
     ) as Temporal.Instant;
     const obj = new Object({ published: foreignInstant });
     ok(obj.published === foreignInstant);
@@ -91,7 +94,10 @@ test(
   () => {
     const foreignInstant = globalThis.Object.create(
       globalThis.Object.prototype,
-      { [Symbol.toStringTag]: { value: "Temporal.Instant" } },
+      {
+        [Symbol.toStringTag]: { value: "Temporal.Instant" },
+        epochNanoseconds: { value: 0n },
+      },
     ) as Temporal.Instant;
     const obj = new Object({}).clone({ published: foreignInstant });
     ok(obj.published === foreignInstant);

--- a/packages/vocab/src/vocab.test.ts
+++ b/packages/vocab/src/vocab.test.ts
@@ -82,6 +82,7 @@ test(
       {
         [Symbol.toStringTag]: { value: "Temporal.Instant" },
         epochNanoseconds: { value: 0n },
+        toString: { value: () => "1970-01-01T00:00:00Z" },
       },
     ) as Temporal.Instant;
     const obj = new Object({ published: foreignInstant });
@@ -97,6 +98,7 @@ test(
       {
         [Symbol.toStringTag]: { value: "Temporal.Instant" },
         epochNanoseconds: { value: 0n },
+        toString: { value: () => "1970-01-01T00:00:00Z" },
       },
     ) as Temporal.Instant;
     const obj = new Object({}).clone({ published: foreignInstant });

--- a/packages/vocab/tsdown.config.ts
+++ b/packages/vocab/tsdown.config.ts
@@ -19,17 +19,14 @@ export default [
     format: ["esm", "cjs"],
     platform: "neutral",
     external: [/^node:/],
-    outputOptions(outputOptions, format) {
-      if (format === "cjs") {
-        outputOptions.intro = `
-          const { Temporal } = require("@js-temporal/polyfill");
-        `;
-      } else {
-        outputOptions.intro = `
-          import { Temporal } from "@js-temporal/polyfill";
-        `;
-      }
-      return outputOptions;
+    banner({ format }) {
+      const js = format === "cjs"
+        ? `const { Temporal } = require("@js-temporal/polyfill");`
+        : `import { Temporal } from "@js-temporal/polyfill";`;
+      return {
+        js,
+        dts: `/// <reference lib="esnext.temporal" />`,
+      };
     },
   }),
   defineConfig({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,8 +142,8 @@ catalogs:
       specifier: ^0.21.6
       version: 0.21.6
     typescript:
-      specifier: ^5.9.2
-      version: 5.9.3
+      specifier: ^6.0.0
+      version: 6.0.3
     urlpattern-polyfill:
       specifier: ^10.1.0
       version: 10.1.0
@@ -255,7 +255,7 @@ importers:
         version: 8.55.0
       '@shikijs/vitepress-twoslash':
         specifier: ^1.24.4
-        version: 1.29.2(typescript@5.9.3)
+        version: 1.29.2(typescript@6.0.3)
       '@teidesu/deno-types':
         specifier: ^2.1.4
         version: 2.1.10
@@ -327,10 +327,10 @@ importers:
         version: 4.0.4
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       vitepress:
         specifier: ^1.6.3
-        version: 1.6.3(@algolia/client-search@5.29.0)(@types/node@22.19.1)(@types/react@18.3.23)(lightningcss@1.30.1)(postcss@8.5.6)(search-insights@2.17.3)(typescript@5.9.3)
+        version: 1.6.3(@algolia/client-search@5.29.0)(@types/node@22.19.1)(@types/react@18.3.23)(lightningcss@1.30.1)(postcss@8.5.6)(search-insights@2.17.3)(typescript@6.0.3)
       vitepress-plugin-group-icons:
         specifier: ^1.3.5
         version: 1.6.1(markdown-it@14.1.0)(vite@7.1.3(@types/node@22.19.1)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.8.1))
@@ -339,7 +339,7 @@ importers:
         version: 1.6.0
       vitepress-plugin-mermaid:
         specifier: ^2.0.17
-        version: 2.0.17(mermaid@11.7.0)(vitepress@1.6.3(@algolia/client-search@5.29.0)(@types/node@22.19.1)(@types/react@18.3.23)(lightningcss@1.30.1)(postcss@8.5.6)(search-insights@2.17.3)(typescript@5.9.3))
+        version: 2.0.17(mermaid@11.7.0)(vitepress@1.6.3(@algolia/client-search@5.29.0)(@types/node@22.19.1)(@types/react@18.3.23)(lightningcss@1.30.1)(postcss@8.5.6)(search-insights@2.17.3)(typescript@6.0.3))
       x-forwarded-fetch:
         specifier: ^0.2.0
         version: 0.2.0
@@ -358,7 +358,7 @@ importers:
     devDependencies:
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       wrangler:
         specifier: ^4.18.0
         version: 4.22.0(@cloudflare/workers-types@4.20251221.0)
@@ -376,7 +376,7 @@ importers:
         version: link:../../packages/vocab
       elysia:
         specifier: 'catalog:'
-        version: 1.3.8(exact-mirror@0.1.3(@sinclair/typebox@0.34.38))(file-type@21.0.0)(typescript@5.9.3)
+        version: 1.3.8(exact-mirror@0.1.3(@sinclair/typebox@0.34.38))(file-type@21.0.0)(typescript@6.0.3)
     devDependencies:
       bun-types:
         specifier: ^1.2.19
@@ -556,7 +556,7 @@ importers:
         version: 8.57.1
       eslint-config-next:
         specifier: 15.0.0-canary.136
-        version: 15.0.0-canary.136(eslint@8.57.1)(typescript@5.9.3)
+        version: 15.0.0-canary.136(eslint@8.57.1)(typescript@6.0.3)
       postcss:
         specifier: ^8
         version: 8.5.6
@@ -565,7 +565,7 @@ importers:
         version: 3.4.17
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   examples/next15-app-router:
     dependencies:
@@ -608,13 +608,13 @@ importers:
         version: 9.32.0(jiti@2.5.1)
       eslint-config-next:
         specifier: 15.3.1
-        version: 15.3.1(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3)
+        version: 15.3.1(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3)
       tailwindcss:
         specifier: ^4
         version: 4.1.11
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   examples/sveltekit-sample:
     dependencies:
@@ -718,10 +718,10 @@ importers:
         version: 0.10.7
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/cfworkers:
     dependencies:
@@ -737,10 +737,10 @@ importers:
         version: 0.8.71(@cloudflare/workers-types@4.20251221.0)(@vitest/runner@3.2.4)(@vitest/snapshot@3.2.4)(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.8.1))
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       vitest:
         specifier: ~3.2.0
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.0)(jiti@2.5.1)(lightningcss@1.30.1)(tsx@4.20.3)(yaml@2.8.1)
@@ -860,7 +860,7 @@ importers:
         version: 0.8.16
       valibot:
         specifier: ^1.2.0
-        version: 1.2.0(typescript@5.9.3)
+        version: 1.2.0(typescript@6.0.3)
     devDependencies:
       '@types/bun':
         specifier: 'catalog:'
@@ -870,10 +870,10 @@ importers:
         version: 22.19.1
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/create:
     dependencies:
@@ -895,10 +895,10 @@ importers:
         version: 22.19.1
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/debugger:
     dependencies:
@@ -929,10 +929,10 @@ importers:
     devDependencies:
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/elysia:
     dependencies:
@@ -941,17 +941,17 @@ importers:
         version: link:../fedify
       elysia:
         specifier: ^1.3.6
-        version: 1.3.8(exact-mirror@0.1.3(@sinclair/typebox@0.34.38))(file-type@21.0.0)(typescript@5.9.3)
+        version: 1.3.8(exact-mirror@0.1.3(@sinclair/typebox@0.34.38))(file-type@21.0.0)(typescript@6.0.3)
     devDependencies:
       bun-types:
         specifier: ^1.2.19
         version: 1.2.19(@types/react@19.1.8)
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/express:
     dependencies:
@@ -970,10 +970,10 @@ importers:
         version: 22.19.1
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/fastify:
     dependencies:
@@ -992,10 +992,10 @@ importers:
         version: 22.19.1
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/fedify:
     dependencies:
@@ -1074,13 +1074,13 @@ importers:
         version: 4.20250617.4
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       tsx:
         specifier: ^4.19.4
         version: 4.20.3
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       wrangler:
         specifier: ^4.17.0
         version: 4.22.0(@cloudflare/workers-types@4.20251221.0)
@@ -1105,10 +1105,10 @@ importers:
         version: 0.5.1
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       urlpattern-polyfill:
         specifier: 'catalog:'
         version: 10.1.0
@@ -1124,10 +1124,10 @@ importers:
     devDependencies:
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/hono:
     dependencies:
@@ -1140,10 +1140,10 @@ importers:
     devDependencies:
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/init:
     dependencies:
@@ -1177,10 +1177,10 @@ importers:
         version: 22.19.1
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/koa:
     dependencies:
@@ -1199,10 +1199,10 @@ importers:
         version: 22.19.1
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/lint:
     dependencies:
@@ -1214,10 +1214,10 @@ importers:
         version: 1.20.0
       '@typescript-eslint/parser':
         specifier: ^8.49.0
-        version: 8.50.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3)
+        version: 8.50.0(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3)
       '@typescript-eslint/utils':
         specifier: ^8.0.0
-        version: 8.41.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3)
+        version: 8.41.0(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3)
     devDependencies:
       '@types/eslint':
         specifier: ^9.0.0
@@ -1230,10 +1230,10 @@ importers:
         version: 9.32.0(jiti@2.5.1)
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/nestjs:
     dependencies:
@@ -1255,10 +1255,10 @@ importers:
         version: 22.19.1
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/next:
     dependencies:
@@ -1271,10 +1271,10 @@ importers:
     devDependencies:
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/postgres:
     dependencies:
@@ -1302,10 +1302,10 @@ importers:
         version: '@jsr/std__async@1.0.13'
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/redis:
     dependencies:
@@ -1336,10 +1336,10 @@ importers:
         version: 22.19.1
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/relay:
     dependencies:
@@ -1361,10 +1361,10 @@ importers:
         version: link:../vocab-runtime
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
       urlpattern-polyfill:
         specifier: 'catalog:'
         version: 10.1.0
@@ -1392,10 +1392,10 @@ importers:
         version: '@jsr/std__async@1.0.13'
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/sveltekit:
     dependencies:
@@ -1408,10 +1408,10 @@ importers:
     devDependencies:
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/testing:
     dependencies:
@@ -1436,10 +1436,10 @@ importers:
         version: '@jsr/std__async@1.0.13'
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/vocab:
     dependencies:
@@ -1491,13 +1491,16 @@ importers:
         version: 12.6.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/vocab-runtime:
     dependencies:
+      '@js-temporal/polyfill':
+        specifier: 'catalog:'
+        version: 0.5.1
       '@logtape/logtape':
         specifier: 'catalog:'
         version: 2.0.0
@@ -1528,10 +1531,10 @@ importers:
         version: 12.6.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/vocab-tools:
     dependencies:
@@ -1553,10 +1556,10 @@ importers:
         version: 22.19.1
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
   packages/webfinger:
     dependencies:
@@ -1584,10 +1587,10 @@ importers:
         version: 12.6.0
       tsdown:
         specifier: 'catalog:'
-        version: 0.21.6(typescript@5.9.3)
+        version: 0.21.6(typescript@6.0.3)
       typescript:
         specifier: 'catalog:'
-        version: 5.9.3
+        version: 6.0.3
 
 packages:
 
@@ -9207,8 +9210,8 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+  typescript@6.0.3:
+    resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
 
@@ -12260,12 +12263,12 @@ snapshots:
       '@shikijs/core': 2.5.0
       '@shikijs/types': 2.5.0
 
-  '@shikijs/twoslash@3.7.0(typescript@5.9.3)':
+  '@shikijs/twoslash@3.7.0(typescript@6.0.3)':
     dependencies:
       '@shikijs/core': 3.7.0
       '@shikijs/types': 3.7.0
-      twoslash: 0.3.1(typescript@5.9.3)
-      typescript: 5.9.3
+      twoslash: 0.3.1(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -12284,17 +12287,17 @@ snapshots:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 
-  '@shikijs/vitepress-twoslash@1.29.2(typescript@5.9.3)':
+  '@shikijs/vitepress-twoslash@1.29.2(typescript@6.0.3)':
     dependencies:
-      '@shikijs/twoslash': 3.7.0(typescript@5.9.3)
-      floating-vue: 5.2.2(vue@3.5.17(typescript@5.9.3))
+      '@shikijs/twoslash': 3.7.0(typescript@6.0.3)
+      floating-vue: 5.2.2(vue@3.5.17(typescript@6.0.3))
       mdast-util-from-markdown: 2.0.2
       mdast-util-gfm: 3.1.0
       mdast-util-to-hast: 13.2.0
       shiki: 1.29.2
-      twoslash: 0.2.12(typescript@5.9.3)
-      twoslash-vue: 0.2.12(typescript@5.9.3)
-      vue: 3.5.17(typescript@5.9.3)
+      twoslash: 0.2.12(typescript@6.0.3)
+      twoslash-vue: 0.2.12(typescript@6.0.3)
+      vue: 3.5.17(typescript@6.0.3)
     transitivePeerDependencies:
       - '@nuxt/kit'
       - supports-color
@@ -12864,38 +12867,38 @@ snapshots:
 
   '@types/wrap-ansi@3.0.0': {}
 
-  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 7.18.0
-      '@typescript-eslint/type-utils': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 7.18.0(eslint@8.57.1)(typescript@6.0.3)
+      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 7.18.0
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      ts-api-utils: 1.4.3(typescript@5.9.3)
+      ts-api-utils: 1.4.3(typescript@6.0.3)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3))(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3))(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3)
       '@typescript-eslint/scope-manager': 8.38.0
-      '@typescript-eslint/type-utils': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.38.0
       eslint: 9.32.0(jiti@2.5.1)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
-      ts-api-utils: 2.1.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.1.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -12932,28 +12935,28 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 7.18.0
       debug: 4.4.1
       eslint: 8.57.1
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.38.0
       '@typescript-eslint/types': 8.38.0
-      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.38.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.38.0
       debug: 4.4.1
       eslint: 9.32.0(jiti@2.5.1)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -12969,15 +12972,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.50.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.50.0(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.50.0
       '@typescript-eslint/types': 8.50.0
-      '@typescript-eslint/typescript-estree': 8.50.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.50.0(typescript@6.0.3)
       '@typescript-eslint/visitor-keys': 8.50.0
       debug: 4.4.1
       eslint: 9.32.0(jiti@2.5.1)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -12993,12 +12996,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.38.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.38.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.41.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.41.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.41.0
       debug: 4.4.3
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -13011,21 +13014,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.41.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.41.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.41.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.41.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.41.0
       debug: 4.4.1
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.50.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.50.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.50.0(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.50.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.50.0
       debug: 4.4.1
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -13063,47 +13066,47 @@ snapshots:
       '@typescript-eslint/types': 8.59.0
       '@typescript-eslint/visitor-keys': 8.59.0
 
-  '@typescript-eslint/tsconfig-utils@8.38.0(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.38.0(typescript@6.0.3)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   '@typescript-eslint/tsconfig-utils@8.41.0(typescript@5.9.2)':
     dependencies:
       typescript: 5.9.2
 
-  '@typescript-eslint/tsconfig-utils@8.41.0(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.41.0(typescript@6.0.3)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
-  '@typescript-eslint/tsconfig-utils@8.50.0(typescript@5.9.3)':
+  '@typescript-eslint/tsconfig-utils@8.50.0(typescript@6.0.3)':
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   '@typescript-eslint/tsconfig-utils@8.59.0(typescript@5.9.2)':
     dependencies:
       typescript: 5.9.2
 
-  '@typescript-eslint/type-utils@7.18.0(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@7.18.0(eslint@8.57.1)(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@6.0.3)
       debug: 4.4.1
       eslint: 8.57.1
-      ts-api-utils: 1.4.3(typescript@5.9.3)
+      ts-api-utils: 1.4.3(typescript@6.0.3)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.38.0
-      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.38.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3)
       debug: 4.4.1
       eslint: 9.32.0(jiti@2.5.1)
-      ts-api-utils: 2.1.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.1.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -13141,7 +13144,7 @@ snapshots:
 
   '@typescript-eslint/types@8.59.0': {}
 
-  '@typescript-eslint/typescript-estree@7.18.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@7.18.0(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
@@ -13150,16 +13153,16 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.2
-      ts-api-utils: 1.4.3(typescript@5.9.3)
+      ts-api-utils: 1.4.3(typescript@6.0.3)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.38.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.38.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.38.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.38.0(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.38.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.38.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.38.0
       '@typescript-eslint/visitor-keys': 8.38.0
       debug: 4.4.1
@@ -13167,8 +13170,8 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.2
-      ts-api-utils: 2.1.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.1.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -13188,10 +13191,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.41.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.41.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.41.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.41.0(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.41.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.41.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.41.0
       '@typescript-eslint/visitor-keys': 8.41.0
       debug: 4.4.1
@@ -13199,23 +13202,23 @@ snapshots:
       is-glob: 4.0.3
       minimatch: 9.0.5
       semver: 7.7.2
-      ts-api-utils: 2.1.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.1.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/typescript-estree@8.50.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.50.0(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.50.0(typescript@5.9.3)
-      '@typescript-eslint/tsconfig-utils': 8.50.0(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.50.0(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.50.0(typescript@6.0.3)
       '@typescript-eslint/types': 8.50.0
       '@typescript-eslint/visitor-keys': 8.50.0
       debug: 4.4.1
       minimatch: 9.0.5
       semver: 7.7.2
       tinyglobby: 0.2.15
-      ts-api-utils: 2.1.0(typescript@5.9.3)
-      typescript: 5.9.3
+      ts-api-utils: 2.1.0(typescript@6.0.3)
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -13234,25 +13237,25 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@7.18.0(eslint@8.57.1)(typescript@5.9.3)':
+  '@typescript-eslint/utils@7.18.0(eslint@8.57.1)(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@8.57.1)
       '@typescript-eslint/scope-manager': 7.18.0
       '@typescript-eslint/types': 7.18.0
-      '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 7.18.0(typescript@6.0.3)
       eslint: 8.57.1
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  '@typescript-eslint/utils@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.32.0(jiti@2.5.1))
       '@typescript-eslint/scope-manager': 8.38.0
       '@typescript-eslint/types': 8.38.0
-      '@typescript-eslint/typescript-estree': 8.38.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.38.0(typescript@6.0.3)
       eslint: 9.32.0(jiti@2.5.1)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -13267,14 +13270,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.41.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.41.0(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.7.0(eslint@9.32.0(jiti@2.5.1))
       '@typescript-eslint/scope-manager': 8.41.0
       '@typescript-eslint/types': 8.41.0
-      '@typescript-eslint/typescript-estree': 8.41.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.41.0(typescript@6.0.3)
       eslint: 9.32.0(jiti@2.5.1)
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -13314,10 +13317,10 @@ snapshots:
       '@typescript-eslint/types': 8.59.0
       eslint-visitor-keys: 5.0.1
 
-  '@typescript/vfs@1.6.1(typescript@5.9.3)':
+  '@typescript/vfs@1.6.1(typescript@6.0.3)':
     dependencies:
       debug: 4.4.1
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -13382,10 +13385,10 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-vue@5.2.4(vite@5.4.19(@types/node@22.19.1)(lightningcss@1.30.1))(vue@3.5.17(typescript@5.9.3))':
+  '@vitejs/plugin-vue@5.2.4(vite@5.4.19(@types/node@22.19.1)(lightningcss@1.30.1))(vue@3.5.17(typescript@6.0.3))':
     dependencies:
       vite: 5.4.19(@types/node@22.19.1)(lightningcss@1.30.1)
-      vue: 3.5.17(typescript@5.9.3)
+      vue: 3.5.17(typescript@6.0.3)
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -13488,7 +13491,7 @@ snapshots:
     dependencies:
       rfdc: 1.4.1
 
-  '@vue/language-core@2.1.10(typescript@5.9.3)':
+  '@vue/language-core@2.1.10(typescript@6.0.3)':
     dependencies:
       '@volar/language-core': 2.4.15
       '@vue/compiler-dom': 3.5.17
@@ -13499,7 +13502,7 @@ snapshots:
       muggle-string: 0.4.1
       path-browserify: 1.0.1
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   '@vue/reactivity@3.5.17':
     dependencies:
@@ -13517,28 +13520,28 @@ snapshots:
       '@vue/shared': 3.5.17
       csstype: 3.1.3
 
-  '@vue/server-renderer@3.5.17(vue@3.5.17(typescript@5.9.3))':
+  '@vue/server-renderer@3.5.17(vue@3.5.17(typescript@6.0.3))':
     dependencies:
       '@vue/compiler-ssr': 3.5.17
       '@vue/shared': 3.5.17
-      vue: 3.5.17(typescript@5.9.3)
+      vue: 3.5.17(typescript@6.0.3)
 
   '@vue/shared@3.5.17': {}
 
-  '@vueuse/core@12.8.2(typescript@5.9.3)':
+  '@vueuse/core@12.8.2(typescript@6.0.3)':
     dependencies:
       '@types/web-bluetooth': 0.0.21
       '@vueuse/metadata': 12.8.2
-      '@vueuse/shared': 12.8.2(typescript@5.9.3)
-      vue: 3.5.17(typescript@5.9.3)
+      '@vueuse/shared': 12.8.2(typescript@6.0.3)
+      vue: 3.5.17(typescript@6.0.3)
     transitivePeerDependencies:
       - typescript
 
-  '@vueuse/integrations@12.8.2(focus-trap@7.6.5)(typescript@5.9.3)':
+  '@vueuse/integrations@12.8.2(focus-trap@7.6.5)(typescript@6.0.3)':
     dependencies:
-      '@vueuse/core': 12.8.2(typescript@5.9.3)
-      '@vueuse/shared': 12.8.2(typescript@5.9.3)
-      vue: 3.5.17(typescript@5.9.3)
+      '@vueuse/core': 12.8.2(typescript@6.0.3)
+      '@vueuse/shared': 12.8.2(typescript@6.0.3)
+      vue: 3.5.17(typescript@6.0.3)
     optionalDependencies:
       focus-trap: 7.6.5
     transitivePeerDependencies:
@@ -13546,9 +13549,9 @@ snapshots:
 
   '@vueuse/metadata@12.8.2': {}
 
-  '@vueuse/shared@12.8.2(typescript@5.9.3)':
+  '@vueuse/shared@12.8.2(typescript@6.0.3)':
     dependencies:
-      vue: 3.5.17(typescript@5.9.3)
+      vue: 3.5.17(typescript@6.0.3)
     transitivePeerDependencies:
       - typescript
 
@@ -14417,13 +14420,13 @@ snapshots:
 
   electron-to-chromium@1.5.343: {}
 
-  elysia@1.3.8(exact-mirror@0.1.3(@sinclair/typebox@0.34.38))(file-type@21.0.0)(typescript@5.9.3):
+  elysia@1.3.8(exact-mirror@0.1.3(@sinclair/typebox@0.34.38))(file-type@21.0.0)(typescript@6.0.3):
     dependencies:
       cookie: 1.0.2
       exact-mirror: 0.1.3(@sinclair/typebox@0.34.38)
       fast-decode-uri-component: 1.0.1
       file-type: 21.0.0
-      typescript: 5.9.3
+      typescript: 6.0.3
     optionalDependencies:
       '@sinclair/typebox': 0.34.38
       openapi-types: 12.1.3
@@ -14660,41 +14663,41 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-next@15.0.0-canary.136(eslint@8.57.1)(typescript@5.9.3):
+  eslint-config-next@15.0.0-canary.136(eslint@8.57.1)(typescript@6.0.3):
     dependencies:
       '@next/eslint-plugin-next': 15.0.0-canary.136
       '@rushstack/eslint-patch': 1.12.0
-      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)(typescript@5.9.3)
-      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@6.0.3))(eslint@8.57.1)(typescript@6.0.3)
+      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@6.0.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - eslint-plugin-import-x
       - supports-color
 
-  eslint-config-next@15.3.1(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3):
+  eslint-config-next@15.3.1(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3):
     dependencies:
       '@next/eslint-plugin-next': 15.3.1
       '@rushstack/eslint-patch': 1.12.0
-      '@typescript-eslint/eslint-plugin': 8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3))(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3)
+      '@typescript-eslint/eslint-plugin': 8.38.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3))(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3)
       eslint: 9.32.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.32.0(jiti@2.5.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.5.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.32.0(jiti@2.5.1))
       eslint-plugin-react: 7.37.5(eslint@9.32.0(jiti@2.5.1))
       eslint-plugin-react-hooks: 5.2.0(eslint@9.32.0(jiti@2.5.1))
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - eslint-plugin-import-x
@@ -14758,7 +14761,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -14773,26 +14776,26 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.5.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.5.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@6.0.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.5.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.5.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3)
       eslint: 9.32.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.32.0(jiti@2.5.1))
@@ -14810,7 +14813,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -14821,7 +14824,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -14833,13 +14836,13 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@5.9.3)
+      '@typescript-eslint/parser': 7.18.0(eslint@8.57.1)(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.5.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.5.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -14850,7 +14853,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.32.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.5.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.5.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -14862,7 +14865,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.38.0(eslint@9.32.0(jiti@2.5.1))(typescript@6.0.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -15373,11 +15376,11 @@ snapshots:
 
   flatted@3.3.3: {}
 
-  floating-vue@5.2.2(vue@3.5.17(typescript@5.9.3)):
+  floating-vue@5.2.2(vue@3.5.17(typescript@6.0.3)):
     dependencies:
       '@floating-ui/dom': 1.1.1
-      vue: 3.5.17(typescript@5.9.3)
-      vue-resize: 2.0.0-alpha.1(vue@3.5.17(typescript@5.9.3))
+      vue: 3.5.17(typescript@6.0.3)
+      vue-resize: 2.0.0-alpha.1(vue@3.5.17(typescript@6.0.3))
 
   focus-trap@7.6.5:
     dependencies:
@@ -17404,7 +17407,7 @@ snapshots:
 
   robust-predicates@3.0.2: {}
 
-  rolldown-plugin-dts@0.23.1(rolldown@1.0.0-rc.12)(typescript@5.9.3):
+  rolldown-plugin-dts@0.23.1(rolldown@1.0.0-rc.12)(typescript@6.0.3):
     dependencies:
       '@babel/generator': 8.0.0-rc.3
       '@babel/helper-validator-identifier': 8.0.0-rc.3
@@ -17417,7 +17420,7 @@ snapshots:
       obug: 2.1.1
       rolldown: 1.0.0-rc.12
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - oxc-resolver
 
@@ -18122,17 +18125,17 @@ snapshots:
 
   trough@2.2.0: {}
 
-  ts-api-utils@1.4.3(typescript@5.9.3):
+  ts-api-utils@1.4.3(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   ts-api-utils@2.1.0(typescript@5.9.2):
     dependencies:
       typescript: 5.9.2
 
-  ts-api-utils@2.1.0(typescript@5.9.3):
+  ts-api-utils@2.1.0(typescript@6.0.3):
     dependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   ts-api-utils@2.5.0(typescript@5.9.2):
     dependencies:
@@ -18149,7 +18152,7 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tsdown@0.21.6(typescript@5.9.3):
+  tsdown@0.21.6(typescript@6.0.3):
     dependencies:
       ansis: 4.2.0
       cac: 7.0.0
@@ -18160,7 +18163,7 @@ snapshots:
       obug: 2.1.1
       picomatch: 4.0.4
       rolldown: 1.0.0-rc.12
-      rolldown-plugin-dts: 0.23.1(rolldown@1.0.0-rc.12)(typescript@5.9.3)
+      rolldown-plugin-dts: 0.23.1(rolldown@1.0.0-rc.12)(typescript@6.0.3)
       semver: 7.7.4
       tinyexec: 1.0.4
       tinyglobby: 0.2.15
@@ -18168,7 +18171,7 @@ snapshots:
       unconfig-core: 7.5.0
       unrun: 0.2.34
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - '@ts-macro/tsc'
       - '@typescript/native-preview'
@@ -18191,28 +18194,28 @@ snapshots:
 
   twoslash-protocol@0.3.1: {}
 
-  twoslash-vue@0.2.12(typescript@5.9.3):
+  twoslash-vue@0.2.12(typescript@6.0.3):
     dependencies:
-      '@vue/language-core': 2.1.10(typescript@5.9.3)
-      twoslash: 0.2.12(typescript@5.9.3)
+      '@vue/language-core': 2.1.10(typescript@6.0.3)
+      twoslash: 0.2.12(typescript@6.0.3)
       twoslash-protocol: 0.2.12
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  twoslash@0.2.12(typescript@5.9.3):
+  twoslash@0.2.12(typescript@6.0.3):
     dependencies:
-      '@typescript/vfs': 1.6.1(typescript@5.9.3)
+      '@typescript/vfs': 1.6.1(typescript@6.0.3)
       twoslash-protocol: 0.2.12
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  twoslash@0.3.1(typescript@5.9.3):
+  twoslash@0.3.1(typescript@6.0.3):
     dependencies:
-      '@typescript/vfs': 1.6.1(typescript@5.9.3)
+      '@typescript/vfs': 1.6.1(typescript@6.0.3)
       twoslash-protocol: 0.3.1
-      typescript: 5.9.3
+      typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
@@ -18294,7 +18297,7 @@ snapshots:
 
   typescript@5.9.2: {}
 
-  typescript@5.9.3: {}
+  typescript@6.0.3: {}
 
   uc.micro@2.1.0: {}
 
@@ -18448,9 +18451,9 @@ snapshots:
 
   uuid@11.1.0: {}
 
-  valibot@1.2.0(typescript@5.9.3):
+  valibot@1.2.0(typescript@6.0.3):
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   vary@1.1.2: {}
 
@@ -18560,14 +18563,14 @@ snapshots:
       - '@75lb/nature'
       - supports-color
 
-  vitepress-plugin-mermaid@2.0.17(mermaid@11.7.0)(vitepress@1.6.3(@algolia/client-search@5.29.0)(@types/node@22.19.1)(@types/react@18.3.23)(lightningcss@1.30.1)(postcss@8.5.6)(search-insights@2.17.3)(typescript@5.9.3)):
+  vitepress-plugin-mermaid@2.0.17(mermaid@11.7.0)(vitepress@1.6.3(@algolia/client-search@5.29.0)(@types/node@22.19.1)(@types/react@18.3.23)(lightningcss@1.30.1)(postcss@8.5.6)(search-insights@2.17.3)(typescript@6.0.3)):
     dependencies:
       mermaid: 11.7.0
-      vitepress: 1.6.3(@algolia/client-search@5.29.0)(@types/node@22.19.1)(@types/react@18.3.23)(lightningcss@1.30.1)(postcss@8.5.6)(search-insights@2.17.3)(typescript@5.9.3)
+      vitepress: 1.6.3(@algolia/client-search@5.29.0)(@types/node@22.19.1)(@types/react@18.3.23)(lightningcss@1.30.1)(postcss@8.5.6)(search-insights@2.17.3)(typescript@6.0.3)
     optionalDependencies:
       '@mermaid-js/mermaid-mindmap': 9.3.0
 
-  vitepress@1.6.3(@algolia/client-search@5.29.0)(@types/node@22.19.1)(@types/react@18.3.23)(lightningcss@1.30.1)(postcss@8.5.6)(search-insights@2.17.3)(typescript@5.9.3):
+  vitepress@1.6.3(@algolia/client-search@5.29.0)(@types/node@22.19.1)(@types/react@18.3.23)(lightningcss@1.30.1)(postcss@8.5.6)(search-insights@2.17.3)(typescript@6.0.3):
     dependencies:
       '@docsearch/css': 3.8.2
       '@docsearch/js': 3.8.2(@algolia/client-search@5.29.0)(@types/react@18.3.23)(search-insights@2.17.3)
@@ -18576,17 +18579,17 @@ snapshots:
       '@shikijs/transformers': 2.5.0
       '@shikijs/types': 2.5.0
       '@types/markdown-it': 14.1.2
-      '@vitejs/plugin-vue': 5.2.4(vite@5.4.19(@types/node@22.19.1)(lightningcss@1.30.1))(vue@3.5.17(typescript@5.9.3))
+      '@vitejs/plugin-vue': 5.2.4(vite@5.4.19(@types/node@22.19.1)(lightningcss@1.30.1))(vue@3.5.17(typescript@6.0.3))
       '@vue/devtools-api': 7.7.7
       '@vue/shared': 3.5.17
-      '@vueuse/core': 12.8.2(typescript@5.9.3)
-      '@vueuse/integrations': 12.8.2(focus-trap@7.6.5)(typescript@5.9.3)
+      '@vueuse/core': 12.8.2(typescript@6.0.3)
+      '@vueuse/integrations': 12.8.2(focus-trap@7.6.5)(typescript@6.0.3)
       focus-trap: 7.6.5
       mark.js: 8.11.1
       minisearch: 7.1.2
       shiki: 2.5.0
       vite: 5.4.19(@types/node@22.19.1)(lightningcss@1.30.1)
-      vue: 3.5.17(typescript@5.9.3)
+      vue: 3.5.17(typescript@6.0.3)
     optionalDependencies:
       postcss: 8.5.6
     transitivePeerDependencies:
@@ -18675,19 +18678,19 @@ snapshots:
 
   vscode-uri@3.0.8: {}
 
-  vue-resize@2.0.0-alpha.1(vue@3.5.17(typescript@5.9.3)):
+  vue-resize@2.0.0-alpha.1(vue@3.5.17(typescript@6.0.3)):
     dependencies:
-      vue: 3.5.17(typescript@5.9.3)
+      vue: 3.5.17(typescript@6.0.3)
 
-  vue@3.5.17(typescript@5.9.3):
+  vue@3.5.17(typescript@6.0.3):
     dependencies:
       '@vue/compiler-dom': 3.5.17
       '@vue/compiler-sfc': 3.5.17
       '@vue/runtime-dom': 3.5.17
-      '@vue/server-renderer': 3.5.17(vue@3.5.17(typescript@5.9.3))
+      '@vue/server-renderer': 3.5.17(vue@3.5.17(typescript@6.0.3))
       '@vue/shared': 3.5.17
     optionalDependencies:
-      typescript: 5.9.3
+      typescript: 6.0.3
 
   wasm-feature-detect@1.8.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -91,5 +91,5 @@ catalog:
   pkijs: ^3.3.3
   postgres: ^3.4.7
   tsdown: ^0.21.6
-  typescript: ^5.9.2
+  typescript: ^6.0.0
   urlpattern-polyfill: "^10.1.0"


### PR DESCRIPTION
Closes #767.

## Summary

Activity Vocabulary constructors and `clone()` methods rejected `Temporal.Instant`/`Temporal.Duration` values produced by anything other than the bundled `@js-temporal/polyfill`. On Node.js 26+, that meant the native `Temporal` threw `TypeError: The published must be of type Temporal.Instant.`, and TypeScript flagged native instances as the wrong type even when the runtime would have accepted them. The generated declarations had the same problem in `@fedify/postgres`, `@fedify/redis`, and `@fedify/sqlite`, where `pollInterval` and `handlerTimeout` carried the polyfill's nominal classes through the generated *.d.ts*.

Runtime validation now uses a `Symbol.toStringTag` guard and also checks `epochNanoseconds` on `Instant` or `sign` on `Duration`, so objects with only a spoofed tag are still rejected. Generated *.d.ts* files no longer import `Temporal` from `@js-temporal/polyfill`; they reference the ambient `Temporal` namespace through `lib.esnext.temporal` instead, so both polyfill and native values satisfy the declared types. This requires TypeScript 6.0, the first version that ships `lib.esnext.temporal`.

The guards are exported from `@fedify/vocab-runtime/temporal`, following the existing `@fedify/vocab-runtime/jsonld` subpath, so callers can import the guard without importing the whole runtime. The JS output still imports the polyfill at runtime, preserving Node 22-25 support.

### Breaking change

Consumers must use TypeScript 6.0 or later. The generated *.d.ts* references `lib.esnext.temporal`, which TS 5.x doesn't ship. *CHANGES.md* notes this under each affected package.

## Test plan

- [ ] `mise run check` passes
- [ ] `mise run test:deno` passes (`22,027` Deno tests across vocab + actor + lookup + type suites)
- [ ] Node test suite passes for `@fedify/vocab`, `@fedify/fedify`, `@fedify/postgres`, `@fedify/redis`, `@fedify/sqlite` (`cd packages/<name> && pnpm pretest && cd dist && node --test`)
- [ ] Confirm `dist/**/*.d.ts` in those packages no longer imports `@js-temporal/polyfill` and starts with `/// <reference lib="esnext.temporal" />`
- [ ] Confirm `dist/**/*.{js,cjs}` in those packages still imports the polyfill (runtime fallback for Node ≤ 25)
- [ ] Smoke-test on Node 26 (or with `globalThis.Temporal` patched in) that `new Article({ published: globalThis.Temporal.Instant.from("…") })` no longer throws