### PR TITLE
Handle URL string icons

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -201,6 +201,7 @@ To be released.
 
 [#316]: https://github.com/fedify-dev/fedify/issues/316
 [#418]: https://github.com/fedify-dev/fedify/issues/418
+[#420]: https://github.com/fedify-dev/fedify/issues/420
 [#619]: https://github.com/fedify-dev/fedify/issues/619
 [#735]: https://github.com/fedify-dev/fedify/issues/735
 [#736]: https://github.com/fedify-dev/fedify/issues/736
@@ -231,6 +232,12 @@ To be released.
 
  -  Added a `meterProvider` option to `createFederation()` so mock contexts can
     expose a test OpenTelemetry meter provider.  [[#316], [#619], [#755]]
+
+### @fedify/vocab
+
+ -  Fixed Activity Vocabulary parsing so URL string `icon` values are exposed
+    as `Link` instances instead of being dereferenced as remote `Image`
+    documents.  [[#420]]
 
 ### @fedify/uri-template
 

--- a/packages/fedify/src/federation/webfinger.ts
+++ b/packages/fedify/src/federation/webfinger.ts
@@ -330,12 +330,13 @@ async function handleWebFingerInternal<TContextData>(
       });
     }
   }
-  for await (const image of actor.getIcons()) {
-    if (image.url?.href == null) continue;
+  for await (const icon of actor.getIcons()) {
+    const href = icon instanceof LinkObject ? icon.href : icon.url;
+    if (href?.href == null) continue;
     links.push({
       rel: "http://webfinger.net/rel/avatar",
-      href: image.url.href.toString(),
-      ...(image.mediaType != null && { type: image.mediaType }),
+      href: href.href.toString(),
+      ...(icon.mediaType != null && { type: icon.mediaType }),
     });
   }
 

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -101,7 +101,7 @@ export class Object {
       #_86xFhmgBapoMvYqjbjRuDPayTrS_generator: (Object | Link | URL)[] = [];
       #_trust_86xFhmgBapoMvYqjbjRuDPayTrS_generator: Set<number> = new Set();
     
-      #_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon: (Image | URL)[] = [];
+      #_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon: (Image | Link | URL)[] = [];
       #_trust_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon: Set<number> = new Set();
     
       #_3dXrUdkARxwyJLtJcYi1AJ92H41U_image: (Image | URL)[] = [];
@@ -179,8 +179,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -439,14 +439,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         }
       
         if (\\"icon\\" in values &&             values.icon != null) {
-          if (values.icon instanceof Image || values.icon instanceof URL) {
+          if (values.icon instanceof Image || values.icon instanceof Link || values.icon instanceof URL) {
             // @ts-ignore: type is checked above.
             this.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = [values.icon];
       this.#_trust_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.add(0);
           } else {
             throw new TypeError(
               \\"The icon must be of type \\" +
-              \\"Image | URL\\" + \\".\\",
+              \\"Image | Link | URL\\" + \\".\\",
             );
           }
         }
@@ -462,7 +462,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           }
         
           if (Array.isArray(values.icons) &&
-              values.icons.every(v => v instanceof Image || v instanceof URL)) {
+              values.icons.every(v => v instanceof Image || v instanceof Link || v instanceof URL)) {
             // @ts-ignore: type is checked above.
             this.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = values.icons;
       
@@ -473,7 +473,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           } else {
             throw new TypeError(
               \\"The icons must be an array of type \\" +
-              \\"Image | URL\\" + \\".\\",
+              \\"Image | Link | URL\\" + \\".\\",
             );
           }
         }
@@ -1152,8 +1152,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -1415,14 +1415,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         }
       clone.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = this.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon;clone.#_trust_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = new Set(this.#_trust_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon);
         if (\\"icon\\" in values &&             values.icon != null) {
-          if (values.icon instanceof Image || values.icon instanceof URL) {
+          if (values.icon instanceof Image || values.icon instanceof Link || values.icon instanceof URL) {
             // @ts-ignore: type is checked above.
             clone.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = [values.icon];
       clone.#_trust_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = new Set([0]);
           } else {
             throw new TypeError(
               \\"The icon must be of type \\" +
-              \\"Image | URL\\" + \\".\\",
+              \\"Image | Link | URL\\" + \\".\\",
             );
           }
         }
@@ -1438,7 +1438,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           }
         
           if (Array.isArray(values.icons) &&
-              values.icons.every(v => v instanceof Image || v instanceof URL)) {
+              values.icons.every(v => v instanceof Image || v instanceof Link || v instanceof URL)) {
             // @ts-ignore: type is checked above.
             clone.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = values.icons;
       
@@ -1450,7 +1450,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           } else {
             throw new TypeError(
               \\"The icons must be an array of type \\" +
-              \\"Image | URL\\" + \\".\\",
+              \\"Image | Link | URL\\" + \\".\\",
             );
           }
         }
@@ -2243,7 +2243,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -2252,7 +2252,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await PropertyValue.fromJsonLd(
             jsonLd,
@@ -2261,7 +2261,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"https://www.w3.org/ns/activitystreams#Link\\",\\"http://schema.org#PropertyValue\\"].join(\\", \\"));
     }
@@ -2480,7 +2480,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -2489,7 +2489,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -2498,7 +2498,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -2507,7 +2507,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -2516,7 +2516,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -2830,7 +2830,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -3171,7 +3171,7 @@ get contents(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -3180,7 +3180,7 @@ get contents(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"https://www.w3.org/ns/activitystreams#Link\\"].join(\\", \\"));
     }
@@ -3445,7 +3445,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -3454,7 +3454,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"https://www.w3.org/ns/activitystreams#Link\\"].join(\\", \\"));
     }
@@ -3564,7 +3564,7 @@ get names(): ((string | LanguageString))[] {
         tracerProvider?: TracerProvider,
         crossOrigin?: \\"ignore\\" | \\"throw\\" | \\"trust\\";
       } = {},
-    ): Promise<Image | null> {
+    ): Promise<Image | Link | null> {
       const documentLoader =
         options.documentLoader ?? this._documentLoader ?? getDocumentLoader();
       const contextLoader =
@@ -3654,7 +3654,7 @@ get names(): ((string | LanguageString))[] {
         tracerProvider?: TracerProvider,
         baseUrl?: URL
       }
-    ): Promise<Image> {
+    ): Promise<Image | Link> {
       const documentLoader =
         options.documentLoader ?? this._documentLoader ?? getDocumentLoader();
       const contextLoader =
@@ -3671,9 +3671,18 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
+        try {
+          return await Link.fromJsonLd(
+            jsonLd,
+            { documentLoader, contextLoader, tracerProvider, baseUrl },
+          );
+        } catch (e) {
+          if (!(e instanceof TypeError)) throw e;
+        }
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
-        [\\"https://www.w3.org/ns/activitystreams#Image\\"].join(\\", \\"));
+        [\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Link\\"].join(\\", \\"));
     }
 
     
@@ -3709,7 +3718,7 @@ get names(): ((string | LanguageString))[] {
           tracerProvider?: TracerProvider,
           crossOrigin?: \\"ignore\\" | \\"throw\\" | \\"trust\\";
         } = {}
-      ): Promise<Image | null> {
+      ): Promise<Image | Link | null> {
         if (this._warning != null) {
           getLogger(this._warning.category).warn(
             this._warning.message,
@@ -3803,7 +3812,7 @@ get names(): ((string | LanguageString))[] {
           tracerProvider?: TracerProvider,
           crossOrigin?: \\"ignore\\" | \\"throw\\" | \\"trust\\";
         } = {}
-      ): AsyncIterable<Image> {
+      ): AsyncIterable<Image | Link> {
         if (this._warning != null) {
           getLogger(this._warning.category).warn(
             this._warning.message,
@@ -3985,7 +3994,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Image\\"].join(\\", \\"));
     }
@@ -4299,7 +4308,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -4308,7 +4317,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"https://www.w3.org/ns/activitystreams#Link\\"].join(\\", \\"));
     }
@@ -4620,7 +4629,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -4629,7 +4638,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"https://www.w3.org/ns/activitystreams#Link\\"].join(\\", \\"));
     }
@@ -4941,7 +4950,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Object.fromJsonLd(
             jsonLd,
@@ -4950,7 +4959,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -5273,7 +5282,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -5489,7 +5498,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -5711,7 +5720,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -5933,7 +5942,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -6189,7 +6198,7 @@ get summaries(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -6198,7 +6207,7 @@ get summaries(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"https://www.w3.org/ns/activitystreams#Link\\"].join(\\", \\"));
     }
@@ -6452,7 +6461,7 @@ get urls(): ((URL | Link))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -6764,7 +6773,7 @@ get urls(): ((URL | Link))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -7076,7 +7085,7 @@ get urls(): ((URL | Link))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -7388,7 +7397,7 @@ get urls(): ((URL | Link))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -7764,7 +7773,7 @@ get urls(): ((URL | Link))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/security#DataIntegrityProof\\"].join(\\", \\"));
     }
@@ -8113,7 +8122,7 @@ get urls(): ((URL | Link))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://gotosocial.org/ns#LikeApproval\\"].join(\\", \\"));
     }
@@ -8329,7 +8338,7 @@ get urls(): ((URL | Link))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://gotosocial.org/ns#ReplyAuthorization\\"].join(\\", \\"));
     }
@@ -8545,7 +8554,7 @@ get urls(): ((URL | Link))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://gotosocial.org/ns#AnnounceAuthorization\\"].join(\\", \\"));
     }
@@ -8868,7 +8877,11 @@ get urls(): ((URL | Link))[] {
       compactItems = [];
       for (const v of this.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon) {
         const item = (
-      v instanceof URL ? v.href : await v.toJsonLd({
+      v instanceof URL ? v.href : v instanceof Image ? await v.toJsonLd({
+           ...(options),
+           format: undefined,
+           context: undefined,
+         }) : await v.toJsonLd({
            ...(options),
            format: undefined,
            context: undefined,
@@ -9573,7 +9586,7 @@ get urls(): ((URL | Link))[] {
     array = [];
     for (const v of this.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon) {
       const element = (
-    v instanceof URL ? { \\"@id\\": v.href } : await v.toJsonLd(options)
+    v instanceof URL ? { \\"@id\\": v.href } : v instanceof Image ? await v.toJsonLd(options) : await v.toJsonLd(options)
       );
     array.push(element);;
     }
@@ -10479,7 +10492,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _49BipA5dq9eoH8LX8xdsVumveTca_attachment.push(decoded);
-      
+
     }
     instance.#_49BipA5dq9eoH8LX8xdsVumveTca_attachment = _49BipA5dq9eoH8LX8xdsVumveTca_attachment;
     
@@ -10532,7 +10545,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo.push(decoded);
-      
+
     }
     instance.#_42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo = _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo;
     
@@ -10589,7 +10602,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
-      
+
     }
     instance.#_4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content = _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content;
     
@@ -10632,7 +10645,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3mhZzGXSpQ431mBSz2kvych22v4e_context.push(decoded);
-      
+
     }
     instance.#_3mhZzGXSpQ431mBSz2kvych22v4e_context = _3mhZzGXSpQ431mBSz2kvych22v4e_context;
     const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
@@ -10656,7 +10669,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
-      
+
     }
     instance.#_4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name = _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name;
     const _219RwDanjScTv5tYCjwGZVCM7KZ9_endTime: (Temporal.Instant)[] = [];
@@ -10721,11 +10734,11 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _86xFhmgBapoMvYqjbjRuDPayTrS_generator.push(decoded);
-      
+
     }
     instance.#_86xFhmgBapoMvYqjbjRuDPayTrS_generator = _86xFhmgBapoMvYqjbjRuDPayTrS_generator;
     
-      const _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon: (Image | URL)[] = [];
+      const _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon: (Image | Link | URL)[] = [];
       const _trust_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon: Set<number> = new Set();
     
     let _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon__array = values[\\"https://www.w3.org/ns/activitystreams#icon\\"];
@@ -10741,20 +10754,29 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
-        _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(
+        const href =
           !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
-        );
+            : new URL(v[\\"@id\\"]);
+        _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(new Link({ href }));
         continue;
       }
       
-      const decoded = await Image.fromJsonLd(
+      const decoded =
+      typeof v === \\"object\\" && \\"@type\\" in v
+      && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Image\\") ? await Image.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    );
+    ) : typeof v === \\"object\\" && \\"@type\\" in v
+      && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
+            t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
+      v,
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+    ) : undefined
+      ;
       if (typeof decoded === \\"undefined\\") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
+
     }
     instance.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon;
     
@@ -10830,7 +10852,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo.push(decoded);
-      
+
     }
     instance.#_3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo = _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo;
     
@@ -10873,7 +10895,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _31k5MUZJsnsPNg8dQQJieWaXTFnR_location.push(decoded);
-      
+
     }
     instance.#_31k5MUZJsnsPNg8dQQJieWaXTFnR_location = _31k5MUZJsnsPNg8dQQJieWaXTFnR_location;
     
@@ -10916,7 +10938,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(decoded);
-      
+
     }
     instance.#_gCVTegXxWWCw6wWRxa1QF65zusg_preview = _gCVTegXxWWCw6wWRxa1QF65zusg_preview;
     const _5e258TDXtuhaFRPZiGoDfEpjdMr_published: (Temporal.Instant)[] = [];
@@ -11116,7 +11138,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _4LqirZspQbFWWQEbFcXAxm7tTDN1_summary.push(decoded);
-      
+
     }
     instance.#_4LqirZspQbFWWQEbFcXAxm7tTDN1_summary = _4LqirZspQbFWWQEbFcXAxm7tTDN1_summary;
     
@@ -11159,7 +11181,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _5chuqj6s95p5gg2sk1HntGfarRf_tag.push(decoded);
-      
+
     }
     instance.#_5chuqj6s95p5gg2sk1HntGfarRf_tag = _5chuqj6s95p5gg2sk1HntGfarRf_tag;
     const _385aB7ySixcf5Un6z3VsWmThgCzQ_updated: (Temporal.Instant)[] = [];
@@ -11224,7 +11246,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2oPEH9MQ3aj8JVwyYuWkqoVwV865_url.push(decoded);
-      
+
     }
     instance.#_2oPEH9MQ3aj8JVwyYuWkqoVwV865_url = _2oPEH9MQ3aj8JVwyYuWkqoVwV865_url;
     
@@ -12546,8 +12568,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -12582,8 +12604,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -12895,8 +12917,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -12970,8 +12992,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -13157,7 +13179,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -13397,7 +13419,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/fep/044f#QuoteAuthorization\\"].join(\\", \\"));
     }
@@ -14056,8 +14078,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -14338,8 +14360,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -14738,7 +14760,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -14747,7 +14769,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -14756,7 +14778,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -14765,7 +14787,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -14774,7 +14796,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -15088,7 +15110,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -15402,7 +15424,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -15722,7 +15744,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -16036,7 +16058,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -16352,7 +16374,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -17009,7 +17031,7 @@ instruments?: (Object | URL)[];}
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor.push(decoded);
-      
+
     }
     instance.#_2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor = _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor;
     
@@ -17401,8 +17423,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -17443,8 +17465,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -18185,7 +18207,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
-      
+
     }
     instance.#_4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name = _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name;
     const _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value: ((string | LanguageString))[] = [];
@@ -18209,7 +18231,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value.push(decoded);
-      
+
     }
     instance.#_2cSy2magg4iZ7zLaG8U7DiJMoCkx_value = _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value;
     
@@ -18923,8 +18945,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -18985,8 +19007,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -19159,7 +19181,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -19375,7 +19397,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -19930,8 +19952,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -19972,8 +19994,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -21743,8 +21765,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -21805,8 +21827,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -21979,7 +22001,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -22195,7 +22217,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -22749,8 +22771,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -22791,8 +22813,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -23095,8 +23117,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -23157,8 +23179,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -23331,7 +23353,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -23547,7 +23569,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -24101,8 +24123,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -24143,8 +24165,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -24447,8 +24469,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -24509,8 +24531,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -24683,7 +24705,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -24898,7 +24920,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -25452,8 +25474,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -25494,8 +25516,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -26952,7 +26974,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/security#Multikey\\"].join(\\", \\"));
     }
@@ -27894,7 +27916,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -27903,7 +27925,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -27912,7 +27934,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -27921,7 +27943,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -27930,7 +27952,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -28343,7 +28365,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner.push(decoded);
-      
+
     }
     instance.#_5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner = _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner;
     const _2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem: (CryptoKey)[] = [];
@@ -28765,7 +28787,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -28774,7 +28796,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -28783,7 +28805,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -28792,7 +28814,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -28801,7 +28823,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -29221,7 +29243,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller.push(decoded);
-      
+
     }
     instance.#_2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller = _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller;
     const _4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase: (CryptoKey)[] = [];
@@ -30318,8 +30340,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -30406,8 +30428,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -31111,8 +31133,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -31153,8 +31175,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -31451,8 +31473,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -31493,8 +31515,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -31786,8 +31808,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -31828,8 +31850,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -32166,8 +32188,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -32630,8 +32652,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -33234,7 +33256,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/security#Key\\"].join(\\", \\"));
     }
@@ -33542,7 +33564,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/security#Multikey\\"].join(\\", \\"));
     }
@@ -33877,7 +33899,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -33886,7 +33908,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\"].join(\\", \\"));
     }
@@ -34113,7 +34135,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -34122,7 +34144,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\"].join(\\", \\"));
     }
@@ -34346,7 +34368,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -34565,7 +34587,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -34787,7 +34809,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -35007,7 +35029,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -35225,7 +35247,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -35443,7 +35465,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -35735,7 +35757,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -35744,7 +35766,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -35753,7 +35775,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -35762,7 +35784,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -35771,7 +35793,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -35985,7 +36007,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -35994,7 +36016,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -36003,7 +36025,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -36012,7 +36034,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -36021,7 +36043,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -36337,7 +36359,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/did#Service\\"].join(\\", \\"));
     }
@@ -37585,7 +37607,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
-      
+
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -37710,7 +37732,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
-      
+
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -37751,7 +37773,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
-      
+
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -38095,7 +38117,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
-      
+
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -38148,7 +38170,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
-      
+
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -38762,8 +38784,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -38804,8 +38826,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -39109,8 +39131,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -39151,8 +39173,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -39448,8 +39470,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -39523,8 +39545,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -39710,7 +39732,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -39950,7 +39972,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/fep/044f#QuoteAuthorization\\"].join(\\", \\"));
     }
@@ -40588,8 +40610,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -40650,8 +40672,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -41167,8 +41189,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -41203,8 +41225,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -41506,8 +41528,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -41548,8 +41570,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -41846,8 +41868,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -41888,8 +41910,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -42220,8 +42242,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -42431,8 +42453,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -42771,7 +42793,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#CollectionPage\\"].join(\\", \\"));
     }
@@ -42987,7 +43009,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#CollectionPage\\"].join(\\", \\"));
     }
@@ -43203,7 +43225,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#CollectionPage\\"].join(\\", \\"));
     }
@@ -43419,7 +43441,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -43428,7 +43450,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"https://www.w3.org/ns/activitystreams#Link\\"].join(\\", \\"));
     }
@@ -43646,7 +43668,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -43861,7 +43883,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -44076,7 +44098,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -44291,7 +44313,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -44506,7 +44528,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -44721,7 +44743,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -44936,7 +44958,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -45151,7 +45173,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -46079,7 +46101,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
-      
+
     }
     instance.#_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items = _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items;
     
@@ -46687,8 +46709,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -46762,8 +46784,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -46949,7 +46971,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -47165,7 +47187,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#CollectionPage\\"].join(\\", \\"));
     }
@@ -47379,7 +47401,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#CollectionPage\\"].join(\\", \\"));
     }
@@ -48015,8 +48037,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -48057,8 +48079,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -48349,8 +48371,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -48391,8 +48413,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -48681,8 +48703,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -48723,8 +48745,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -50135,8 +50157,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -50171,8 +50193,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -50475,8 +50497,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -50517,8 +50539,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -50811,8 +50833,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -50853,8 +50875,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -51191,8 +51213,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -51655,8 +51677,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -52259,7 +52281,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/security#Key\\"].join(\\", \\"));
     }
@@ -52567,7 +52589,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/security#Multikey\\"].join(\\", \\"));
     }
@@ -52902,7 +52924,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -52911,7 +52933,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\"].join(\\", \\"));
     }
@@ -53138,7 +53160,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -53147,7 +53169,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\"].join(\\", \\"));
     }
@@ -53371,7 +53393,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -53590,7 +53612,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -53812,7 +53834,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -54032,7 +54054,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -54250,7 +54272,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -54468,7 +54490,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -54760,7 +54782,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -54769,7 +54791,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -54778,7 +54800,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -54787,7 +54809,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -54796,7 +54818,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -55010,7 +55032,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -55019,7 +55041,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -55028,7 +55050,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -55037,7 +55059,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -55046,7 +55068,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -55362,7 +55384,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/did#Service\\"].join(\\", \\"));
     }
@@ -56610,7 +56632,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
-      
+
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -56735,7 +56757,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
-      
+
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -56776,7 +56798,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
-      
+
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -57120,7 +57142,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
-      
+
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -57173,7 +57195,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
-      
+
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -58461,7 +58483,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Object.fromJsonLd(
             jsonLd,
@@ -58470,7 +58492,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -59111,7 +59133,7 @@ get names(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
-      
+
     }
     instance.#_4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name = _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name;
     const _f57HKWCp1YRBbTJE8PF12RbDJGf_hreflang: (Intl.Locale)[] = [];
@@ -59208,7 +59230,7 @@ get names(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(decoded);
-      
+
     }
     instance.#_gCVTegXxWWCw6wWRxa1QF65zusg_preview = _gCVTegXxWWCw6wWRxa1QF65zusg_preview;
     
@@ -59768,8 +59790,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -59804,8 +59826,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -60108,8 +60130,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -60150,8 +60172,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -60446,8 +60468,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -60488,8 +60510,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -60780,8 +60802,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -60822,8 +60844,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -61114,8 +61136,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -61156,8 +61178,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -61448,8 +61470,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -61490,8 +61512,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -61780,8 +61802,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -61822,8 +61844,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -62413,8 +62435,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -62455,8 +62477,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -62754,8 +62776,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -62829,8 +62851,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -63016,7 +63038,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -63256,7 +63278,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/fep/044f#QuoteAuthorization\\"].join(\\", \\"));
     }
@@ -63897,8 +63919,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -63952,8 +63974,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -64120,7 +64142,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -64129,7 +64151,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"https://www.w3.org/ns/activitystreams#Link\\"].join(\\", \\"));
     }
@@ -64509,7 +64531,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
-      
+
     }
     instance.#_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items = _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items;
     
@@ -64608,8 +64630,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -64676,8 +64698,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -64857,7 +64879,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -64866,7 +64888,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"https://www.w3.org/ns/activitystreams#Link\\"].join(\\", \\"));
     }
@@ -65295,7 +65317,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
-      
+
     }
     instance.#_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items = _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items;
     const _2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex: (number)[] = [];
@@ -65473,8 +65495,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -65937,8 +65959,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -66541,7 +66563,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/security#Key\\"].join(\\", \\"));
     }
@@ -66849,7 +66871,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/security#Multikey\\"].join(\\", \\"));
     }
@@ -67184,7 +67206,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -67193,7 +67215,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\"].join(\\", \\"));
     }
@@ -67420,7 +67442,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -67429,7 +67451,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\"].join(\\", \\"));
     }
@@ -67653,7 +67675,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -67872,7 +67894,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -68094,7 +68116,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -68314,7 +68336,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -68532,7 +68554,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -68750,7 +68772,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -69042,7 +69064,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -69051,7 +69073,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -69060,7 +69082,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -69069,7 +69091,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -69078,7 +69100,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -69292,7 +69314,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -69301,7 +69323,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -69310,7 +69332,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -69319,7 +69341,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -69328,7 +69350,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -69644,7 +69666,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/did#Service\\"].join(\\", \\"));
     }
@@ -70892,7 +70914,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
-      
+
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -71017,7 +71039,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
-      
+
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -71058,7 +71080,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
-      
+
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -71402,7 +71424,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
-      
+
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -71455,7 +71477,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
-      
+
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -72066,8 +72088,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -72102,8 +72124,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -72451,8 +72473,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -72915,8 +72937,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -73519,7 +73541,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/security#Key\\"].join(\\", \\"));
     }
@@ -73827,7 +73849,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/security#Multikey\\"].join(\\", \\"));
     }
@@ -74162,7 +74184,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -74171,7 +74193,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\"].join(\\", \\"));
     }
@@ -74398,7 +74420,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -74407,7 +74429,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\"].join(\\", \\"));
     }
@@ -74631,7 +74653,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -74850,7 +74872,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -75072,7 +75094,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -75292,7 +75314,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -75510,7 +75532,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -75728,7 +75750,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -76020,7 +76042,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -76029,7 +76051,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -76038,7 +76060,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -76047,7 +76069,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -76056,7 +76078,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -76270,7 +76292,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -76279,7 +76301,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -76288,7 +76310,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -76297,7 +76319,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -76306,7 +76328,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -76622,7 +76644,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/did#Service\\"].join(\\", \\"));
     }
@@ -77870,7 +77892,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
-      
+
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -77995,7 +78017,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
-      
+
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -78036,7 +78058,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
-      
+
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -78380,7 +78402,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
-      
+
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -78433,7 +78455,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
-      
+
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -79053,8 +79075,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -79167,8 +79189,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -79896,7 +79918,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
-      
+
     }
     instance.#_oKrwxU4V8wiKhMW1QEYQibcJh8c_units = _oKrwxU4V8wiKhMW1QEYQibcJh8c_units;
     
@@ -80094,8 +80116,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -80143,8 +80165,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -80304,7 +80326,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -80784,8 +80806,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -80929,8 +80951,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -81188,7 +81210,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -81407,7 +81429,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -81656,7 +81678,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -81896,7 +81918,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/fep/044f#QuoteAuthorization\\"].join(\\", \\"));
     }
@@ -82390,7 +82412,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3KronwL8DiiKBRcJFKQPiEHm8xb6_closed.push(decoded);
-      
+
     }
     instance.#_3KronwL8DiiKBRcJFKQPiEHm8xb6_closed = _3KronwL8DiiKBRcJFKQPiEHm8xb6_closed;
     const _3H4RdST7dxfmghccvE3rKD3KgcxG_votersCount: (number)[] = [];
@@ -82715,8 +82737,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -82757,8 +82779,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -83049,8 +83071,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -83091,8 +83113,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -83401,8 +83423,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -83532,8 +83554,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -83777,7 +83799,7 @@ relationships?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -83995,7 +84017,7 @@ relationships?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -84305,7 +84327,7 @@ relationships?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -85050,8 +85072,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -85092,8 +85114,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -85430,8 +85452,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -85894,8 +85916,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -86498,7 +86520,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/security#Key\\"].join(\\", \\"));
     }
@@ -86806,7 +86828,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/security#Multikey\\"].join(\\", \\"));
     }
@@ -87141,7 +87163,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -87150,7 +87172,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\"].join(\\", \\"));
     }
@@ -87377,7 +87399,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -87386,7 +87408,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\"].join(\\", \\"));
     }
@@ -87610,7 +87632,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -87829,7 +87851,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -88051,7 +88073,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -88271,7 +88293,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -88489,7 +88511,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -88707,7 +88729,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -88999,7 +89021,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -89008,7 +89030,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -89017,7 +89039,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -89026,7 +89048,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -89035,7 +89057,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -89249,7 +89271,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -89258,7 +89280,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -89267,7 +89289,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -89276,7 +89298,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -89285,7 +89307,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -89601,7 +89623,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/did#Service\\"].join(\\", \\"));
     }
@@ -90849,7 +90871,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
-      
+
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -90974,7 +90996,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
-      
+
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -91015,7 +91037,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
-      
+
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -91359,7 +91381,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
-      
+
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -91412,7 +91434,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
-      
+
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -92518,7 +92540,7 @@ get contents(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
-      
+
     }
     instance.#_4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content = _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content;
     const _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType: (string)[] = [];
@@ -92669,8 +92691,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -92711,8 +92733,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -93003,8 +93025,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -93045,8 +93067,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -93340,8 +93362,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -93426,8 +93448,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -93988,8 +94010,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -94030,8 +94052,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -94327,8 +94349,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -94369,8 +94391,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -94664,8 +94686,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -94706,8 +94728,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -94996,8 +95018,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -95032,8 +95054,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -95334,8 +95356,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -95376,8 +95398,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
@@ -99,7 +99,7 @@ export class Object {
       #_86xFhmgBapoMvYqjbjRuDPayTrS_generator: (Object | Link | URL)[] = [];
       #_trust_86xFhmgBapoMvYqjbjRuDPayTrS_generator: Set<number> = new Set();
     
-      #_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon: (Image | URL)[] = [];
+      #_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon: (Image | Link | URL)[] = [];
       #_trust_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon: Set<number> = new Set();
     
       #_3dXrUdkARxwyJLtJcYi1AJ92H41U_image: (Image | URL)[] = [];
@@ -177,8 +177,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -437,14 +437,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         }
       
         if (\\"icon\\" in values &&             values.icon != null) {
-          if (values.icon instanceof Image || values.icon instanceof URL) {
+          if (values.icon instanceof Image || values.icon instanceof Link || values.icon instanceof URL) {
             // @ts-ignore: type is checked above.
             this.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = [values.icon];
       this.#_trust_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.add(0);
           } else {
             throw new TypeError(
               \\"The icon must be of type \\" +
-              \\"Image | URL\\" + \\".\\",
+              \\"Image | Link | URL\\" + \\".\\",
             );
           }
         }
@@ -460,7 +460,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           }
         
           if (Array.isArray(values.icons) &&
-              values.icons.every(v => v instanceof Image || v instanceof URL)) {
+              values.icons.every(v => v instanceof Image || v instanceof Link || v instanceof URL)) {
             // @ts-ignore: type is checked above.
             this.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = values.icons;
       
@@ -471,7 +471,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           } else {
             throw new TypeError(
               \\"The icons must be an array of type \\" +
-              \\"Image | URL\\" + \\".\\",
+              \\"Image | Link | URL\\" + \\".\\",
             );
           }
         }
@@ -1150,8 +1150,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -1413,14 +1413,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         }
       clone.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = this.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon;clone.#_trust_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = new Set(this.#_trust_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon);
         if (\\"icon\\" in values &&             values.icon != null) {
-          if (values.icon instanceof Image || values.icon instanceof URL) {
+          if (values.icon instanceof Image || values.icon instanceof Link || values.icon instanceof URL) {
             // @ts-ignore: type is checked above.
             clone.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = [values.icon];
       clone.#_trust_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = new Set([0]);
           } else {
             throw new TypeError(
               \\"The icon must be of type \\" +
-              \\"Image | URL\\" + \\".\\",
+              \\"Image | Link | URL\\" + \\".\\",
             );
           }
         }
@@ -1436,7 +1436,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           }
         
           if (Array.isArray(values.icons) &&
-              values.icons.every(v => v instanceof Image || v instanceof URL)) {
+              values.icons.every(v => v instanceof Image || v instanceof Link || v instanceof URL)) {
             // @ts-ignore: type is checked above.
             clone.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = values.icons;
       
@@ -1448,7 +1448,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           } else {
             throw new TypeError(
               \\"The icons must be an array of type \\" +
-              \\"Image | URL\\" + \\".\\",
+              \\"Image | Link | URL\\" + \\".\\",
             );
           }
         }
@@ -2241,7 +2241,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -2250,7 +2250,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await PropertyValue.fromJsonLd(
             jsonLd,
@@ -2259,7 +2259,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"https://www.w3.org/ns/activitystreams#Link\\",\\"http://schema.org#PropertyValue\\"].join(\\", \\"));
     }
@@ -2478,7 +2478,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -2487,7 +2487,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -2496,7 +2496,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -2505,7 +2505,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -2514,7 +2514,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -2828,7 +2828,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -3169,7 +3169,7 @@ get contents(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -3178,7 +3178,7 @@ get contents(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"https://www.w3.org/ns/activitystreams#Link\\"].join(\\", \\"));
     }
@@ -3443,7 +3443,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -3452,7 +3452,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"https://www.w3.org/ns/activitystreams#Link\\"].join(\\", \\"));
     }
@@ -3562,7 +3562,7 @@ get names(): ((string | LanguageString))[] {
         tracerProvider?: TracerProvider,
         crossOrigin?: \\"ignore\\" | \\"throw\\" | \\"trust\\";
       } = {},
-    ): Promise<Image | null> {
+    ): Promise<Image | Link | null> {
       const documentLoader =
         options.documentLoader ?? this._documentLoader ?? getDocumentLoader();
       const contextLoader =
@@ -3652,7 +3652,7 @@ get names(): ((string | LanguageString))[] {
         tracerProvider?: TracerProvider,
         baseUrl?: URL
       }
-    ): Promise<Image> {
+    ): Promise<Image | Link> {
       const documentLoader =
         options.documentLoader ?? this._documentLoader ?? getDocumentLoader();
       const contextLoader =
@@ -3669,9 +3669,18 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
+        try {
+          return await Link.fromJsonLd(
+            jsonLd,
+            { documentLoader, contextLoader, tracerProvider, baseUrl },
+          );
+        } catch (e) {
+          if (!(e instanceof TypeError)) throw e;
+        }
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
-        [\\"https://www.w3.org/ns/activitystreams#Image\\"].join(\\", \\"));
+        [\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Link\\"].join(\\", \\"));
     }
 
     
@@ -3707,7 +3716,7 @@ get names(): ((string | LanguageString))[] {
           tracerProvider?: TracerProvider,
           crossOrigin?: \\"ignore\\" | \\"throw\\" | \\"trust\\";
         } = {}
-      ): Promise<Image | null> {
+      ): Promise<Image | Link | null> {
         if (this._warning != null) {
           getLogger(this._warning.category).warn(
             this._warning.message,
@@ -3801,7 +3810,7 @@ get names(): ((string | LanguageString))[] {
           tracerProvider?: TracerProvider,
           crossOrigin?: \\"ignore\\" | \\"throw\\" | \\"trust\\";
         } = {}
-      ): AsyncIterable<Image> {
+      ): AsyncIterable<Image | Link> {
         if (this._warning != null) {
           getLogger(this._warning.category).warn(
             this._warning.message,
@@ -3983,7 +3992,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Image\\"].join(\\", \\"));
     }
@@ -4297,7 +4306,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -4306,7 +4315,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"https://www.w3.org/ns/activitystreams#Link\\"].join(\\", \\"));
     }
@@ -4618,7 +4627,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -4627,7 +4636,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"https://www.w3.org/ns/activitystreams#Link\\"].join(\\", \\"));
     }
@@ -4939,7 +4948,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Object.fromJsonLd(
             jsonLd,
@@ -4948,7 +4957,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -5271,7 +5280,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -5487,7 +5496,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -5709,7 +5718,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -5931,7 +5940,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -6187,7 +6196,7 @@ get summaries(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -6196,7 +6205,7 @@ get summaries(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"https://www.w3.org/ns/activitystreams#Link\\"].join(\\", \\"));
     }
@@ -6450,7 +6459,7 @@ get urls(): ((URL | Link))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -6762,7 +6771,7 @@ get urls(): ((URL | Link))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -7074,7 +7083,7 @@ get urls(): ((URL | Link))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -7386,7 +7395,7 @@ get urls(): ((URL | Link))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -7762,7 +7771,7 @@ get urls(): ((URL | Link))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/security#DataIntegrityProof\\"].join(\\", \\"));
     }
@@ -8111,7 +8120,7 @@ get urls(): ((URL | Link))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://gotosocial.org/ns#LikeApproval\\"].join(\\", \\"));
     }
@@ -8327,7 +8336,7 @@ get urls(): ((URL | Link))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://gotosocial.org/ns#ReplyAuthorization\\"].join(\\", \\"));
     }
@@ -8543,7 +8552,7 @@ get urls(): ((URL | Link))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://gotosocial.org/ns#AnnounceAuthorization\\"].join(\\", \\"));
     }
@@ -8866,7 +8875,11 @@ get urls(): ((URL | Link))[] {
       compactItems = [];
       for (const v of this.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon) {
         const item = (
-      v instanceof URL ? v.href : await v.toJsonLd({
+      v instanceof URL ? v.href : v instanceof Image ? await v.toJsonLd({
+           ...(options),
+           format: undefined,
+           context: undefined,
+         }) : await v.toJsonLd({
            ...(options),
            format: undefined,
            context: undefined,
@@ -9571,7 +9584,7 @@ get urls(): ((URL | Link))[] {
     array = [];
     for (const v of this.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon) {
       const element = (
-    v instanceof URL ? { \\"@id\\": v.href } : await v.toJsonLd(options)
+    v instanceof URL ? { \\"@id\\": v.href } : v instanceof Image ? await v.toJsonLd(options) : await v.toJsonLd(options)
       );
     array.push(element);;
     }
@@ -10477,7 +10490,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _49BipA5dq9eoH8LX8xdsVumveTca_attachment.push(decoded);
-      
+
     }
     instance.#_49BipA5dq9eoH8LX8xdsVumveTca_attachment = _49BipA5dq9eoH8LX8xdsVumveTca_attachment;
     
@@ -10530,7 +10543,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo.push(decoded);
-      
+
     }
     instance.#_42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo = _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo;
     
@@ -10587,7 +10600,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
-      
+
     }
     instance.#_4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content = _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content;
     
@@ -10630,7 +10643,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3mhZzGXSpQ431mBSz2kvych22v4e_context.push(decoded);
-      
+
     }
     instance.#_3mhZzGXSpQ431mBSz2kvych22v4e_context = _3mhZzGXSpQ431mBSz2kvych22v4e_context;
     const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
@@ -10654,7 +10667,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
-      
+
     }
     instance.#_4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name = _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name;
     const _219RwDanjScTv5tYCjwGZVCM7KZ9_endTime: (Temporal.Instant)[] = [];
@@ -10719,11 +10732,11 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _86xFhmgBapoMvYqjbjRuDPayTrS_generator.push(decoded);
-      
+
     }
     instance.#_86xFhmgBapoMvYqjbjRuDPayTrS_generator = _86xFhmgBapoMvYqjbjRuDPayTrS_generator;
     
-      const _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon: (Image | URL)[] = [];
+      const _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon: (Image | Link | URL)[] = [];
       const _trust_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon: Set<number> = new Set();
     
     let _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon__array = values[\\"https://www.w3.org/ns/activitystreams#icon\\"];
@@ -10739,20 +10752,29 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === \\"object\\" && \\"@id\\" in v && !(\\"@type\\" in v)
           && globalThis.Object.keys(v).length === 1) {
-        _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(
+        const href =
           !URL.canParse(v[\\"@id\\"]) && v[\\"@id\\"].startsWith(\\"at://\\")
             ? new URL(\\"at://\\" + encodeURIComponent(v[\\"@id\\"].substring(5)))
-            : new URL(v[\\"@id\\"])
-        );
+            : new URL(v[\\"@id\\"]);
+        _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(new Link({ href }));
         continue;
       }
       
-      const decoded = await Image.fromJsonLd(
+      const decoded =
+      typeof v === \\"object\\" && \\"@type\\" in v
+      && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Image\\") ? await Image.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    );
+    ) : typeof v === \\"object\\" && \\"@type\\" in v
+      && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
+            t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
+      v,
+      { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
+    ) : undefined
+      ;
       if (typeof decoded === \\"undefined\\") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
+
     }
     instance.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon;
     
@@ -10828,7 +10850,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo.push(decoded);
-      
+
     }
     instance.#_3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo = _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo;
     
@@ -10871,7 +10893,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _31k5MUZJsnsPNg8dQQJieWaXTFnR_location.push(decoded);
-      
+
     }
     instance.#_31k5MUZJsnsPNg8dQQJieWaXTFnR_location = _31k5MUZJsnsPNg8dQQJieWaXTFnR_location;
     
@@ -10914,7 +10936,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(decoded);
-      
+
     }
     instance.#_gCVTegXxWWCw6wWRxa1QF65zusg_preview = _gCVTegXxWWCw6wWRxa1QF65zusg_preview;
     const _5e258TDXtuhaFRPZiGoDfEpjdMr_published: (Temporal.Instant)[] = [];
@@ -11114,7 +11136,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _4LqirZspQbFWWQEbFcXAxm7tTDN1_summary.push(decoded);
-      
+
     }
     instance.#_4LqirZspQbFWWQEbFcXAxm7tTDN1_summary = _4LqirZspQbFWWQEbFcXAxm7tTDN1_summary;
     
@@ -11157,7 +11179,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _5chuqj6s95p5gg2sk1HntGfarRf_tag.push(decoded);
-      
+
     }
     instance.#_5chuqj6s95p5gg2sk1HntGfarRf_tag = _5chuqj6s95p5gg2sk1HntGfarRf_tag;
     const _385aB7ySixcf5Un6z3VsWmThgCzQ_updated: (Temporal.Instant)[] = [];
@@ -11222,7 +11244,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2oPEH9MQ3aj8JVwyYuWkqoVwV865_url.push(decoded);
-      
+
     }
     instance.#_2oPEH9MQ3aj8JVwyYuWkqoVwV865_url = _2oPEH9MQ3aj8JVwyYuWkqoVwV865_url;
     
@@ -12544,8 +12566,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -12580,8 +12602,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -12893,8 +12915,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -12968,8 +12990,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -13155,7 +13177,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -13395,7 +13417,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/fep/044f#QuoteAuthorization\\"].join(\\", \\"));
     }
@@ -14054,8 +14076,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -14336,8 +14358,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -14736,7 +14758,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -14745,7 +14767,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -14754,7 +14776,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -14763,7 +14785,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -14772,7 +14794,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -15086,7 +15108,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -15400,7 +15422,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -15720,7 +15742,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -16034,7 +16056,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -16350,7 +16372,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -17007,7 +17029,7 @@ instruments?: (Object | URL)[];}
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor.push(decoded);
-      
+
     }
     instance.#_2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor = _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor;
     
@@ -17399,8 +17421,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -17441,8 +17463,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -18183,7 +18205,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
-      
+
     }
     instance.#_4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name = _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name;
     const _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value: ((string | LanguageString))[] = [];
@@ -18207,7 +18229,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value.push(decoded);
-      
+
     }
     instance.#_2cSy2magg4iZ7zLaG8U7DiJMoCkx_value = _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value;
     
@@ -18921,8 +18943,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -18983,8 +19005,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -19157,7 +19179,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -19373,7 +19395,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -19928,8 +19950,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -19970,8 +19992,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -21741,8 +21763,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -21803,8 +21825,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -21977,7 +21999,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -22193,7 +22215,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -22747,8 +22769,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -22789,8 +22811,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -23093,8 +23115,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -23155,8 +23177,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -23329,7 +23351,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -23545,7 +23567,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -24099,8 +24121,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -24141,8 +24163,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -24445,8 +24467,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -24507,8 +24529,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -24681,7 +24703,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -24896,7 +24918,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -25450,8 +25472,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -25492,8 +25514,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -26950,7 +26972,7 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/security#Multikey\\"].join(\\", \\"));
     }
@@ -27892,7 +27914,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -27901,7 +27923,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -27910,7 +27932,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -27919,7 +27941,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -27928,7 +27950,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -28341,7 +28363,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner.push(decoded);
-      
+
     }
     instance.#_5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner = _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner;
     const _2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem: (CryptoKey)[] = [];
@@ -28763,7 +28785,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -28772,7 +28794,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -28781,7 +28803,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -28790,7 +28812,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -28799,7 +28821,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -29219,7 +29241,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller.push(decoded);
-      
+
     }
     instance.#_2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller = _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller;
     const _4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase: (CryptoKey)[] = [];
@@ -30316,8 +30338,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -30404,8 +30426,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -31109,8 +31131,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -31151,8 +31173,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -31449,8 +31471,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -31491,8 +31513,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -31784,8 +31806,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -31826,8 +31848,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -32164,8 +32186,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -32628,8 +32650,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -33232,7 +33254,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/security#Key\\"].join(\\", \\"));
     }
@@ -33540,7 +33562,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/security#Multikey\\"].join(\\", \\"));
     }
@@ -33875,7 +33897,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -33884,7 +33906,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\"].join(\\", \\"));
     }
@@ -34111,7 +34133,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -34120,7 +34142,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\"].join(\\", \\"));
     }
@@ -34344,7 +34366,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -34563,7 +34585,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -34785,7 +34807,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -35005,7 +35027,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -35223,7 +35245,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -35441,7 +35463,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -35733,7 +35755,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -35742,7 +35764,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -35751,7 +35773,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -35760,7 +35782,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -35769,7 +35791,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -35983,7 +36005,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -35992,7 +36014,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -36001,7 +36023,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -36010,7 +36032,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -36019,7 +36041,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -36335,7 +36357,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/did#Service\\"].join(\\", \\"));
     }
@@ -37583,7 +37605,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
-      
+
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -37708,7 +37730,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
-      
+
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -37749,7 +37771,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
-      
+
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -38093,7 +38115,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
-      
+
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -38146,7 +38168,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
-      
+
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -38760,8 +38782,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -38802,8 +38824,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -39107,8 +39129,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -39149,8 +39171,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -39446,8 +39468,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -39521,8 +39543,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -39708,7 +39730,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -39948,7 +39970,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/fep/044f#QuoteAuthorization\\"].join(\\", \\"));
     }
@@ -40586,8 +40608,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -40648,8 +40670,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -41165,8 +41187,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -41201,8 +41223,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -41504,8 +41526,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -41546,8 +41568,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -41844,8 +41866,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -41886,8 +41908,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -42218,8 +42240,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -42429,8 +42451,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -42769,7 +42791,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#CollectionPage\\"].join(\\", \\"));
     }
@@ -42985,7 +43007,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#CollectionPage\\"].join(\\", \\"));
     }
@@ -43201,7 +43223,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#CollectionPage\\"].join(\\", \\"));
     }
@@ -43417,7 +43439,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -43426,7 +43448,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"https://www.w3.org/ns/activitystreams#Link\\"].join(\\", \\"));
     }
@@ -43644,7 +43666,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -43859,7 +43881,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -44074,7 +44096,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -44289,7 +44311,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -44504,7 +44526,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -44719,7 +44741,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -44934,7 +44956,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -45149,7 +45171,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -46077,7 +46099,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
-      
+
     }
     instance.#_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items = _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items;
     
@@ -46685,8 +46707,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -46760,8 +46782,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -46947,7 +46969,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -47163,7 +47185,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#CollectionPage\\"].join(\\", \\"));
     }
@@ -47377,7 +47399,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#CollectionPage\\"].join(\\", \\"));
     }
@@ -48013,8 +48035,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -48055,8 +48077,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -48347,8 +48369,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -48389,8 +48411,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -48679,8 +48701,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -48721,8 +48743,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -50133,8 +50155,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -50169,8 +50191,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -50473,8 +50495,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -50515,8 +50537,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -50809,8 +50831,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -50851,8 +50873,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -51189,8 +51211,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -51653,8 +51675,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -52257,7 +52279,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/security#Key\\"].join(\\", \\"));
     }
@@ -52565,7 +52587,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/security#Multikey\\"].join(\\", \\"));
     }
@@ -52900,7 +52922,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -52909,7 +52931,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\"].join(\\", \\"));
     }
@@ -53136,7 +53158,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -53145,7 +53167,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\"].join(\\", \\"));
     }
@@ -53369,7 +53391,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -53588,7 +53610,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -53810,7 +53832,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -54030,7 +54052,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -54248,7 +54270,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -54466,7 +54488,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -54758,7 +54780,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -54767,7 +54789,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -54776,7 +54798,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -54785,7 +54807,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -54794,7 +54816,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -55008,7 +55030,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -55017,7 +55039,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -55026,7 +55048,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -55035,7 +55057,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -55044,7 +55066,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -55360,7 +55382,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/did#Service\\"].join(\\", \\"));
     }
@@ -56608,7 +56630,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
-      
+
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -56733,7 +56755,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
-      
+
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -56774,7 +56796,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
-      
+
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -57118,7 +57140,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
-      
+
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -57171,7 +57193,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
-      
+
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -58459,7 +58481,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Object.fromJsonLd(
             jsonLd,
@@ -58468,7 +58490,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -59109,7 +59131,7 @@ get names(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
-      
+
     }
     instance.#_4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name = _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name;
     const _f57HKWCp1YRBbTJE8PF12RbDJGf_hreflang: (Intl.Locale)[] = [];
@@ -59206,7 +59228,7 @@ get names(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(decoded);
-      
+
     }
     instance.#_gCVTegXxWWCw6wWRxa1QF65zusg_preview = _gCVTegXxWWCw6wWRxa1QF65zusg_preview;
     
@@ -59766,8 +59788,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -59802,8 +59824,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -60106,8 +60128,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -60148,8 +60170,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -60444,8 +60466,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -60486,8 +60508,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -60778,8 +60800,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -60820,8 +60842,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -61112,8 +61134,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -61154,8 +61176,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -61446,8 +61468,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -61488,8 +61510,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -61778,8 +61800,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -61820,8 +61842,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -62411,8 +62433,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -62453,8 +62475,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -62752,8 +62774,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -62827,8 +62849,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -63014,7 +63036,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -63254,7 +63276,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/fep/044f#QuoteAuthorization\\"].join(\\", \\"));
     }
@@ -63895,8 +63917,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -63950,8 +63972,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -64118,7 +64140,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -64127,7 +64149,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"https://www.w3.org/ns/activitystreams#Link\\"].join(\\", \\"));
     }
@@ -64507,7 +64529,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
-      
+
     }
     instance.#_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items = _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items;
     
@@ -64606,8 +64628,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -64674,8 +64696,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -64855,7 +64877,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -64864,7 +64886,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"https://www.w3.org/ns/activitystreams#Link\\"].join(\\", \\"));
     }
@@ -65293,7 +65315,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
-      
+
     }
     instance.#_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items = _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items;
     const _2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex: (number)[] = [];
@@ -65471,8 +65493,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -65935,8 +65957,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -66539,7 +66561,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/security#Key\\"].join(\\", \\"));
     }
@@ -66847,7 +66869,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/security#Multikey\\"].join(\\", \\"));
     }
@@ -67182,7 +67204,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -67191,7 +67213,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\"].join(\\", \\"));
     }
@@ -67418,7 +67440,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -67427,7 +67449,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\"].join(\\", \\"));
     }
@@ -67651,7 +67673,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -67870,7 +67892,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -68092,7 +68114,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -68312,7 +68334,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -68530,7 +68552,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -68748,7 +68770,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -69040,7 +69062,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -69049,7 +69071,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -69058,7 +69080,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -69067,7 +69089,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -69076,7 +69098,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -69290,7 +69312,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -69299,7 +69321,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -69308,7 +69330,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -69317,7 +69339,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -69326,7 +69348,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -69642,7 +69664,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/did#Service\\"].join(\\", \\"));
     }
@@ -70890,7 +70912,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
-      
+
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -71015,7 +71037,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
-      
+
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -71056,7 +71078,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
-      
+
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -71400,7 +71422,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
-      
+
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -71453,7 +71475,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
-      
+
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -72064,8 +72086,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -72100,8 +72122,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -72449,8 +72471,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -72913,8 +72935,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -73517,7 +73539,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/security#Key\\"].join(\\", \\"));
     }
@@ -73825,7 +73847,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/security#Multikey\\"].join(\\", \\"));
     }
@@ -74160,7 +74182,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -74169,7 +74191,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\"].join(\\", \\"));
     }
@@ -74396,7 +74418,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -74405,7 +74427,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\"].join(\\", \\"));
     }
@@ -74629,7 +74651,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -74848,7 +74870,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -75070,7 +75092,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -75290,7 +75312,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -75508,7 +75530,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -75726,7 +75748,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -76018,7 +76040,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -76027,7 +76049,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -76036,7 +76058,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -76045,7 +76067,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -76054,7 +76076,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -76268,7 +76290,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -76277,7 +76299,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -76286,7 +76308,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -76295,7 +76317,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -76304,7 +76326,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -76620,7 +76642,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/did#Service\\"].join(\\", \\"));
     }
@@ -77868,7 +77890,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
-      
+
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -77993,7 +78015,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
-      
+
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -78034,7 +78056,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
-      
+
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -78378,7 +78400,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
-      
+
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -78431,7 +78453,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
-      
+
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -79051,8 +79073,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -79165,8 +79187,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -79894,7 +79916,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
-      
+
     }
     instance.#_oKrwxU4V8wiKhMW1QEYQibcJh8c_units = _oKrwxU4V8wiKhMW1QEYQibcJh8c_units;
     
@@ -80092,8 +80114,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -80141,8 +80163,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -80302,7 +80324,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -80782,8 +80804,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -80927,8 +80949,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -81186,7 +81208,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -81405,7 +81427,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -81654,7 +81676,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -81894,7 +81916,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/fep/044f#QuoteAuthorization\\"].join(\\", \\"));
     }
@@ -82388,7 +82410,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3KronwL8DiiKBRcJFKQPiEHm8xb6_closed.push(decoded);
-      
+
     }
     instance.#_3KronwL8DiiKBRcJFKQPiEHm8xb6_closed = _3KronwL8DiiKBRcJFKQPiEHm8xb6_closed;
     const _3H4RdST7dxfmghccvE3rKD3KgcxG_votersCount: (number)[] = [];
@@ -82713,8 +82735,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -82755,8 +82777,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -83047,8 +83069,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -83089,8 +83111,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -83399,8 +83421,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -83530,8 +83552,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -83775,7 +83797,7 @@ relationships?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -83993,7 +84015,7 @@ relationships?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -84303,7 +84325,7 @@ relationships?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Object\\"].join(\\", \\"));
     }
@@ -85048,8 +85070,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -85090,8 +85112,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -85428,8 +85450,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -85892,8 +85914,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -86496,7 +86518,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/security#Key\\"].join(\\", \\"));
     }
@@ -86804,7 +86826,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://w3id.org/security#Multikey\\"].join(\\", \\"));
     }
@@ -87139,7 +87161,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -87148,7 +87170,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\"].join(\\", \\"));
     }
@@ -87375,7 +87397,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -87384,7 +87406,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\"].join(\\", \\"));
     }
@@ -87608,7 +87630,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -87827,7 +87849,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -88049,7 +88071,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -88269,7 +88291,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -88487,7 +88509,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -88705,7 +88727,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Collection\\"].join(\\", \\"));
     }
@@ -88997,7 +89019,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -89006,7 +89028,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -89015,7 +89037,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -89024,7 +89046,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -89033,7 +89055,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -89247,7 +89269,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -89256,7 +89278,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -89265,7 +89287,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -89274,7 +89296,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -89283,7 +89305,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Service\\"].join(\\", \\"));
     }
@@ -89599,7 +89621,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError(\\"Expected an object of any type of: \\" +
         [\\"https://www.w3.org/ns/did#Service\\"].join(\\", \\"));
     }
@@ -90847,7 +90869,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
-      
+
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -90972,7 +90994,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
-      
+
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -91013,7 +91035,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
-      
+
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -91357,7 +91379,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
-      
+
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -91410,7 +91432,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
-      
+
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -92516,7 +92538,7 @@ get contents(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
-      
+
     }
     instance.#_4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content = _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content;
     const _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType: (string)[] = [];
@@ -92667,8 +92689,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -92709,8 +92731,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -93001,8 +93023,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -93043,8 +93065,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -93338,8 +93360,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -93424,8 +93446,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -93986,8 +94008,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -94028,8 +94050,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -94325,8 +94347,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -94367,8 +94389,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -94662,8 +94684,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -94704,8 +94726,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -94994,8 +95016,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -95030,8 +95052,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -95332,8 +95354,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -95374,8 +95396,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
@@ -101,7 +101,7 @@ export class Object {
       #_86xFhmgBapoMvYqjbjRuDPayTrS_generator: (Object | Link | URL)[] = [];
       #_trust_86xFhmgBapoMvYqjbjRuDPayTrS_generator: Set<number> = new Set();
     
-      #_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon: (Image | URL)[] = [];
+      #_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon: (Image | Link | URL)[] = [];
       #_trust_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon: Set<number> = new Set();
     
       #_3dXrUdkARxwyJLtJcYi1AJ92H41U_image: (Image | URL)[] = [];
@@ -179,8 +179,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -439,14 +439,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         }
       
         if ("icon" in values &&             values.icon != null) {
-          if (values.icon instanceof Image || values.icon instanceof URL) {
+          if (values.icon instanceof Image || values.icon instanceof Link || values.icon instanceof URL) {
             // @ts-ignore: type is checked above.
             this.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = [values.icon];
       this.#_trust_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.add(0);
           } else {
             throw new TypeError(
               "The icon must be of type " +
-              "Image | URL" + ".",
+              "Image | Link | URL" + ".",
             );
           }
         }
@@ -462,7 +462,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           }
         
           if (Array.isArray(values.icons) &&
-              values.icons.every(v => v instanceof Image || v instanceof URL)) {
+              values.icons.every(v => v instanceof Image || v instanceof Link || v instanceof URL)) {
             // @ts-ignore: type is checked above.
             this.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = values.icons;
       
@@ -473,7 +473,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           } else {
             throw new TypeError(
               "The icons must be an array of type " +
-              "Image | URL" + ".",
+              "Image | Link | URL" + ".",
             );
           }
         }
@@ -1152,8 +1152,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -1415,14 +1415,14 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         }
       clone.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = this.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon;clone.#_trust_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = new Set(this.#_trust_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon);
         if ("icon" in values &&             values.icon != null) {
-          if (values.icon instanceof Image || values.icon instanceof URL) {
+          if (values.icon instanceof Image || values.icon instanceof Link || values.icon instanceof URL) {
             // @ts-ignore: type is checked above.
             clone.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = [values.icon];
       clone.#_trust_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = new Set([0]);
           } else {
             throw new TypeError(
               "The icon must be of type " +
-              "Image | URL" + ".",
+              "Image | Link | URL" + ".",
             );
           }
         }
@@ -1438,7 +1438,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           }
         
           if (Array.isArray(values.icons) &&
-              values.icons.every(v => v instanceof Image || v instanceof URL)) {
+              values.icons.every(v => v instanceof Image || v instanceof Link || v instanceof URL)) {
             // @ts-ignore: type is checked above.
             clone.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = values.icons;
       
@@ -1450,7 +1450,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
           } else {
             throw new TypeError(
               "The icons must be an array of type " +
-              "Image | URL" + ".",
+              "Image | Link | URL" + ".",
             );
           }
         }
@@ -2243,7 +2243,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -2252,7 +2252,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await PropertyValue.fromJsonLd(
             jsonLd,
@@ -2261,7 +2261,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object","https://www.w3.org/ns/activitystreams#Link","http://schema.org#PropertyValue"].join(", "));
     }
@@ -2480,7 +2480,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -2489,7 +2489,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -2498,7 +2498,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -2507,7 +2507,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -2516,7 +2516,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Service"].join(", "));
     }
@@ -2830,7 +2830,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -3171,7 +3171,7 @@ get contents(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -3180,7 +3180,7 @@ get contents(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object","https://www.w3.org/ns/activitystreams#Link"].join(", "));
     }
@@ -3445,7 +3445,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -3454,7 +3454,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object","https://www.w3.org/ns/activitystreams#Link"].join(", "));
     }
@@ -3564,7 +3564,7 @@ get names(): ((string | LanguageString))[] {
         tracerProvider?: TracerProvider,
         crossOrigin?: "ignore" | "throw" | "trust";
       } = {},
-    ): Promise<Image | null> {
+    ): Promise<Image | Link | null> {
       const documentLoader =
         options.documentLoader ?? this._documentLoader ?? getDocumentLoader();
       const contextLoader =
@@ -3654,7 +3654,7 @@ get names(): ((string | LanguageString))[] {
         tracerProvider?: TracerProvider,
         baseUrl?: URL
       }
-    ): Promise<Image> {
+    ): Promise<Image | Link> {
       const documentLoader =
         options.documentLoader ?? this._documentLoader ?? getDocumentLoader();
       const contextLoader =
@@ -3671,9 +3671,18 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
+        try {
+          return await Link.fromJsonLd(
+            jsonLd,
+            { documentLoader, contextLoader, tracerProvider, baseUrl },
+          );
+        } catch (e) {
+          if (!(e instanceof TypeError)) throw e;
+        }
+
       throw new TypeError("Expected an object of any type of: " +
-        ["https://www.w3.org/ns/activitystreams#Image"].join(", "));
+        ["https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Link"].join(", "));
     }
 
     
@@ -3709,7 +3718,7 @@ get names(): ((string | LanguageString))[] {
           tracerProvider?: TracerProvider,
           crossOrigin?: "ignore" | "throw" | "trust";
         } = {}
-      ): Promise<Image | null> {
+      ): Promise<Image | Link | null> {
         if (this._warning != null) {
           getLogger(this._warning.category).warn(
             this._warning.message,
@@ -3803,7 +3812,7 @@ get names(): ((string | LanguageString))[] {
           tracerProvider?: TracerProvider,
           crossOrigin?: "ignore" | "throw" | "trust";
         } = {}
-      ): AsyncIterable<Image> {
+      ): AsyncIterable<Image | Link> {
         if (this._warning != null) {
           getLogger(this._warning.category).warn(
             this._warning.message,
@@ -3985,7 +3994,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Image"].join(", "));
     }
@@ -4299,7 +4308,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -4308,7 +4317,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object","https://www.w3.org/ns/activitystreams#Link"].join(", "));
     }
@@ -4620,7 +4629,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -4629,7 +4638,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object","https://www.w3.org/ns/activitystreams#Link"].join(", "));
     }
@@ -4941,7 +4950,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Object.fromJsonLd(
             jsonLd,
@@ -4950,7 +4959,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -5273,7 +5282,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -5489,7 +5498,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -5711,7 +5720,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -5933,7 +5942,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -6189,7 +6198,7 @@ get summaries(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -6198,7 +6207,7 @@ get summaries(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object","https://www.w3.org/ns/activitystreams#Link"].join(", "));
     }
@@ -6452,7 +6461,7 @@ get urls(): ((URL | Link))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -6764,7 +6773,7 @@ get urls(): ((URL | Link))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -7076,7 +7085,7 @@ get urls(): ((URL | Link))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -7388,7 +7397,7 @@ get urls(): ((URL | Link))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -7764,7 +7773,7 @@ get urls(): ((URL | Link))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://w3id.org/security#DataIntegrityProof"].join(", "));
     }
@@ -8113,7 +8122,7 @@ get urls(): ((URL | Link))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://gotosocial.org/ns#LikeApproval"].join(", "));
     }
@@ -8329,7 +8338,7 @@ get urls(): ((URL | Link))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://gotosocial.org/ns#ReplyAuthorization"].join(", "));
     }
@@ -8545,7 +8554,7 @@ get urls(): ((URL | Link))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://gotosocial.org/ns#AnnounceAuthorization"].join(", "));
     }
@@ -8868,7 +8877,11 @@ get urls(): ((URL | Link))[] {
       compactItems = [];
       for (const v of this.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon) {
         const item = (
-      v instanceof URL ? v.href : await v.toJsonLd({
+      v instanceof URL ? v.href : v instanceof Image ? await v.toJsonLd({
+           ...(options),
+           format: undefined,
+           context: undefined,
+         }) : await v.toJsonLd({
            ...(options),
            format: undefined,
            context: undefined,
@@ -9573,7 +9586,7 @@ get urls(): ((URL | Link))[] {
     array = [];
     for (const v of this.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon) {
       const element = (
-    v instanceof URL ? { "@id": v.href } : await v.toJsonLd(options)
+    v instanceof URL ? { "@id": v.href } : v instanceof Image ? await v.toJsonLd(options) : await v.toJsonLd(options)
       );
     array.push(element);;
     }
@@ -10479,7 +10492,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _49BipA5dq9eoH8LX8xdsVumveTca_attachment.push(decoded);
-      
+
     }
     instance.#_49BipA5dq9eoH8LX8xdsVumveTca_attachment = _49BipA5dq9eoH8LX8xdsVumveTca_attachment;
     
@@ -10532,7 +10545,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo.push(decoded);
-      
+
     }
     instance.#_42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo = _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo;
     
@@ -10589,7 +10602,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
-      
+
     }
     instance.#_4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content = _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content;
     
@@ -10632,7 +10645,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _3mhZzGXSpQ431mBSz2kvych22v4e_context.push(decoded);
-      
+
     }
     instance.#_3mhZzGXSpQ431mBSz2kvych22v4e_context = _3mhZzGXSpQ431mBSz2kvych22v4e_context;
     const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
@@ -10656,7 +10669,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
-      
+
     }
     instance.#_4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name = _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name;
     const _219RwDanjScTv5tYCjwGZVCM7KZ9_endTime: (Temporal.Instant)[] = [];
@@ -10721,11 +10734,11 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _86xFhmgBapoMvYqjbjRuDPayTrS_generator.push(decoded);
-      
+
     }
     instance.#_86xFhmgBapoMvYqjbjRuDPayTrS_generator = _86xFhmgBapoMvYqjbjRuDPayTrS_generator;
     
-      const _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon: (Image | URL)[] = [];
+      const _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon: (Image | Link | URL)[] = [];
       const _trust_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon: Set<number> = new Set();
     
     let _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon__array = values["https://www.w3.org/ns/activitystreams#icon"];
@@ -10741,20 +10754,29 @@ get urls(): ((URL | Link))[] {
     
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
-        _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(
+        const href =
           !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
             ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
-            : new URL(v["@id"])
-        );
+            : new URL(v["@id"]);
+        _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(new Link({ href }));
         continue;
       }
       
-      const decoded = await Image.fromJsonLd(
+      const decoded =
+      typeof v === "object" && "@type" in v
+      && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Image") ? await Image.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    );
+    ) : typeof v === "object" && "@type" in v
+      && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
+            t => v["@type"].includes(t)) ? await Link.fromJsonLd(
+      v,
+      { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
+    ) : undefined
+      ;
       if (typeof decoded === "undefined") continue;
       _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
+
     }
     instance.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon;
     
@@ -10830,7 +10852,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo.push(decoded);
-      
+
     }
     instance.#_3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo = _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo;
     
@@ -10873,7 +10895,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _31k5MUZJsnsPNg8dQQJieWaXTFnR_location.push(decoded);
-      
+
     }
     instance.#_31k5MUZJsnsPNg8dQQJieWaXTFnR_location = _31k5MUZJsnsPNg8dQQJieWaXTFnR_location;
     
@@ -10916,7 +10938,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(decoded);
-      
+
     }
     instance.#_gCVTegXxWWCw6wWRxa1QF65zusg_preview = _gCVTegXxWWCw6wWRxa1QF65zusg_preview;
     const _5e258TDXtuhaFRPZiGoDfEpjdMr_published: (Temporal.Instant)[] = [];
@@ -11116,7 +11138,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _4LqirZspQbFWWQEbFcXAxm7tTDN1_summary.push(decoded);
-      
+
     }
     instance.#_4LqirZspQbFWWQEbFcXAxm7tTDN1_summary = _4LqirZspQbFWWQEbFcXAxm7tTDN1_summary;
     
@@ -11159,7 +11181,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _5chuqj6s95p5gg2sk1HntGfarRf_tag.push(decoded);
-      
+
     }
     instance.#_5chuqj6s95p5gg2sk1HntGfarRf_tag = _5chuqj6s95p5gg2sk1HntGfarRf_tag;
     const _385aB7ySixcf5Un6z3VsWmThgCzQ_updated: (Temporal.Instant)[] = [];
@@ -11224,7 +11246,7 @@ get urls(): ((URL | Link))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _2oPEH9MQ3aj8JVwyYuWkqoVwV865_url.push(decoded);
-      
+
     }
     instance.#_2oPEH9MQ3aj8JVwyYuWkqoVwV865_url = _2oPEH9MQ3aj8JVwyYuWkqoVwV865_url;
     
@@ -12546,8 +12568,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -12582,8 +12604,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -12895,8 +12917,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -12970,8 +12992,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -13157,7 +13179,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -13397,7 +13419,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://w3id.org/fep/044f#QuoteAuthorization"].join(", "));
     }
@@ -14056,8 +14078,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -14338,8 +14360,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -14738,7 +14760,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -14747,7 +14769,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -14756,7 +14778,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -14765,7 +14787,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -14774,7 +14796,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Service"].join(", "));
     }
@@ -15088,7 +15110,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -15402,7 +15424,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -15722,7 +15744,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -16036,7 +16058,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -16352,7 +16374,7 @@ instruments?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -17009,7 +17031,7 @@ instruments?: (Object | URL)[];}
       ;
       if (typeof decoded === "undefined") continue;
       _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor.push(decoded);
-      
+
     }
     instance.#_2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor = _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor;
     
@@ -17401,8 +17423,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -17443,8 +17465,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -18185,7 +18207,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
       ;
       if (typeof decoded === "undefined") continue;
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
-      
+
     }
     instance.#_4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name = _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name;
     const _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value: ((string | LanguageString))[] = [];
@@ -18209,7 +18231,7 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
       ;
       if (typeof decoded === "undefined") continue;
       _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value.push(decoded);
-      
+
     }
     instance.#_2cSy2magg4iZ7zLaG8U7DiJMoCkx_value = _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value;
     
@@ -18923,8 +18945,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -18985,8 +19007,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -19159,7 +19181,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -19375,7 +19397,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -19930,8 +19952,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -19972,8 +19994,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -21743,8 +21765,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -21805,8 +21827,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -21979,7 +22001,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -22195,7 +22217,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -22749,8 +22771,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -22791,8 +22813,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -23095,8 +23117,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -23157,8 +23179,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -23331,7 +23353,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -23547,7 +23569,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -24101,8 +24123,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -24143,8 +24165,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -24447,8 +24469,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -24509,8 +24531,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -24683,7 +24705,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -24898,7 +24920,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -25452,8 +25474,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -25494,8 +25516,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -26952,7 +26974,7 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://w3id.org/security#Multikey"].join(", "));
     }
@@ -27894,7 +27916,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -27903,7 +27925,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -27912,7 +27934,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -27921,7 +27943,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -27930,7 +27952,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Service"].join(", "));
     }
@@ -28343,7 +28365,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       ;
       if (typeof decoded === "undefined") continue;
       _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner.push(decoded);
-      
+
     }
     instance.#_5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner = _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner;
     const _2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem: (CryptoKey)[] = [];
@@ -28765,7 +28787,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -28774,7 +28796,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -28783,7 +28805,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -28792,7 +28814,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -28801,7 +28823,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Service"].join(", "));
     }
@@ -29221,7 +29243,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       ;
       if (typeof decoded === "undefined") continue;
       _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller.push(decoded);
-      
+
     }
     instance.#_2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller = _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller;
     const _4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase: (CryptoKey)[] = [];
@@ -30318,8 +30340,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -30406,8 +30428,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -31111,8 +31133,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -31153,8 +31175,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -31451,8 +31473,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -31493,8 +31515,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -31786,8 +31808,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -31828,8 +31850,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -32166,8 +32188,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -32630,8 +32652,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -33234,7 +33256,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://w3id.org/security#Key"].join(", "));
     }
@@ -33542,7 +33564,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://w3id.org/security#Multikey"].join(", "));
     }
@@ -33877,7 +33899,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -33886,7 +33908,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#OrderedCollectionPage"].join(", "));
     }
@@ -34113,7 +34135,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -34122,7 +34144,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#OrderedCollectionPage"].join(", "));
     }
@@ -34346,7 +34368,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -34565,7 +34587,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -34787,7 +34809,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -35007,7 +35029,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -35225,7 +35247,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -35443,7 +35465,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -35735,7 +35757,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -35744,7 +35766,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -35753,7 +35775,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -35762,7 +35784,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -35771,7 +35793,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Service"].join(", "));
     }
@@ -35985,7 +36007,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -35994,7 +36016,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -36003,7 +36025,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -36012,7 +36034,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -36021,7 +36043,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Service"].join(", "));
     }
@@ -36337,7 +36359,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/did#Service"].join(", "));
     }
@@ -37585,7 +37607,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
-      
+
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -37710,7 +37732,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
-      
+
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -37751,7 +37773,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
-      
+
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -38095,7 +38117,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
-      
+
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -38148,7 +38170,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
-      
+
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -38762,8 +38784,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -38804,8 +38826,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -39109,8 +39131,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -39151,8 +39173,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -39448,8 +39470,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -39523,8 +39545,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -39710,7 +39732,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -39950,7 +39972,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://w3id.org/fep/044f#QuoteAuthorization"].join(", "));
     }
@@ -40588,8 +40610,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -40650,8 +40672,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -41167,8 +41189,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -41203,8 +41225,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -41506,8 +41528,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -41548,8 +41570,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -41846,8 +41868,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -41888,8 +41910,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -42220,8 +42242,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -42431,8 +42453,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -42771,7 +42793,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#CollectionPage"].join(", "));
     }
@@ -42987,7 +43009,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#CollectionPage"].join(", "));
     }
@@ -43203,7 +43225,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#CollectionPage"].join(", "));
     }
@@ -43419,7 +43441,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -43428,7 +43450,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object","https://www.w3.org/ns/activitystreams#Link"].join(", "));
     }
@@ -43646,7 +43668,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -43861,7 +43883,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -44076,7 +44098,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -44291,7 +44313,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -44506,7 +44528,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -44721,7 +44743,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -44936,7 +44958,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -45151,7 +45173,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -46079,7 +46101,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       ;
       if (typeof decoded === "undefined") continue;
       _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
-      
+
     }
     instance.#_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items = _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items;
     
@@ -46687,8 +46709,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -46762,8 +46784,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -46949,7 +46971,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -47165,7 +47187,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#CollectionPage"].join(", "));
     }
@@ -47379,7 +47401,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#CollectionPage"].join(", "));
     }
@@ -48015,8 +48037,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -48057,8 +48079,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -48349,8 +48371,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -48391,8 +48413,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -48681,8 +48703,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -48723,8 +48745,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -50135,8 +50157,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -50171,8 +50193,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -50475,8 +50497,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -50517,8 +50539,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -50811,8 +50833,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -50853,8 +50875,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -51191,8 +51213,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -51655,8 +51677,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -52259,7 +52281,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://w3id.org/security#Key"].join(", "));
     }
@@ -52567,7 +52589,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://w3id.org/security#Multikey"].join(", "));
     }
@@ -52902,7 +52924,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -52911,7 +52933,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#OrderedCollectionPage"].join(", "));
     }
@@ -53138,7 +53160,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -53147,7 +53169,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#OrderedCollectionPage"].join(", "));
     }
@@ -53371,7 +53393,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -53590,7 +53612,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -53812,7 +53834,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -54032,7 +54054,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -54250,7 +54272,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -54468,7 +54490,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -54760,7 +54782,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -54769,7 +54791,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -54778,7 +54800,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -54787,7 +54809,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -54796,7 +54818,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Service"].join(", "));
     }
@@ -55010,7 +55032,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -55019,7 +55041,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -55028,7 +55050,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -55037,7 +55059,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -55046,7 +55068,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Service"].join(", "));
     }
@@ -55362,7 +55384,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/did#Service"].join(", "));
     }
@@ -56610,7 +56632,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
-      
+
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -56735,7 +56757,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
-      
+
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -56776,7 +56798,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
-      
+
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -57120,7 +57142,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
-      
+
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -57173,7 +57195,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
-      
+
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -58461,7 +58483,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Object.fromJsonLd(
             jsonLd,
@@ -58470,7 +58492,7 @@ get names(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -59111,7 +59133,7 @@ get names(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
-      
+
     }
     instance.#_4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name = _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name;
     const _f57HKWCp1YRBbTJE8PF12RbDJGf_hreflang: (Intl.Locale)[] = [];
@@ -59208,7 +59230,7 @@ get names(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(decoded);
-      
+
     }
     instance.#_gCVTegXxWWCw6wWRxa1QF65zusg_preview = _gCVTegXxWWCw6wWRxa1QF65zusg_preview;
     
@@ -59768,8 +59790,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -59804,8 +59826,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -60108,8 +60130,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -60150,8 +60172,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -60446,8 +60468,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -60488,8 +60510,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -60780,8 +60802,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -60822,8 +60844,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -61114,8 +61136,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -61156,8 +61178,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -61448,8 +61470,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -61490,8 +61512,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -61780,8 +61802,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -61822,8 +61844,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -62413,8 +62435,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -62455,8 +62477,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -62754,8 +62776,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -62829,8 +62851,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -63016,7 +63038,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -63256,7 +63278,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://w3id.org/fep/044f#QuoteAuthorization"].join(", "));
     }
@@ -63897,8 +63919,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -63952,8 +63974,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -64120,7 +64142,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -64129,7 +64151,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object","https://www.w3.org/ns/activitystreams#Link"].join(", "));
     }
@@ -64509,7 +64531,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       ;
       if (typeof decoded === "undefined") continue;
       _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
-      
+
     }
     instance.#_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items = _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items;
     
@@ -64608,8 +64630,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -64676,8 +64698,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -64857,7 +64879,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Link.fromJsonLd(
             jsonLd,
@@ -64866,7 +64888,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object","https://www.w3.org/ns/activitystreams#Link"].join(", "));
     }
@@ -65295,7 +65317,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       ;
       if (typeof decoded === "undefined") continue;
       _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
-      
+
     }
     instance.#_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items = _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items;
     const _2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex: (number)[] = [];
@@ -65473,8 +65495,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -65937,8 +65959,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -66541,7 +66563,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://w3id.org/security#Key"].join(", "));
     }
@@ -66849,7 +66871,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://w3id.org/security#Multikey"].join(", "));
     }
@@ -67184,7 +67206,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -67193,7 +67215,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#OrderedCollectionPage"].join(", "));
     }
@@ -67420,7 +67442,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -67429,7 +67451,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#OrderedCollectionPage"].join(", "));
     }
@@ -67653,7 +67675,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -67872,7 +67894,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -68094,7 +68116,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -68314,7 +68336,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -68532,7 +68554,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -68750,7 +68772,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -69042,7 +69064,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -69051,7 +69073,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -69060,7 +69082,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -69069,7 +69091,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -69078,7 +69100,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Service"].join(", "));
     }
@@ -69292,7 +69314,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -69301,7 +69323,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -69310,7 +69332,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -69319,7 +69341,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -69328,7 +69350,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Service"].join(", "));
     }
@@ -69644,7 +69666,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/did#Service"].join(", "));
     }
@@ -70892,7 +70914,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
-      
+
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -71017,7 +71039,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
-      
+
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -71058,7 +71080,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
-      
+
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -71402,7 +71424,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
-      
+
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -71455,7 +71477,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
-      
+
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -72066,8 +72088,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -72102,8 +72124,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -72451,8 +72473,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -72915,8 +72937,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -73519,7 +73541,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://w3id.org/security#Key"].join(", "));
     }
@@ -73827,7 +73849,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://w3id.org/security#Multikey"].join(", "));
     }
@@ -74162,7 +74184,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -74171,7 +74193,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#OrderedCollectionPage"].join(", "));
     }
@@ -74398,7 +74420,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -74407,7 +74429,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#OrderedCollectionPage"].join(", "));
     }
@@ -74631,7 +74653,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -74850,7 +74872,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -75072,7 +75094,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -75292,7 +75314,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -75510,7 +75532,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -75728,7 +75750,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -76020,7 +76042,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -76029,7 +76051,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -76038,7 +76060,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -76047,7 +76069,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -76056,7 +76078,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Service"].join(", "));
     }
@@ -76270,7 +76292,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -76279,7 +76301,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -76288,7 +76310,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -76297,7 +76319,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -76306,7 +76328,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Service"].join(", "));
     }
@@ -76622,7 +76644,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/did#Service"].join(", "));
     }
@@ -77870,7 +77892,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
-      
+
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -77995,7 +78017,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
-      
+
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -78036,7 +78058,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
-      
+
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -78380,7 +78402,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
-      
+
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -78433,7 +78455,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
-      
+
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -79053,8 +79075,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -79167,8 +79189,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -79896,7 +79918,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
       ;
       if (typeof decoded === "undefined") continue;
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
-      
+
     }
     instance.#_oKrwxU4V8wiKhMW1QEYQibcJh8c_units = _oKrwxU4V8wiKhMW1QEYQibcJh8c_units;
     
@@ -80094,8 +80116,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -80143,8 +80165,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -80304,7 +80326,7 @@ proofs?: (DataIntegrityProof | URL)[];interactionPolicy?: InteractionPolicy | nu
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -80784,8 +80806,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -80929,8 +80951,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -81188,7 +81210,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -81407,7 +81429,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -81656,7 +81678,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -81896,7 +81918,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://w3id.org/fep/044f#QuoteAuthorization"].join(", "));
     }
@@ -82390,7 +82412,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       ;
       if (typeof decoded === "undefined") continue;
       _3KronwL8DiiKBRcJFKQPiEHm8xb6_closed.push(decoded);
-      
+
     }
     instance.#_3KronwL8DiiKBRcJFKQPiEHm8xb6_closed = _3KronwL8DiiKBRcJFKQPiEHm8xb6_closed;
     const _3H4RdST7dxfmghccvE3rKD3KgcxG_votersCount: (number)[] = [];
@@ -82715,8 +82737,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -82757,8 +82779,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -83049,8 +83071,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -83091,8 +83113,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -83401,8 +83423,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -83532,8 +83554,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -83777,7 +83799,7 @@ relationships?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -83995,7 +84017,7 @@ relationships?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -84305,7 +84327,7 @@ relationships?: (Object | URL)[];}
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Object"].join(", "));
     }
@@ -85050,8 +85072,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -85092,8 +85114,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -85430,8 +85452,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -85894,8 +85916,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -86498,7 +86520,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://w3id.org/security#Key"].join(", "));
     }
@@ -86806,7 +86828,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://w3id.org/security#Multikey"].join(", "));
     }
@@ -87141,7 +87163,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -87150,7 +87172,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#OrderedCollectionPage"].join(", "));
     }
@@ -87377,7 +87399,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await OrderedCollectionPage.fromJsonLd(
             jsonLd,
@@ -87386,7 +87408,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#OrderedCollectionPage"].join(", "));
     }
@@ -87610,7 +87632,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -87829,7 +87851,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -88051,7 +88073,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -88271,7 +88293,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -88489,7 +88511,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -88707,7 +88729,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Collection"].join(", "));
     }
@@ -88999,7 +89021,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -89008,7 +89030,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -89017,7 +89039,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -89026,7 +89048,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -89035,7 +89057,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Service"].join(", "));
     }
@@ -89249,7 +89271,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Group.fromJsonLd(
             jsonLd,
@@ -89258,7 +89280,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Organization.fromJsonLd(
             jsonLd,
@@ -89267,7 +89289,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Person.fromJsonLd(
             jsonLd,
@@ -89276,7 +89298,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
         try {
           return await Service.fromJsonLd(
             jsonLd,
@@ -89285,7 +89307,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Service"].join(", "));
     }
@@ -89601,7 +89623,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      
+
       throw new TypeError("Expected an object of any type of: " +
         ["https://www.w3.org/ns/did#Service"].join(", "));
     }
@@ -90849,7 +90871,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
-      
+
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -90974,7 +90996,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
-      
+
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -91015,7 +91037,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
-      
+
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -91359,7 +91381,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
-      
+
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -91412,7 +91434,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
-      
+
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -92518,7 +92540,7 @@ get contents(): ((string | LanguageString))[] {
       ;
       if (typeof decoded === "undefined") continue;
       _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
-      
+
     }
     instance.#_4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content = _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content;
     const _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType: (string)[] = [];
@@ -92669,8 +92691,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -92711,8 +92733,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -93003,8 +93025,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -93045,8 +93067,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -93340,8 +93362,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -93426,8 +93448,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -93988,8 +94010,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -94030,8 +94052,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -94327,8 +94349,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -94369,8 +94391,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -94664,8 +94686,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -94706,8 +94728,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -94996,8 +95018,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -95032,8 +95054,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -95334,8 +95356,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;
@@ -95376,8 +95398,8 @@ attachments?: (Object | Link | PropertyValue | URL)[];attribution?: Application 
 attributions?: (Application | Group | Organization | Person | Service | URL)[];audience?: Object | URL | null;
 audiences?: (Object | URL)[];content?: string | LanguageString | null;
 contents?: ((string | LanguageString))[];contexts?: (Object | Link | URL)[];name?: string | LanguageString | null;
-names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | URL | null;
-icons?: (Image | URL)[];image?: Image | URL | null;
+names?: ((string | LanguageString))[];endTime?: Temporal.Instant | null;generators?: (Object | Link | URL)[];icon?: Image | Link | URL | null;
+icons?: (Image | Link | URL)[];image?: Image | URL | null;
 images?: (Image | URL)[];replyTarget?: Object | Link | URL | null;
 replyTargets?: (Object | Link | URL)[];location?: Object | Link | URL | null;
 locations?: (Object | Link | URL)[];preview?: Link | Object | URL | null;

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -13,6 +13,10 @@ import {
   isCompactableType,
 } from "./type.ts";
 
+const AS_LINK_URI = "https://www.w3.org/ns/activitystreams#Link";
+const AS_OBJECT_URI = "https://www.w3.org/ns/activitystreams#Object";
+const XSD_ANY_URI = "http://www.w3.org/2001/XMLSchema#anyURI";
+
 export async function* generateEncoder(
   typeUri: string,
   types: Record<string, TypeSchema>,
@@ -402,6 +406,9 @@ export async function* generateDecoder(
   }
   for (const property of type.properties) {
     const variable = await getFieldName(property.uri, "");
+    const decodeBareIdAsLink = property.range.includes(AS_LINK_URI) &&
+      !property.range.includes(AS_OBJECT_URI) &&
+      !property.range.includes(XSD_ANY_URI);
     yield await generateField(property, types, "const ");
     const arrayVariable = `${variable}__array`;
     yield `
@@ -427,7 +434,20 @@ export async function* generateDecoder(
       if (v == null) continue;
     `;
     if (!areAllScalarTypes(property.range, types)) {
-      yield `
+      if (decodeBareIdAsLink) {
+        yield `
+      if (typeof v === "object" && "@id" in v && !("@type" in v)
+          && globalThis.Object.keys(v).length === 1) {
+        const href =
+          !URL.canParse(v["@id"]) && v["@id"].startsWith("at://")
+            ? new URL("at://" + encodeURIComponent(v["@id"].substring(5)))
+            : new URL(v["@id"]);
+        ${variable}.push(new Link({ href }));
+        continue;
+      }
+      `;
+      } else {
+        yield `
       if (typeof v === "object" && "@id" in v && !("@type" in v)
           && globalThis.Object.keys(v).length === 1) {
         ${variable}.push(
@@ -438,6 +458,7 @@ export async function* generateDecoder(
         continue;
       }
       `;
+      }
     }
     if (property.range.length == 1) {
       yield `
@@ -468,7 +489,7 @@ export async function* generateDecoder(
       ;
       if (typeof decoded === "undefined") continue;
       ${variable}.push(decoded);
-      `;
+`;
     }
     yield `
     }

--- a/packages/vocab-tools/src/property.ts
+++ b/packages/vocab-tools/src/property.ts
@@ -177,7 +177,7 @@ async function* generateProperty(
         } catch (e) {
           if (!(e instanceof TypeError)) throw e;
         }
-      `;
+`;
     }
     yield `
       throw new TypeError("Expected an object of any type of: " +

--- a/packages/vocab/src/object.yaml
+++ b/packages/vocab/src/object.yaml
@@ -137,6 +137,7 @@ properties:
     (vertical) and should be suitable for presentation at a small size.
   range:
   - "https://www.w3.org/ns/activitystreams#Image"
+  - "https://www.w3.org/ns/activitystreams#Link"
 
 - pluralName: images
   singularName: image

--- a/packages/vocab/src/vocab.test.ts
+++ b/packages/vocab/src/vocab.test.ts
@@ -32,6 +32,7 @@ import {
   Endpoints,
   Follow,
   Hashtag,
+  Image,
   InteractionPolicy,
   InteractionRule,
   Link,
@@ -1766,6 +1767,28 @@ test("Link.fromJsonLd()", async () => {
   );
 });
 
+test("Person.fromJsonLd() treats URL string icon as Link", async () => {
+  const iconUrl = new URL("https://example.com/static/favicon.png");
+  const unavailableDocumentLoader = () => {
+    throw new Error("direct icon URL should not be dereferenced");
+  };
+  const person = await Person.fromJsonLd({
+    "@context": "https://www.w3.org/ns/activitystreams",
+    id: "https://example.com/@alice",
+    type: "Person",
+    icon: iconUrl.href,
+  }, {
+    documentLoader: unavailableDocumentLoader,
+    contextLoader: mockDocumentLoader,
+  });
+
+  const icon = await person.getIcon({
+    documentLoader: unavailableDocumentLoader,
+  }) as unknown;
+  assertInstanceOf(icon, Link);
+  deepStrictEqual((icon as Link).href, iconUrl);
+});
+
 test("Person.fromJsonLd() with relative URLs", async () => {
   const json = {
     "@context": [
@@ -1784,8 +1807,9 @@ test("Person.fromJsonLd() with relative URLs", async () => {
   });
 
   const icon = await person.getIcon();
+  assertInstanceOf(icon, Image);
   deepStrictEqual(
-    icon?.url,
+    icon.url,
     new URL("https://example.com/avatars/test-avatar.jpg"),
   );
 
@@ -1810,8 +1834,9 @@ test("Person.fromJsonLd() with relative URLs", async () => {
   });
 
   const icon2 = await person2.getIcon();
+  assertInstanceOf(icon2, Image);
   deepStrictEqual(
-    icon2?.url,
+    icon2.url,
     new URL("https://media.example.com/avatars/test-avatar.jpg"),
   );
 });
@@ -1838,8 +1863,9 @@ test("Person.fromJsonLd() with relative URLs and baseUrl", async () => {
   });
 
   const icon = await personWithBase.getIcon();
+  assertInstanceOf(icon, Image);
   deepStrictEqual(
-    icon?.url,
+    icon.url,
     new URL("https://example.com/avatars/test-avatar.jpg"),
   );
 });


### PR DESCRIPTION
## Summary

- Allow Activity Vocabulary `icon` URL strings to decode as `Link` values instead of remote `Image` document references.
- Keep WebFinger avatar generation working for both `Image.url` and `Link.href` icons.
- Refresh generated vocab-tools snapshots for Deno, Node, and Bun.

Fixes: https://github.com/fedify-dev/fedify/issues/420

## Verification

- `docker run --rm -v "$PWD":/workspace -w /workspace denoland/deno:2.7.13 deno task -f @fedify/vocab compile`
- `docker run --rm -v "$PWD":/workspace -w /workspace/packages/vocab denoland/deno:2.7.13 deno test --allow-read --allow-write --allow-env --unstable-kv --trace-leaks --filter "URL string icon" src/vocab.test.ts`
- `docker run --rm -v "$PWD":/workspace -w /workspace/packages/vocab denoland/deno:2.7.13 deno test --allow-read --allow-write --allow-env --unstable-kv --trace-leaks --filter "relative URLs" src/vocab.test.ts`
- `docker run --rm -v "$PWD":/workspace -w /workspace/packages/fedify denoland/deno:2.7.13 deno test --check --doc --allow-read --allow-write --allow-env --unstable-kv --trace-leaks src/federation/webfinger.test.ts`
- `docker run --rm -v "$PWD":/workspace -w /workspace/packages/vocab-tools denoland/deno:2.7.13 deno test -A`
- `node --experimental-transform-types --test src/class.test.ts` from `packages/vocab-tools`
- `bun test --timeout 15000 src/class.test.ts` from `packages/vocab-tools`
- `docker run --rm -v "$PWD":/workspace -w /workspace denoland/deno:2.7.13 deno fmt --check CHANGES.md packages/fedify/src/federation/webfinger.ts packages/vocab-tools/src/codec.ts packages/vocab-tools/src/property.ts packages/vocab/src/vocab.test.ts`
- `docker run --rm -v "$PWD":/workspace -w /workspace denoland/deno:2.7.13 deno lint packages/fedify/src/federation/webfinger.ts packages/vocab-tools/src/codec.ts packages/vocab-tools/src/property.ts packages/vocab/src/vocab.test.ts`
- `docker run --rm -v "$PWD":/workspace -w /workspace denoland/deno:2.7.13 deno check packages/fedify/src/federation/webfinger.ts packages/vocab-tools/src/codec.ts packages/vocab-tools/src/property.ts packages/vocab/src/vocab.test.ts`
- `git diff --check`

## AI usage

This change and PR description were assisted by OpenAI GPT-5. The commit includes the required `Assisted-by: OpenAI GPT-5:gpt-5` trailer.