### PR TITLE
fix(cli): use ReturnType<typeof setTimeout> for timer map

### DIFF
--- a/packages/cli/src/lookup.ts
+++ b/packages/cli/src/lookup.ts
@@ -482,7 +482,7 @@ export async function collectAsyncItems<T>(
   }
 }
 
-const signalTimers = new WeakMap<AbortSignal, number>();
+const signalTimers = new WeakMap<AbortSignal, ReturnType<typeof setTimeout>>();
 
 export function createTimeoutSignal(
   timeoutSeconds?: number,


### PR DESCRIPTION
## Summary

Deno 2.8+ / TypeScript 6.0 changed `setTimeout`'s return type from `number` to `Timeout`, causing TS2345 when storing timer IDs in the `signalTimers` WeakMap.

## Fix

Use `ReturnType<typeof setTimeout>` which is compatible across all TypeScript/Deno versions.

```
TS2345 [ERROR]: Argument of type 'Timeout' is not assignable to parameter of type 'number'.
  signalTimers.set(controller.signal, timerId);
                                      ~~~~~~~
    at packages/cli/src/lookup.ts:498:39
```


- https://github.com/Homebrew/homebrew-core/pull/286203