### PR TITLE
Add `--skip-install` option to `fedify init`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -265,6 +265,15 @@ To be released.
  -  Added `SqliteMessageQueue.getDepth()` for reporting queued, ready, and
     delayed message counts.  [[#735], [#748]]
 
+### @fedify/cli
+
+ -  Added the `--skip-install` option to `fedify init`, following the
+    corresponding `@fedify/init` update, which skips automatic dependency
+    installation after scaffolding.  [[#720], [#776] by fru1tworld]
+
+[#720]: https://github.com/fedify-dev/fedify/issues/720
+[#776]: https://github.com/fedify-dev/fedify/pull/776
+
 ### @fedify/init
 
  -  Added a `--skip-install` option to `fedify init` that skips automatic
@@ -272,9 +281,6 @@ To be released.
     environments, monorepo workspaces that install dependencies from the
     root, or when you want to inspect the generated files before
     installing.  [[#720], [#776] by fru1tworld]
-
-[#720]: https://github.com/fedify-dev/fedify/issues/720
-[#776]: https://github.com/fedify-dev/fedify/pull/776
 
 ### Claude Code plugin
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -265,6 +265,17 @@ To be released.
  -  Added `SqliteMessageQueue.getDepth()` for reporting queued, ready, and
     delayed message counts.  [[#735], [#748]]
 
+### @fedify/init
+
+ -  Added a `--skip-install` option to `fedify init` that skips automatic
+    dependency installation after scaffolding.  This is useful for CI
+    environments, monorepo workspaces that install dependencies from the
+    root, or when you want to inspect the generated files before
+    installing.  [[#720], [#776] by fru1tworld]
+
+[#720]: https://github.com/fedify-dev/fedify/issues/720
+[#776]: https://github.com/fedify-dev/fedify/pull/776
+
 ### Claude Code plugin
 
  -  Added a Claude Code plugin at *claude-plugin/*, installable with:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -372,6 +372,28 @@ the selected framework scaffolder accepts them.  Some scaffolders, such as
 own confirmation prompt, while a freshly initialized *.git* directory remains
 acceptable.
 
+### `--skip-install`: Skip installing dependencies
+
+*This option is available since Fedify 2.3.0.*
+
+By default, `fedify init` runs the selected package manager's install command
+right after scaffolding the project.  The `--skip-install` option scaffolds the
+files without running install, which is useful when:
+
+ -  installation is handled separately in a CI pipeline;
+ -  the new project lives inside a monorepo whose dependencies are installed
+    from the workspace root; or
+ -  you want to inspect the generated files before installing.
+
+~~~~ sh
+fedify init my-fedify-project --skip-install
+~~~~
+
+After scaffolding, `fedify init` prints the command to run to install
+dependencies later.  Other steps such as creating files, applying patches, and
+running the framework-specific scaffolder (e.g., *create-next-app*) still
+happen as usual; only the final install step is skipped.
+
 
 `fedify lookup`: Looking up an ActivityPub object
 -------------------------------------------------

--- a/packages/init/src/action/configs.test.ts
+++ b/packages/init/src/action/configs.test.ts
@@ -21,6 +21,7 @@ function createInitData(): InitCommandData {
     messageQueue: "denokv",
     dryRun: false,
     allowNonEmpty: false,
+    skipInstall: false,
     testMode: false,
     dir: "/tmp/example",
     initializer: {
@@ -166,6 +167,7 @@ async function createNpmInitData(dir: string): Promise<InitCommandData> {
     messageQueue: "in-process",
     dryRun: false,
     allowNonEmpty: false,
+    skipInstall: false,
     testMode: false,
     dir,
   });
@@ -179,6 +181,7 @@ async function createNpmInitData(dir: string): Promise<InitCommandData> {
     messageQueue: "in-process",
     dryRun: false,
     allowNonEmpty: false,
+    skipInstall: false,
     testMode: false,
     dir,
     initializer,
@@ -199,6 +202,7 @@ async function createNuxtNpmInitData(dir: string): Promise<InitCommandData> {
     messageQueue: "in-process",
     dryRun: false,
     allowNonEmpty: false,
+    skipInstall: false,
     testMode: false,
     dir,
   });
@@ -212,6 +216,7 @@ async function createNuxtNpmInitData(dir: string): Promise<InitCommandData> {
     messageQueue: "in-process",
     dryRun: false,
     allowNonEmpty: false,
+    skipInstall: false,
     testMode: false,
     dir,
     initializer,

--- a/packages/init/src/action/mod.ts
+++ b/packages/init/src/action/mod.ts
@@ -39,11 +39,11 @@ import {
  * 5. Converts `InitCommandOptions` into `InitCommandData` via `setData`.
  * 6. Branches based on `isDry`:
  *    - If dry run, executes `handleDryRun`.
- *    - Otherwise, executes `handleHydRun`.
+ *    - Otherwise, executes `handleHydRun`, which installs dependencies, or—when
+ *      `--skip-install` is set—prints how to install them manually via
+ *      `noticeSkippedInstall`.
  * 7. Recommends configuration environment via `recommendConfigEnv`.
- * 8. If installation was skipped and not a dry run, prints how to install
- *    dependencies manually via `noticeSkippedInstall`.
- * 9. Shows how to run the project via `noticeHowToRun`.
+ * 8. Shows how to run the project via `noticeHowToRun`.
  */
 const runInit = (options: InitCommand) =>
   pipe(
@@ -56,7 +56,6 @@ const runInit = (options: InitCommand) =>
     when(isDry, handleDryRun),
     unless(isDry, handleHydRun),
     tap(recommendConfigEnv),
-    tap(unless(isDry, when(isSkipInstall, noticeSkippedInstall))),
     tap(noticeHowToRun),
   );
 
@@ -82,4 +81,5 @@ const handleHydRun = (data: InitCommandData) =>
     tap(when(hasCommand, runPrecommand)),
     tap(patchFiles),
     tap(unless(isSkipInstall, installDependencies)),
+    tap(when(isSkipInstall, noticeSkippedInstall)),
   );

--- a/packages/init/src/action/mod.ts
+++ b/packages/init/src/action/mod.ts
@@ -11,6 +11,7 @@ import {
   noticeHowToRun,
   noticeOptions,
   noticePrecommand,
+  noticeSkippedInstall,
 } from "./notice.ts";
 import {
   assertNoGeneratedFileConflicts,
@@ -23,6 +24,7 @@ import {
   hasCommand,
   installDependencies,
   isDry,
+  isSkipInstall,
   runPrecommand,
 } from "./utils.ts";
 
@@ -39,7 +41,9 @@ import {
  *    - If dry run, executes `handleDryRun`.
  *    - Otherwise, executes `handleHydRun`.
  * 7. Recommends configuration environment via `recommendConfigEnv`.
- * 8. Shows how to run the project via `noticeHowToRun`.
+ * 8. If installation was skipped and not a dry run, prints how to install
+ *    dependencies manually via `noticeSkippedInstall`.
+ * 9. Shows how to run the project via `noticeHowToRun`.
  */
 const runInit = (options: InitCommand) =>
   pipe(
@@ -52,6 +56,7 @@ const runInit = (options: InitCommand) =>
     when(isDry, handleDryRun),
     unless(isDry, handleHydRun),
     tap(recommendConfigEnv),
+    tap(unless(isDry, when(isSkipInstall, noticeSkippedInstall))),
     tap(noticeHowToRun),
   );
 
@@ -76,5 +81,5 @@ const handleHydRun = (data: InitCommandData) =>
     tap(assertNoGeneratedFileConflicts),
     tap(when(hasCommand, runPrecommand)),
     tap(patchFiles),
-    tap(installDependencies),
+    tap(unless(isSkipInstall, installDependencies)),
   );

--- a/packages/init/src/action/notice.ts
+++ b/packages/init/src/action/notice.ts
@@ -1,4 +1,4 @@
-import { text } from "@optique/core";
+import { commandLine, text } from "@optique/core";
 import { flow } from "es-toolkit";
 import type { InitCommand } from "../command.ts";
 import type { InitCommandData } from "../types.ts";
@@ -123,7 +123,7 @@ export const noticeSkippedInstall = (
 ) =>
   printMessage`
 Dependencies were not installed.  Run ${
-    text(`${packageManager} install`)
+    commandLine(`${packageManager} install`)
   } in the project directory to install them.
 `;
 

--- a/packages/init/src/action/notice.ts
+++ b/packages/init/src/action/notice.ts
@@ -117,6 +117,16 @@ ${instruction}
 Start by editing the ${text(federationFile)} file to define your federation!
 `;
 
+/** Prints a notice that dependency installation was skipped and how to install them manually. */
+export const noticeSkippedInstall = (
+  { packageManager }: InitCommandData,
+) =>
+  printMessage`
+Dependencies were not installed.  Run ${
+    text(`${packageManager} install`)
+  } in the project directory to install them.
+`;
+
 /**
  * Returns an error handler that prints a formatted error message when
  * a dependency installation command fails, then throws.

--- a/packages/init/src/action/patch.test.ts
+++ b/packages/init/src/action/patch.test.ts
@@ -74,6 +74,7 @@ function createInitData(
     messageQueue: "in-process",
     dryRun: false,
     allowNonEmpty,
+    skipInstall: false,
     testMode: false,
     dir,
     initializer: {

--- a/packages/init/src/action/utils.ts
+++ b/packages/init/src/action/utils.ts
@@ -5,6 +5,11 @@ import type { InitCommandData } from "../types.ts";
 /** Returns `true` if the current run is in dry-run mode. */
 export const isDry = ({ dryRun }: InitCommandData) => dryRun;
 
+/** Returns `true` if the current run skips dependency installation. */
+export const isSkipInstall = (
+  { skipInstall }: Pick<InitCommandData, "skipInstall">,
+) => skipInstall;
+
 /** Returns `true` if the framework initializer has a precommand to execute. */
 export const hasCommand = (data: InitCommandData) => !!data.initializer.command;
 

--- a/packages/init/src/command.ts
+++ b/packages/init/src/command.ts
@@ -77,6 +77,10 @@ export const initOptions = object("Initialization options", {
     description:
       message`Allow initializing in a non-empty directory when the selected framework scaffolder supports it, failing if any generated file already exists.`,
   }),
+  skipInstall: option("--skip-install", {
+    description:
+      message`Skip installing dependencies after scaffolding the project.`,
+  }),
 });
 
 /**

--- a/packages/init/src/package.test.ts
+++ b/packages/init/src/package.test.ts
@@ -46,6 +46,7 @@ test(
       dir: packageDir,
       dryRun: true,
       allowNonEmpty: false,
+      skipInstall: false,
       kvStore: "in-memory",
       messageQueue: "in-process",
       packageManager: "bun",

--- a/packages/init/src/skip-install.test.ts
+++ b/packages/init/src/skip-install.test.ts
@@ -1,0 +1,26 @@
+import { parse } from "@optique/core/parser";
+import { ok, strictEqual } from "node:assert/strict";
+import test from "node:test";
+import { isSkipInstall } from "./action/utils.ts";
+import { initOptions } from "./command.ts";
+
+test("initOptions parses --skip-install as true", () => {
+  const result = parse(initOptions, ["--skip-install"]);
+  ok(result.success);
+  if (result.success) {
+    strictEqual(result.value.skipInstall, true);
+  }
+});
+
+test("initOptions defaults skipInstall to false when the flag is absent", () => {
+  const result = parse(initOptions, []);
+  ok(result.success);
+  if (result.success) {
+    strictEqual(result.value.skipInstall, false);
+  }
+});
+
+test("isSkipInstall mirrors the skipInstall field", () => {
+  strictEqual(isSkipInstall({ skipInstall: false }), false);
+  strictEqual(isSkipInstall({ skipInstall: true }), true);
+});

--- a/packages/init/src/webframeworks.test.ts
+++ b/packages/init/src/webframeworks.test.ts
@@ -17,6 +17,7 @@ test("Nitro template loads LogTape during server startup", async () => {
     testMode: false,
     dryRun: true,
     allowNonEmpty: false,
+    skipInstall: false,
   });
 
   ok(files);
@@ -38,6 +39,7 @@ test("Next.js template loads LogTape through instrumentation", async () => {
     testMode: false,
     dryRun: true,
     allowNonEmpty: false,
+    skipInstall: false,
   });
 
   ok(files);
@@ -61,6 +63,7 @@ test("Astro template loads LogTape through middleware", async () => {
     testMode: false,
     dryRun: true,
     allowNonEmpty: false,
+    skipInstall: false,
   });
 
   ok(files);
@@ -81,6 +84,7 @@ test("SolidStart template loads LogTape through middleware", async () => {
     testMode: false,
     dryRun: true,
     allowNonEmpty: false,
+    skipInstall: false,
   });
 
   ok(files);

--- a/packages/init/src/webframeworks/next.ts
+++ b/packages/init/src/webframeworks/next.ts
@@ -9,8 +9,8 @@ const nextDescription: WebFrameworkDescription = {
   label: "Next.js",
   packageManagers: PACKAGE_MANAGER,
   defaultPort: 3000,
-  init: async ({ packageManager: pm }) => ({
-    command: getNextInitCommand(pm),
+  init: async ({ packageManager: pm, skipInstall }) => ({
+    command: getNextInitCommand(pm, skipInstall),
     dependencies: {
       "@fedify/next": PACKAGE_VERSION,
       ...(pm === "deno" ? defaultDenoDependencies : {}),
@@ -43,7 +43,13 @@ export default nextDescription;
  */
 const getNextInitCommand = (
   pm: PackageManager,
-): string[] => [...createNextAppCommand(pm), ".", "--yes"];
+  skipInstall: boolean,
+): string[] => [
+  ...createNextAppCommand(pm),
+  ".",
+  "--yes",
+  ...(skipInstall ? ["--skip-install"] : []),
+];
 
 const createNextAppCommand = (pm: PackageManager): string[] =>
   pm === "deno"


### PR DESCRIPTION
Closes #720.

`fedify init` always ran the package manager's install command after scaffolding, with no way to skip it.  This is disruptive in CI pipelines that install from a fixed lockfile in a separate step, in monorepo workspaces that install from the root, and when developers want to inspect the generated files before installing.

Adds `--skip-install` to the `initOptions` schema and threads an `isSkipInstall` predicate through the action pipeline so `installDependencies` is bypassed when the flag is set.  When the run is not in dry-run mode, `noticeSkippedInstall` prints the exact install command for the selected package manager.

## Verification

 -  `mise run check`
 -  `mise run test`