### PR TITLE
Add reply-tree backfill strategy

### DIFF
--- a/FEDERATION.md
+++ b/FEDERATION.md
@@ -25,6 +25,7 @@ Supported FEPs
 --------------
 
  -  [FEP-67ff][]: FEDERATION.md
+ -  [FEP-f228][]: Backfilling conversations
  -  [FEP-8fcf][]: Followers collection synchronization across servers
  -  [FEP-9091][]: Export Actor Service Endpoint
  -  [FEP-f1d5][]: NodeInfo in Fediverse Software
@@ -40,6 +41,7 @@ Supported FEPs
  -  [FEP-ae0c][]: Fediverse Relay Protocols: Mastodon and LitePub
 
 [FEP-67ff]: https://w3id.org/fep/67ff
+[FEP-f228]: https://w3id.org/fep/f228
 [FEP-8fcf]: https://w3id.org/fep/8fcf
 [FEP-9091]: https://w3id.org/fep/9091
 [FEP-f1d5]: https://w3id.org/fep/f1d5

--- a/packages/backfill/README.md
+++ b/packages/backfill/README.md
@@ -13,7 +13,9 @@ This package provides ActivityPub conversation backfill support for the
 [Fedify] ecosystem.  It can retrieve post-like objects from a seed object's
 context collection, following the direct FEP-f228-style path where the
 context dereferences to a `Collection`, `OrderedCollection`, `CollectionPage`,
-or `OrderedCollectionPage`.
+or `OrderedCollectionPage`.  It can also use an opt-in reply-tree strategy to
+walk `inReplyTo` ancestors and `replies` descendants when context collections
+are unavailable or incomplete.
 
 [JSR badge]: https://jsr.io/badges/@fedify/backfill
 [JSR]: https://jsr.io/@fedify/backfill
@@ -62,6 +64,10 @@ for await (
 The seed object itself is not yielded.  If it appears in the discovered
 collection, it is skipped by ID.
 
+Configured strategies run in order.  They share `maxItems`, `maxRequests`,
+abort state, and object ID deduplication; if two strategies discover the same
+object, the first strategy keeps its `BackfillItem` metadata.
+
 By default, `backfill()` uses the `context-auto` strategy.  In this mode,
 collection items are treated as backfillable objects by default.  If an item is
 recognized as a supported `Create` activity, `backfill()` extracts the
@@ -99,4 +105,5 @@ for await (
 
 The `reply-tree` strategy walks `inReplyTo` ancestors and `replies`
 descendants.  It yields discovered post-like objects only; it does not extract
-objects from Activity wrappers.
+objects from Activity wrappers.  Immediate parents and direct replies have
+depth 1, their next-level parents or replies have depth 2, and so on.

--- a/packages/backfill/README.md
+++ b/packages/backfill/README.md
@@ -107,3 +107,5 @@ The `reply-tree` strategy walks `inReplyTo` ancestors and `replies`
 descendants.  It yields discovered post-like objects only; it does not extract
 objects from Activity wrappers.  Immediate parents and direct replies have
 depth 1, their next-level parents or replies have depth 2, and so on.
+Reply-tree traversal defaults to a maximum depth of 10; set `maxDepth` to use a
+different limit.

--- a/packages/backfill/README.md
+++ b/packages/backfill/README.md
@@ -82,3 +82,21 @@ for await (
 
 The `context-activities` strategy currently supports `Create` activities and
 yields the activity's object, not the activity itself.
+
+To combine the FEP-f228 context collection path with traditional reply-tree
+crawling, add the `reply-tree` strategy after `context-auto`:
+
+~~~~ typescript
+for await (
+  const item of backfill({ documentLoader }, note, {
+    strategies: ["context-auto", "reply-tree"],
+    maxDepth: 4,
+  })
+) {
+  console.log(item.origin, item.depth, item.object);
+}
+~~~~
+
+The `reply-tree` strategy walks `inReplyTo` ancestors and `replies`
+descendants.  It yields discovered post-like objects only; it does not extract
+objects from Activity wrappers.

--- a/packages/backfill/src/backfill.test.ts
+++ b/packages/backfill/src/backfill.test.ts
@@ -635,8 +635,44 @@ describe("backfill", () => {
     strictEqual(items.length, 2);
     strictEqual(items[0].object, parent);
     strictEqual(items[0].origin, "in-reply-to");
+    strictEqual(items[0].depth, 1);
     strictEqual(items[1].object, sibling);
     strictEqual(items[1].origin, "replies");
+    strictEqual(items[1].depth, 2);
+  });
+
+  test("reply tree maxDepth applies from seed through ancestors", async () => {
+    const seedId = new URL("https://example.com/notes/2");
+    const sibling = new Note({
+      id: new URL("https://example.com/notes/3"),
+      content: "sibling",
+    });
+    const parent = new Note({
+      id: new URL("https://example.com/notes/1"),
+      content: "parent",
+      replies: new Collection({
+        id: new URL("https://example.com/notes/1/replies"),
+        items: [seedId, sibling],
+      }),
+    });
+    const note = new Note({
+      id: seedId,
+      replyTarget: parent,
+    });
+    const context: BackfillContext = {
+      documentLoader: () => {
+        throw new Error("documentLoader should not be called");
+      },
+    };
+
+    const items = await collect(context, note, {
+      strategies: ["reply-tree"],
+      maxDepth: 1,
+    });
+
+    strictEqual(items.length, 1);
+    strictEqual(items[0].object, parent);
+    strictEqual(items[0].depth, 1);
   });
 
   test("reply tree dereferences replies collection URL", async () => {
@@ -787,6 +823,54 @@ describe("backfill", () => {
     strictEqual(requests, 1);
     strictEqual(items.length, 1);
     strictEqual(items[0].object.id?.href, reply.id?.href);
+  });
+
+  test("reply tree retries a replies collection after load failure", async () => {
+    const repliesId = new URL("https://example.com/replies/shared");
+    const grandchild = new Note({
+      id: new URL("https://example.com/notes/4"),
+      content: "grandchild",
+    });
+    const first = new Note({
+      id: new URL("https://example.com/notes/2"),
+      replies: repliesId,
+    });
+    const second = new Note({
+      id: new URL("https://example.com/notes/3"),
+      replies: repliesId,
+    });
+    const note = new Note({
+      id: new URL("https://example.com/notes/1"),
+      replies: new Collection({
+        id: new URL("https://example.com/notes/1/replies"),
+        items: [first, second],
+      }),
+    });
+    let requests = 0;
+    const context: BackfillContext = {
+      documentLoader: (iri) => {
+        strictEqual(iri.href, repliesId.href);
+        requests++;
+        if (requests === 1) throw new Error("temporary failure");
+        return Promise.resolve(
+          new Collection({
+            id: repliesId,
+            items: [grandchild],
+          }),
+        );
+      },
+    };
+
+    const items = await collect(context, note, {
+      strategies: ["reply-tree"],
+    });
+
+    strictEqual(requests, 2);
+    deepStrictEqual(
+      items.map((item) => item.object.id?.href),
+      [first.id?.href, second.id?.href, grandchild.id?.href],
+    );
+    strictEqual(items[2].depth, 2);
   });
 
   test("reply tree skips visited reply IRIs before dereferencing", async () => {

--- a/packages/backfill/src/backfill.test.ts
+++ b/packages/backfill/src/backfill.test.ts
@@ -425,6 +425,43 @@ describe("backfill", () => {
     strictEqual(items[0].origin, "in-reply-to");
   });
 
+  test("context auto preserves strategy order across reply tree", async () => {
+    const contextId = new URL("https://example.com/contexts/1");
+    const parentId = new URL("https://example.com/notes/1");
+    const parent = new Note({
+      id: parentId,
+      content: "parent",
+    });
+    const note = new Note({
+      id: new URL("https://example.com/notes/2"),
+      contexts: [contextId],
+      replyTarget: parentId,
+    });
+    const context: BackfillContext = {
+      documentLoader: (iri) => {
+        if (iri.href === contextId.href) {
+          return Promise.resolve(
+            new Collection({
+              id: contextId,
+              items: [parent],
+            }),
+          );
+        }
+        if (iri.href === parentId.href) return Promise.resolve(parent);
+        return Promise.resolve(null);
+      },
+    };
+
+    const items = await collect(context, note, {
+      strategies: ["context-objects", "reply-tree", "context-auto"],
+    });
+
+    strictEqual(items.length, 1);
+    strictEqual(items[0].object.id?.href, parentId.href);
+    strictEqual(items[0].strategy, "context-objects");
+    strictEqual(items[0].origin, "collection");
+  });
+
   test("reply tree yields embedded descendants", async () => {
     const reply = new Note({
       id: new URL("https://example.com/notes/2"),

--- a/packages/backfill/src/backfill.test.ts
+++ b/packages/backfill/src/backfill.test.ts
@@ -388,6 +388,47 @@ describe("backfill", () => {
     strictEqual(items[0].strategy, "context-auto");
   });
 
+  test("document cache avoids duplicate dereferences across strategies", async () => {
+    const contextId = new URL("https://example.com/contexts/1");
+    const parentId = new URL("https://example.com/notes/1");
+    const parent = new Note({
+      id: parentId,
+      content: "parent",
+    });
+    const note = new Note({
+      id: new URL("https://example.com/notes/2"),
+      contexts: [contextId],
+      replyTarget: parentId,
+    });
+    const requests: URL[] = [];
+    const context: BackfillContext = {
+      documentLoader: (iri) => {
+        requests.push(iri);
+        if (iri.href === contextId.href) {
+          return Promise.resolve(
+            new Collection({
+              id: contextId,
+              items: [parentId],
+            }),
+          );
+        }
+        if (iri.href === parentId.href) return Promise.resolve(parent);
+        return Promise.resolve(null);
+      },
+    };
+
+    const items = await collect(context, note, {
+      strategies: ["context-auto", "reply-tree"],
+    });
+
+    strictEqual(items.length, 1);
+    strictEqual(items[0].object.id?.href, parentId.href);
+    deepStrictEqual(requests.map((url) => url.href), [
+      contextId.href,
+      parentId.href,
+    ]);
+  });
+
   test("strategy order controls deduplicated item metadata", async () => {
     const contextId = new URL("https://example.com/contexts/1");
     const parentId = new URL("https://example.com/notes/1");

--- a/packages/backfill/src/backfill.test.ts
+++ b/packages/backfill/src/backfill.test.ts
@@ -666,6 +666,48 @@ describe("backfill", () => {
     strictEqual(items[1].strategy, "context-activities");
   });
 
+  test("combined context strategies share context collection loading", async () => {
+    const contextId = new URL("https://example.com/contexts/1");
+    const post = new Note({
+      id: new URL("https://example.com/notes/2"),
+      content: "hello",
+    });
+    const activityObject = new Note({
+      id: new URL("https://example.com/notes/3"),
+      content: "activity object",
+    });
+    const activity = new Create({
+      id: new URL("https://example.com/activities/1"),
+      object: activityObject,
+    });
+    const note = new Note({
+      id: new URL("https://example.com/notes/1"),
+      contexts: [contextId],
+    });
+    let requests = 0;
+    const context: BackfillContext = {
+      documentLoader: (iri) => {
+        requests++;
+        strictEqual(iri.href, contextId.href);
+        return Promise.resolve(
+          new Collection({
+            id: contextId,
+            items: [post, activity],
+          }),
+        );
+      },
+    };
+
+    const items = await collect(context, note, {
+      strategies: ["context-objects", "context-activities"],
+    });
+
+    strictEqual(requests, 1);
+    strictEqual(items.length, 2);
+    strictEqual(items[0].object, post);
+    strictEqual(items[1].object, activityObject);
+  });
+
   test("context activity collection dereferences activity object URL", async () => {
     const contextId = new URL("https://example.com/contexts/1");
     const itemId = new URL("https://example.com/notes/2");

--- a/packages/backfill/src/backfill.test.ts
+++ b/packages/backfill/src/backfill.test.ts
@@ -388,6 +388,43 @@ describe("backfill", () => {
     strictEqual(items[0].strategy, "context-auto");
   });
 
+  test("strategy order controls deduplicated item metadata", async () => {
+    const contextId = new URL("https://example.com/contexts/1");
+    const parentId = new URL("https://example.com/notes/1");
+    const parent = new Note({
+      id: parentId,
+      content: "parent",
+    });
+    const note = new Note({
+      id: new URL("https://example.com/notes/2"),
+      contexts: [contextId],
+      replyTarget: parentId,
+    });
+    const context: BackfillContext = {
+      documentLoader: (iri) => {
+        if (iri.href === parentId.href) return Promise.resolve(parent);
+        if (iri.href === contextId.href) {
+          return Promise.resolve(
+            new Collection({
+              id: contextId,
+              items: [parent],
+            }),
+          );
+        }
+        return Promise.resolve(null);
+      },
+    };
+
+    const items = await collect(context, note, {
+      strategies: ["reply-tree", "context-auto"],
+    });
+
+    strictEqual(items.length, 1);
+    strictEqual(items[0].object.id?.href, parentId.href);
+    strictEqual(items[0].strategy, "reply-tree");
+    strictEqual(items[0].origin, "in-reply-to");
+  });
+
   test("reply tree yields embedded descendants", async () => {
     const reply = new Note({
       id: new URL("https://example.com/notes/2"),

--- a/packages/backfill/src/backfill.test.ts
+++ b/packages/backfill/src/backfill.test.ts
@@ -507,6 +507,40 @@ describe("backfill", () => {
     );
   });
 
+  test("reply tree does not reload visited replies collection URL", async () => {
+    const repliesId = new URL("https://example.com/notes/1/replies");
+    const reply = new Note({
+      id: new URL("https://example.com/notes/2"),
+      content: "reply",
+      replies: repliesId,
+    });
+    const note = new Note({
+      id: new URL("https://example.com/notes/1"),
+      replies: repliesId,
+    });
+    let requests = 0;
+    const context: BackfillContext = {
+      documentLoader: (iri) => {
+        requests++;
+        strictEqual(iri.href, repliesId.href);
+        return Promise.resolve(
+          new Collection({
+            id: repliesId,
+            items: [reply],
+          }),
+        );
+      },
+    };
+
+    const items = await collect(context, note, {
+      strategies: ["reply-tree"],
+    });
+
+    strictEqual(requests, 1);
+    strictEqual(items.length, 1);
+    strictEqual(items[0].object.id?.href, reply.id?.href);
+  });
+
   test("reply tree avoids descendant cycles", async () => {
     const seedId = new URL("https://example.com/notes/1");
     const replyId = new URL("https://example.com/notes/2");

--- a/packages/backfill/src/backfill.test.ts
+++ b/packages/backfill/src/backfill.test.ts
@@ -580,6 +580,41 @@ describe("backfill", () => {
     strictEqual(items[0].depth, 1);
   });
 
+  test("reply tree walks sibling descendants from discovered ancestor", async () => {
+    const seedId = new URL("https://example.com/notes/2");
+    const sibling = new Note({
+      id: new URL("https://example.com/notes/3"),
+      content: "sibling",
+    });
+    const parent = new Note({
+      id: new URL("https://example.com/notes/1"),
+      content: "parent",
+      replies: new Collection({
+        id: new URL("https://example.com/notes/1/replies"),
+        items: [seedId, sibling],
+      }),
+    });
+    const note = new Note({
+      id: seedId,
+      replyTarget: parent,
+    });
+    const context: BackfillContext = {
+      documentLoader: () => {
+        throw new Error("documentLoader should not be called");
+      },
+    };
+
+    const items = await collect(context, note, {
+      strategies: ["reply-tree"],
+    });
+
+    strictEqual(items.length, 2);
+    strictEqual(items[0].object, parent);
+    strictEqual(items[0].origin, "in-reply-to");
+    strictEqual(items[1].object, sibling);
+    strictEqual(items[1].origin, "replies");
+  });
+
   test("reply tree dereferences replies collection URL", async () => {
     const repliesId = new URL("https://example.com/notes/1/replies");
     const reply = new Note({
@@ -701,6 +736,42 @@ describe("backfill", () => {
     strictEqual(requests, 1);
     strictEqual(items.length, 1);
     strictEqual(items[0].object.id?.href, reply.id?.href);
+  });
+
+  test("reply tree skips visited reply IRIs before dereferencing", async () => {
+    const seedId = new URL("https://example.com/notes/1");
+    const siblingId = new URL("https://example.com/notes/2");
+    const sibling = new Note({
+      id: siblingId,
+      content: "sibling",
+    });
+    const note = new Note({
+      id: seedId,
+      replies: new Collection({
+        id: new URL("https://example.com/notes/1/replies"),
+        items: [seedId, siblingId],
+      }),
+    });
+    const requests: string[] = [];
+    const context: BackfillContext = {
+      documentLoader: (iri) => {
+        requests.push(iri.href);
+        if (iri.href === siblingId.href) return Promise.resolve(sibling);
+        if (iri.href === seedId.href) {
+          throw new Error("seed should have been skipped");
+        }
+        return Promise.resolve(null);
+      },
+    };
+
+    const items = await collect(context, note, {
+      strategies: ["reply-tree"],
+      maxRequests: 1,
+    });
+
+    deepStrictEqual(requests, [siblingId.href]);
+    strictEqual(items.length, 1);
+    strictEqual(items[0].object.id?.href, siblingId.href);
   });
 
   test("reply tree avoids descendant cycles", async () => {

--- a/packages/backfill/src/backfill.test.ts
+++ b/packages/backfill/src/backfill.test.ts
@@ -218,6 +218,176 @@ describe("backfill", () => {
     );
   });
 
+  test("reply tree yields embedded ancestor", async () => {
+    const parent = new Note({
+      id: new URL("https://example.com/notes/1"),
+      content: "parent",
+    });
+    const note = new Note({
+      id: new URL("https://example.com/notes/2"),
+      replyTarget: parent,
+    });
+    const context: BackfillContext = {
+      documentLoader: () => {
+        throw new Error("documentLoader should not be called");
+      },
+    };
+
+    const items = await collect(context, note, {
+      strategies: ["reply-tree"],
+    });
+
+    strictEqual(items.length, 1);
+    strictEqual(items[0].object, parent);
+    deepStrictEqual(items[0].id, parent.id);
+    strictEqual(items[0].strategy, "reply-tree");
+    strictEqual(items[0].origin, "in-reply-to");
+    strictEqual(items[0].depth, 1);
+  });
+
+  test("reply tree dereferences ancestor URL", async () => {
+    const parentId = new URL("https://example.com/notes/1");
+    const parent = new Note({
+      id: parentId,
+      content: "parent",
+    });
+    const note = new Note({
+      id: new URL("https://example.com/notes/2"),
+      replyTarget: parentId,
+    });
+    const context: BackfillContext = {
+      documentLoader: (iri) =>
+        Promise.resolve(iri.href === parentId.href ? parent : null),
+    };
+
+    const items = await collect(context, note, {
+      strategies: ["reply-tree"],
+    });
+
+    strictEqual(items.length, 1);
+    deepStrictEqual(items[0].object.id, parent.id);
+    strictEqual(items[0].origin, "in-reply-to");
+    strictEqual(items[0].depth, 1);
+  });
+
+  test("reply tree maxDepth limits ancestors", async () => {
+    const rootId = new URL("https://example.com/notes/1");
+    const parentId = new URL("https://example.com/notes/2");
+    const root = new Note({
+      id: rootId,
+      content: "root",
+    });
+    const parent = new Note({
+      id: parentId,
+      content: "parent",
+      replyTarget: rootId,
+    });
+    const note = new Note({
+      id: new URL("https://example.com/notes/3"),
+      replyTarget: parentId,
+    });
+    const context: BackfillContext = {
+      documentLoader: (iri) => {
+        if (iri.href === parentId.href) return Promise.resolve(parent);
+        if (iri.href === rootId.href) return Promise.resolve(root);
+        return Promise.resolve(null);
+      },
+    };
+
+    const items = await collect(context, note, {
+      strategies: ["reply-tree"],
+      maxDepth: 1,
+    });
+
+    strictEqual(items.length, 1);
+    deepStrictEqual(items[0].object.id, parent.id);
+    strictEqual(items[0].depth, 1);
+  });
+
+  test("maxRequests limits reply tree ancestor dereferencing", async () => {
+    const parentId = new URL("https://example.com/notes/1");
+    const note = new Note({
+      id: new URL("https://example.com/notes/2"),
+      replyTarget: parentId,
+    });
+    const context: BackfillContext = {
+      documentLoader: () => {
+        throw new Error("documentLoader should not be called");
+      },
+    };
+
+    deepStrictEqual(
+      await collect(context, note, {
+        strategies: ["reply-tree"],
+        maxRequests: 0,
+      }),
+      [],
+    );
+  });
+
+  test("reply tree avoids ancestor cycles", async () => {
+    const seedId = new URL("https://example.com/notes/1");
+    const parentId = new URL("https://example.com/notes/2");
+    const note = new Note({
+      id: seedId,
+      replyTarget: parentId,
+    });
+    const parent = new Note({
+      id: parentId,
+      replyTarget: seedId,
+    });
+    const context: BackfillContext = {
+      documentLoader: (iri) => {
+        if (iri.href === seedId.href) return Promise.resolve(note);
+        if (iri.href === parentId.href) return Promise.resolve(parent);
+        return Promise.resolve(null);
+      },
+    };
+
+    const items = await collect(context, note, {
+      strategies: ["reply-tree"],
+    });
+
+    strictEqual(items.length, 1);
+    deepStrictEqual(items[0].object.id, parent.id);
+  });
+
+  test("reply tree deduplicates ancestors from context collection", async () => {
+    const contextId = new URL("https://example.com/contexts/1");
+    const parentId = new URL("https://example.com/notes/1");
+    const parent = new Note({
+      id: parentId,
+      content: "parent",
+    });
+    const note = new Note({
+      id: new URL("https://example.com/notes/2"),
+      contexts: [contextId],
+      replyTarget: parentId,
+    });
+    const context: BackfillContext = {
+      documentLoader: (iri) => {
+        if (iri.href === contextId.href) {
+          return Promise.resolve(
+            new Collection({
+              id: contextId,
+              items: [parent],
+            }),
+          );
+        }
+        if (iri.href === parentId.href) return Promise.resolve(parent);
+        return Promise.resolve(null);
+      },
+    };
+
+    const items = await collect(context, note, {
+      strategies: ["context-auto", "reply-tree"],
+    });
+
+    strictEqual(items.length, 1);
+    strictEqual(items[0].object, parent);
+    strictEqual(items[0].strategy, "context-auto");
+  });
+
   test("context auto overrides overlapping context strategies", async () => {
     const contextId = new URL("https://example.com/contexts/1");
     const item = new Note({ content: "anonymous" });

--- a/packages/backfill/src/backfill.test.ts
+++ b/packages/backfill/src/backfill.test.ts
@@ -429,6 +429,53 @@ describe("backfill", () => {
     ]);
   });
 
+  test("document cache does not keep failed dereferences", async () => {
+    const contextId = new URL("https://example.com/contexts/1");
+    const parentId = new URL("https://example.com/notes/1");
+    const parent = new Note({
+      id: parentId,
+      content: "parent",
+    });
+    const note = new Note({
+      id: new URL("https://example.com/notes/2"),
+      contexts: [contextId],
+      replyTarget: parentId,
+    });
+    const requests: URL[] = [];
+    let parentRequests = 0;
+    const context: BackfillContext = {
+      documentLoader: (iri) => {
+        requests.push(iri);
+        if (iri.href === contextId.href) {
+          return Promise.resolve(
+            new Collection({
+              id: contextId,
+              items: [parentId],
+            }),
+          );
+        }
+        if (iri.href === parentId.href) {
+          parentRequests++;
+          if (parentRequests === 1) throw new Error("temporary failure");
+          return Promise.resolve(parent);
+        }
+        return Promise.resolve(null);
+      },
+    };
+
+    const items = await collect(context, note, {
+      strategies: ["context-auto", "reply-tree"],
+    });
+
+    strictEqual(items.length, 1);
+    strictEqual(items[0].object.id?.href, parentId.href);
+    deepStrictEqual(requests.map((url) => url.href), [
+      contextId.href,
+      parentId.href,
+      parentId.href,
+    ]);
+  });
+
   test("strategy order controls deduplicated item metadata", async () => {
     const contextId = new URL("https://example.com/contexts/1");
     const parentId = new URL("https://example.com/notes/1");

--- a/packages/backfill/src/backfill.test.ts
+++ b/packages/backfill/src/backfill.test.ts
@@ -201,7 +201,24 @@ describe("backfill", () => {
     deepStrictEqual(await collect(context, note, { strategies: [] }), []);
   });
 
-  test("context auto overrides overlapping strategies", async () => {
+  test("reply tree strategy does not require context collection", async () => {
+    const note = new Note({
+      id: new URL("https://example.com/notes/1"),
+      contexts: [new URL("https://example.com/contexts/1")],
+    });
+    const context: BackfillContext = {
+      documentLoader: () => {
+        throw new Error("documentLoader should not be called");
+      },
+    };
+
+    deepStrictEqual(
+      await collect(context, note, { strategies: ["reply-tree"] }),
+      [],
+    );
+  });
+
+  test("context auto overrides overlapping context strategies", async () => {
     const contextId = new URL("https://example.com/contexts/1");
     const item = new Note({ content: "anonymous" });
     const note = new Note({
@@ -219,7 +236,7 @@ describe("backfill", () => {
     };
 
     const items = await collect(context, note, {
-      strategies: ["context-auto", "context-objects"],
+      strategies: ["context-objects", "context-auto", "reply-tree"],
     });
 
     strictEqual(items.length, 1);

--- a/packages/backfill/src/backfill.test.ts
+++ b/packages/backfill/src/backfill.test.ts
@@ -388,6 +388,158 @@ describe("backfill", () => {
     strictEqual(items[0].strategy, "context-auto");
   });
 
+  test("reply tree yields embedded descendants", async () => {
+    const reply = new Note({
+      id: new URL("https://example.com/notes/2"),
+      content: "reply",
+    });
+    const note = new Note({
+      id: new URL("https://example.com/notes/1"),
+      replies: new Collection({
+        id: new URL("https://example.com/notes/1/replies"),
+        items: [reply],
+      }),
+    });
+    const context: BackfillContext = {
+      documentLoader: () => {
+        throw new Error("documentLoader should not be called");
+      },
+    };
+
+    const items = await collect(context, note, {
+      strategies: ["reply-tree"],
+    });
+
+    strictEqual(items.length, 1);
+    strictEqual(items[0].object, reply);
+    deepStrictEqual(items[0].id, reply.id);
+    strictEqual(items[0].strategy, "reply-tree");
+    strictEqual(items[0].origin, "replies");
+    strictEqual(items[0].depth, 1);
+  });
+
+  test("reply tree dereferences replies collection URL", async () => {
+    const repliesId = new URL("https://example.com/notes/1/replies");
+    const reply = new Note({
+      id: new URL("https://example.com/notes/2"),
+      content: "reply",
+    });
+    const note = new Note({
+      id: new URL("https://example.com/notes/1"),
+      replies: repliesId,
+    });
+    const context: BackfillContext = {
+      documentLoader: (iri) =>
+        Promise.resolve(
+          iri.href === repliesId.href
+            ? new Collection({
+              id: repliesId,
+              items: [reply],
+            })
+            : null,
+        ),
+    };
+
+    const items = await collect(context, note, {
+      strategies: ["reply-tree"],
+    });
+
+    strictEqual(items.length, 1);
+    deepStrictEqual(items[0].object.id, reply.id);
+    strictEqual(items[0].origin, "replies");
+    strictEqual(items[0].depth, 1);
+  });
+
+  test("reply tree maxDepth limits descendants", async () => {
+    const grandchild = new Note({
+      id: new URL("https://example.com/notes/3"),
+      content: "grandchild",
+    });
+    const reply = new Note({
+      id: new URL("https://example.com/notes/2"),
+      content: "reply",
+      replies: new Collection({
+        id: new URL("https://example.com/notes/2/replies"),
+        items: [grandchild],
+      }),
+    });
+    const note = new Note({
+      id: new URL("https://example.com/notes/1"),
+      replies: new Collection({
+        id: new URL("https://example.com/notes/1/replies"),
+        items: [reply],
+      }),
+    });
+    const context: BackfillContext = {
+      documentLoader: () => {
+        throw new Error("documentLoader should not be called");
+      },
+    };
+
+    const items = await collect(context, note, {
+      strategies: ["reply-tree"],
+      maxDepth: 1,
+    });
+
+    strictEqual(items.length, 1);
+    strictEqual(items[0].object, reply);
+    strictEqual(items[0].depth, 1);
+  });
+
+  test("maxRequests limits reply tree replies dereferencing", async () => {
+    const repliesId = new URL("https://example.com/notes/1/replies");
+    const note = new Note({
+      id: new URL("https://example.com/notes/1"),
+      replies: repliesId,
+    });
+    const context: BackfillContext = {
+      documentLoader: () => {
+        throw new Error("documentLoader should not be called");
+      },
+    };
+
+    deepStrictEqual(
+      await collect(context, note, {
+        strategies: ["reply-tree"],
+        maxRequests: 0,
+      }),
+      [],
+    );
+  });
+
+  test("reply tree avoids descendant cycles", async () => {
+    const seedId = new URL("https://example.com/notes/1");
+    const replyId = new URL("https://example.com/notes/2");
+    const note = new Note({
+      id: seedId,
+    });
+    const reply = new Note({
+      id: replyId,
+      replies: new Collection({
+        id: new URL("https://example.com/notes/2/replies"),
+        items: [note],
+      }),
+    });
+    const seed = note.clone({
+      replies: new Collection({
+        id: new URL("https://example.com/notes/1/replies"),
+        items: [reply],
+      }),
+    });
+    const context: BackfillContext = {
+      documentLoader: () => {
+        throw new Error("documentLoader should not be called");
+      },
+    };
+
+    const items = await collect(context, seed, {
+      strategies: ["reply-tree"],
+    });
+
+    strictEqual(items.length, 1);
+    strictEqual(items[0].object, reply);
+  });
+
   test("context auto overrides overlapping context strategies", async () => {
     const contextId = new URL("https://example.com/contexts/1");
     const item = new Note({ content: "anonymous" });

--- a/packages/backfill/src/backfill.test.ts
+++ b/packages/backfill/src/backfill.test.ts
@@ -1142,6 +1142,44 @@ describe("backfill", () => {
     strictEqual(items[0].id?.href, "https://example.com/notes/2");
   });
 
+  test("maxItems is shared across context and reply tree", async () => {
+    const contextId = new URL("https://example.com/contexts/1");
+    const reply = new Note({
+      id: new URL("https://example.com/notes/3"),
+      content: "reply",
+    });
+    const note = new Note({
+      id: new URL("https://example.com/notes/1"),
+      contexts: [contextId],
+      replies: new Collection({
+        id: new URL("https://example.com/notes/1/replies"),
+        items: [reply],
+      }),
+    });
+    const contextItem = new Note({
+      id: new URL("https://example.com/notes/2"),
+      content: "context item",
+    });
+    const context: BackfillContext = {
+      documentLoader: () =>
+        Promise.resolve(
+          new Collection({
+            id: contextId,
+            items: [contextItem],
+          }),
+        ),
+    };
+
+    const items = await collect(context, note, {
+      strategies: ["context-auto", "reply-tree"],
+      maxItems: 1,
+    });
+
+    strictEqual(items.length, 1);
+    strictEqual(items[0].object, contextItem);
+    strictEqual(items[0].strategy, "context-auto");
+  });
+
   test("maxRequests limits dereferencing", async () => {
     const contextId = new URL("https://example.com/contexts/1");
     const itemId = new URL("https://example.com/notes/2");
@@ -1166,6 +1204,41 @@ describe("backfill", () => {
     deepStrictEqual(await collect(context, note, { maxRequests: 1 }), []);
   });
 
+  test("maxRequests is shared across context and reply tree", async () => {
+    const contextId = new URL("https://example.com/contexts/1");
+    const parentId = new URL("https://example.com/notes/0");
+    const note = new Note({
+      id: new URL("https://example.com/notes/1"),
+      contexts: [contextId],
+      replyTarget: parentId,
+    });
+    const contextItem = new Note({
+      id: new URL("https://example.com/notes/2"),
+      content: "context item",
+    });
+    const context: BackfillContext = {
+      documentLoader: (iri) => {
+        if (iri.href === contextId.href) {
+          return Promise.resolve(
+            new Collection({
+              id: contextId,
+              items: [contextItem],
+            }),
+          );
+        }
+        throw new Error("reply-tree request should be budgeted out");
+      },
+    };
+
+    const items = await collect(context, note, {
+      strategies: ["context-auto", "reply-tree"],
+      maxRequests: 1,
+    });
+
+    strictEqual(items.length, 1);
+    strictEqual(items[0].object, contextItem);
+  });
+
   test("AbortSignal stops traversal", async () => {
     const contextId = new URL("https://example.com/contexts/1");
     const note = new Note({
@@ -1188,6 +1261,56 @@ describe("backfill", () => {
       collect(context, note, { signal: controller.signal }),
       { name: "AbortError" },
     );
+  });
+
+  test("AbortSignal stops traversal across strategies", async () => {
+    const contextId = new URL("https://example.com/contexts/1");
+    const parentId = new URL("https://example.com/notes/0");
+    const controller = new AbortController();
+    const note = new Note({
+      id: new URL("https://example.com/notes/1"),
+      contexts: [contextId],
+      replyTarget: parentId,
+    });
+    const contextItem = new Note({
+      id: new URL("https://example.com/notes/2"),
+      content: "context item",
+    });
+    let requests = 0;
+    const context: BackfillContext = {
+      documentLoader: (iri) => {
+        requests++;
+        if (iri.href === contextId.href) {
+          return Promise.resolve(
+            new Collection({
+              id: contextId,
+              items: [contextItem],
+            }),
+          );
+        }
+        throw new Error("reply-tree request should not be started");
+      },
+    };
+
+    const items: Awaited<ReturnType<typeof collect>> = [];
+    await rejects(
+      async () => {
+        for await (
+          const item of backfill(context, note, {
+            strategies: ["context-auto", "reply-tree"],
+            signal: controller.signal,
+          })
+        ) {
+          items.push(item);
+          controller.abort();
+        }
+      },
+      { name: "AbortError" },
+    );
+
+    strictEqual(requests, 1);
+    strictEqual(items.length, 1);
+    strictEqual(items[0].object, contextItem);
   });
 
   test("documentLoader receives AbortSignal", async () => {

--- a/packages/backfill/src/backfill.test.ts
+++ b/packages/backfill/src/backfill.test.ts
@@ -1103,6 +1103,45 @@ describe("backfill", () => {
     ]);
   });
 
+  test("seen context collection URL items are not loaded", async () => {
+    const contextId = new URL("https://example.com/contexts/1");
+    const seedId = new URL("https://example.com/notes/1");
+    const itemId = new URL("https://example.com/notes/2");
+    const item = new Note({
+      id: itemId,
+      content: "hello",
+    });
+    const note = new Note({
+      id: seedId,
+      contexts: [contextId],
+    });
+    const requests: URL[] = [];
+    const context: BackfillContext = {
+      documentLoader: (iri) => {
+        requests.push(iri);
+        if (iri.href === contextId.href) {
+          return Promise.resolve(
+            new Collection({
+              id: contextId,
+              items: [seedId, itemId],
+            }),
+          );
+        }
+        if (iri.href === itemId.href) return Promise.resolve(item);
+        throw new Error("seen collection item should not be loaded");
+      },
+    };
+
+    const items = await collect(context, note);
+
+    strictEqual(items.length, 1);
+    strictEqual(items[0].id?.href, itemId.href);
+    deepStrictEqual(requests.map((url) => url.href), [
+      contextId.href,
+      itemId.href,
+    ]);
+  });
+
   test("failed URL collection items are skipped", async () => {
     const contextId = new URL("https://example.com/contexts/1");
     const missingItemId = new URL("https://example.com/notes/missing");

--- a/packages/backfill/src/backfill.test.ts
+++ b/packages/backfill/src/backfill.test.ts
@@ -304,6 +304,30 @@ describe("backfill", () => {
     strictEqual(items[0].depth, 1);
   });
 
+  test("reply tree defaults maxDepth to 10 for ancestors", async () => {
+    let note = new Note({
+      id: new URL("https://example.com/notes/0"),
+    });
+    for (let i = 1; i <= 12; i++) {
+      note = new Note({
+        id: new URL(`https://example.com/notes/${i}`),
+        replyTarget: note,
+      });
+    }
+    const context: BackfillContext = {
+      documentLoader: () => {
+        throw new Error("documentLoader should not be called");
+      },
+    };
+
+    const items = await collect(context, note, {
+      strategies: ["reply-tree"],
+    });
+
+    strictEqual(items.length, 10);
+    strictEqual(items.at(-1)?.depth, 10);
+  });
+
   test("maxRequests limits reply tree ancestor dereferencing", async () => {
     const parentId = new URL("https://example.com/notes/1");
     const note = new Note({
@@ -681,6 +705,33 @@ describe("backfill", () => {
     strictEqual(items.length, 1);
     strictEqual(items[0].object, reply);
     strictEqual(items[0].depth, 1);
+  });
+
+  test("reply tree defaults maxDepth to 10 for descendants", async () => {
+    let note = new Note({
+      id: new URL("https://example.com/notes/12"),
+    });
+    for (let i = 11; i >= 0; i--) {
+      note = new Note({
+        id: new URL(`https://example.com/notes/${i}`),
+        replies: new Collection({
+          id: new URL(`https://example.com/notes/${i}/replies`),
+          items: [note],
+        }),
+      });
+    }
+    const context: BackfillContext = {
+      documentLoader: () => {
+        throw new Error("documentLoader should not be called");
+      },
+    };
+
+    const items = await collect(context, note, {
+      strategies: ["reply-tree"],
+    });
+
+    strictEqual(items.length, 10);
+    strictEqual(items.at(-1)?.depth, 10);
   });
 
   test("maxRequests limits reply tree replies dereferencing", async () => {

--- a/packages/backfill/src/backfill.ts
+++ b/packages/backfill/src/backfill.ts
@@ -276,7 +276,10 @@ async function* getReplyTreeItems(
   const visitedCollections = new WeakSet<BackfillCollection>();
   if (note.id != null) visitedObjectIds.add(note.id.href);
   visitedObjects.add(note);
-  const ancestors: APObject[] = [];
+  const ancestors: Array<{
+    readonly object: APObject;
+    readonly depth: number;
+  }> = [];
   for await (
     const item of getReplyAncestors(context, note, options, budget, {
       depth: 1,
@@ -286,12 +289,12 @@ async function* getReplyTreeItems(
       visitedCollections,
     })
   ) {
-    ancestors.push(item.object);
+    ancestors.push({ object: item.object, depth: item.depth });
     yield item;
   }
-  for (const object of ancestors.toReversed()) {
-    yield* getReplyDescendants(context, object, options, budget, {
-      depth: 1,
+  for (const ancestor of ancestors.toReversed()) {
+    yield* getReplyDescendants(context, ancestor.object, options, budget, {
+      depth: ancestor.depth + 1,
       visitedObjectIds,
       visitedObjects,
       visitedCollectionIds,
@@ -355,18 +358,17 @@ async function* getReplyDescendants(
 }> {
   if (traversal.depth > (options.maxDepth ?? DEFAULT_MAX_DEPTH)) return;
   const repliesId = object.repliesId;
-  let repliesIdVisited = false;
-  if (repliesId != null && !visitReplyTreeCollectionId(repliesId, traversal)) {
+  if (
+    repliesId != null &&
+    traversal.visitedCollectionIds.has(repliesId.href)
+  ) {
     return;
   }
-  repliesIdVisited = repliesId != null;
   const replies = await getRepliesCollection(context, object, options, budget);
   if (replies == null) return;
-  if (repliesIdVisited) {
-    traversal.visitedCollections.add(replies);
-  } else if (!visitReplyTreeCollection(replies, traversal)) {
-    return;
-  }
+  const unvisited = visitReplyTreeCollection(replies, traversal);
+  if (repliesId != null) traversal.visitedCollectionIds.add(repliesId.href);
+  if (!unvisited) return;
   for await (
     const reply of getCollectionItems(
       context,

--- a/packages/backfill/src/backfill.ts
+++ b/packages/backfill/src/backfill.ts
@@ -179,7 +179,7 @@ async function* getReplyTreeItems(
 ): AsyncIterable<{
   readonly object: APObject;
   readonly strategy: "reply-tree";
-  readonly origin: "in-reply-to";
+  readonly origin: "in-reply-to" | "replies";
   readonly depth: number;
 }> {
   const visitedIds = new Set<string>();
@@ -187,6 +187,11 @@ async function* getReplyTreeItems(
   if (note.id != null) visitedIds.add(note.id.href);
   visitedObjects.add(note);
   yield* getReplyAncestors(context, note, options, budget, {
+    depth: 1,
+    visitedIds,
+    visitedObjects,
+  });
+  yield* getReplyDescendants(context, note, options, budget, {
     depth: 1,
     visitedIds,
     visitedObjects,
@@ -229,6 +234,44 @@ async function* getReplyAncestors(
   }
 }
 
+async function* getReplyDescendants(
+  context: BackfillContext,
+  object: APObject,
+  options: BackfillOptions,
+  budget: RequestBudget,
+  traversal: {
+    readonly depth: number;
+    readonly visitedIds: Set<string>;
+    readonly visitedObjects: WeakSet<APObject>;
+  },
+): AsyncIterable<{
+  readonly object: APObject;
+  readonly strategy: "reply-tree";
+  readonly origin: "replies";
+  readonly depth: number;
+}> {
+  if (options.maxDepth != null && traversal.depth > options.maxDepth) return;
+  const replies = await getRepliesCollection(context, object, options, budget);
+  if (replies == null) return;
+  for await (
+    const reply of getCollectionItems(context, replies, options, budget)
+  ) {
+    if (!isContextPostObject(reply)) continue;
+    if (!visitReplyTreeObject(reply, traversal)) continue;
+    yield {
+      object: reply,
+      strategy: "reply-tree",
+      origin: "replies",
+      depth: traversal.depth,
+    };
+    yield* getReplyDescendants(context, reply, options, budget, {
+      depth: traversal.depth + 1,
+      visitedIds: traversal.visitedIds,
+      visitedObjects: traversal.visitedObjects,
+    });
+  }
+}
+
 async function* getReplyTargets(
   context: BackfillContext,
   object: APObject,
@@ -245,6 +288,26 @@ async function* getReplyTargets(
   } catch (error) {
     if (error instanceof MaxRequestsExceeded) throw error;
     budget.signal?.throwIfAborted();
+  }
+}
+
+async function getRepliesCollection(
+  context: BackfillContext,
+  object: APObject,
+  options: BackfillOptions,
+  budget: RequestBudget,
+): Promise<Collection | null> {
+  try {
+    return await object.getReplies({
+      documentLoader: async (url) => {
+        return await loadCollectionItemDocument(context, url, options, budget);
+      },
+      crossOrigin: "trust",
+    });
+  } catch (error) {
+    if (error instanceof MaxRequestsExceeded) throw error;
+    budget.signal?.throwIfAborted();
+    return null;
   }
 }
 

--- a/packages/backfill/src/backfill.ts
+++ b/packages/backfill/src/backfill.ts
@@ -138,15 +138,18 @@ function normalizeStrategies(
   const normalized: BackfillStrategy[] = [];
   for (const strategy of strategies) {
     if (strategy === "context-auto") {
-      for (let i = normalized.length - 1; i >= 0; i--) {
-        if (isContextStrategy(normalized[i])) normalized.splice(i, 1);
+      for (
+        let i = normalized.length - 1;
+        i >= 0 && isContextStrategy(normalized[i]);
+        i--
+      ) {
+        normalized.splice(i, 1);
       }
       if (!normalized.includes(strategy)) normalized.push(strategy);
     } else if (isContextStrategy(strategy)) {
       if (
-        !normalized.includes("context-auto") && !normalized.includes(
-          strategy,
-        )
+        !currentContextGroupHasAuto(normalized) &&
+        !normalized.includes(strategy)
       ) {
         normalized.push(strategy);
       }
@@ -163,6 +166,17 @@ function isContextStrategy(
   return strategy === "context-objects" ||
     strategy === "context-activities" ||
     strategy === "context-auto";
+}
+
+function currentContextGroupHasAuto(
+  strategies: readonly BackfillStrategy[],
+): boolean {
+  for (let i = strategies.length - 1; i >= 0; i--) {
+    const strategy = strategies[i];
+    if (!isContextStrategy(strategy)) return false;
+    if (strategy === "context-auto") return true;
+  }
+  return false;
 }
 
 async function* getContextStrategyItems(

--- a/packages/backfill/src/backfill.ts
+++ b/packages/backfill/src/backfill.ts
@@ -274,13 +274,28 @@ async function* getReplyTreeItems(
   const visitedCollections = new WeakSet<BackfillCollection>();
   if (note.id != null) visitedObjectIds.add(note.id.href);
   visitedObjects.add(note);
-  yield* getReplyAncestors(context, note, options, budget, {
-    depth: 1,
-    visitedObjectIds,
-    visitedObjects,
-    visitedCollectionIds,
-    visitedCollections,
-  });
+  const ancestors: APObject[] = [];
+  for await (
+    const item of getReplyAncestors(context, note, options, budget, {
+      depth: 1,
+      visitedObjectIds,
+      visitedObjects,
+      visitedCollectionIds,
+      visitedCollections,
+    })
+  ) {
+    ancestors.push(item.object);
+    yield item;
+  }
+  for (const object of ancestors.toReversed()) {
+    yield* getReplyDescendants(context, object, options, budget, {
+      depth: 1,
+      visitedObjectIds,
+      visitedObjects,
+      visitedCollectionIds,
+      visitedCollections,
+    });
+  }
   yield* getReplyDescendants(context, note, options, budget, {
     depth: 1,
     visitedObjectIds,
@@ -351,7 +366,13 @@ async function* getReplyDescendants(
     return;
   }
   for await (
-    const reply of getCollectionItems(context, replies, options, budget)
+    const reply of getCollectionItems(
+      context,
+      replies,
+      options,
+      budget,
+      traversal.visitedObjectIds,
+    )
   ) {
     if (!isContextPostObject(reply)) continue;
     if (!visitReplyTreeObject(reply, traversal)) continue;

--- a/packages/backfill/src/backfill.ts
+++ b/packages/backfill/src/backfill.ts
@@ -31,6 +31,7 @@ export class MaxRequestsExceeded extends Error {}
 interface RequestBudget {
   readonly signal?: AbortSignal;
   requestCount: number;
+  readonly documents: Map<string, Promise<APObject | null>>;
 }
 
 type StrategyItem = {
@@ -70,6 +71,7 @@ export async function* backfill<
   const budget: RequestBudget = {
     signal: options.signal,
     requestCount: 0,
+    documents: new Map(),
   };
   const seenIds = new Set<string>();
   if (note.id != null) seenIds.add(note.id.href);
@@ -575,6 +577,10 @@ async function loadObject(
   throwOnBudgetExceeded = false,
 ): Promise<APObject | null> {
   budget.signal?.throwIfAborted();
+  const cacheKey = iri.href;
+  const cached = budget.documents.get(cacheKey);
+  if (cached != null) return await cached;
+
   if (
     options.maxRequests != null &&
     budget.requestCount >= options.maxRequests
@@ -587,7 +593,16 @@ async function loadObject(
   budget.signal?.throwIfAborted();
 
   budget.requestCount++;
-  return await context.documentLoader(iri, { signal: budget.signal });
+  const document = context.documentLoader(iri, { signal: budget.signal });
+  budget.documents.set(cacheKey, document);
+  try {
+    return await document;
+  } catch (error) {
+    if (budget.documents.get(cacheKey) === document) {
+      budget.documents.delete(cacheKey);
+    }
+    throw error;
+  }
 }
 
 async function waitForInterval(

--- a/packages/backfill/src/backfill.ts
+++ b/packages/backfill/src/backfill.ts
@@ -33,6 +33,13 @@ interface RequestBudget {
   requestCount: number;
 }
 
+type StrategyItem = {
+  readonly object: APObject;
+  readonly strategy: BackfillStrategy;
+  readonly origin: BackfillOrigin;
+  readonly depth: number;
+};
+
 /**
  * Backfills post-like objects related to a seed object.
  *
@@ -61,16 +68,37 @@ export async function* backfill<
 
   let yielded = 0;
   try {
-    for (const strategy of strategies) {
-      for await (
-        const item of getStrategyItems(
+    for (let i = 0; i < strategies.length; i++) {
+      const strategy = strategies[i];
+      let items: AsyncIterable<StrategyItem>;
+      if (isContextStrategy(strategy)) {
+        const contextStrategies: Exclude<BackfillStrategy, "reply-tree">[] = [
+          strategy,
+        ];
+        while (true) {
+          const nextStrategy = strategies[i + 1];
+          if (nextStrategy == null || !isContextStrategy(nextStrategy)) break;
+          contextStrategies.push(nextStrategy);
+          i++;
+        }
+        items = getContextStrategyItems(
+          context,
+          note,
+          contextStrategies,
+          options,
+          budget,
+        );
+      } else {
+        items = getStrategyItems(
           context,
           note,
           strategy,
           options,
           budget,
-        )
-      ) {
+        );
+      }
+
+      for await (const item of items) {
         const id = item.object.id ?? undefined;
         if (id != null) {
           if (seenIds.has(id.href)) continue;
@@ -129,26 +157,26 @@ function isContextStrategy(
     strategy === "context-auto";
 }
 
-async function* getStrategyItems(
+async function* getContextStrategyItems(
   context: BackfillContext,
   note: APObject,
-  strategy: BackfillStrategy,
+  strategies: readonly Exclude<BackfillStrategy, "reply-tree">[],
   options: BackfillOptions,
   budget: RequestBudget,
 ): AsyncIterable<{
   readonly object: APObject;
-  readonly strategy: BackfillStrategy;
-  readonly origin: BackfillOrigin;
-  readonly depth: number;
+  readonly strategy: Exclude<BackfillStrategy, "reply-tree">;
+  readonly origin: "collection";
+  readonly depth: 0;
 }> {
-  if (isContextStrategy(strategy)) {
-    const contextId = note.contextIds[0];
-    if (contextId == null) return;
-    const collection = await loadObject(context, contextId, options, budget);
-    if (!isCollection(collection)) return;
-    for await (
-      const object of getCollectionItems(context, collection, options, budget)
-    ) {
+  const contextId = note.contextIds[0];
+  if (contextId == null) return;
+  const collection = await loadObject(context, contextId, options, budget);
+  if (!isCollection(collection)) return;
+  for await (
+    const object of getCollectionItems(context, collection, options, budget)
+  ) {
+    for (const strategy of strategies) {
       for await (
         const item of getContextBackfillItems(
           context,
@@ -166,6 +194,23 @@ async function* getStrategyItems(
         };
       }
     }
+  }
+}
+
+async function* getStrategyItems(
+  context: BackfillContext,
+  note: APObject,
+  strategy: BackfillStrategy,
+  options: BackfillOptions,
+  budget: RequestBudget,
+): AsyncIterable<{
+  readonly object: APObject;
+  readonly strategy: BackfillStrategy;
+  readonly origin: BackfillOrigin;
+  readonly depth: number;
+}> {
+  if (isContextStrategy(strategy)) {
+    yield* getContextStrategyItems(context, note, [strategy], options, budget);
   } else if (strategy === "reply-tree") {
     yield* getReplyTreeItems(context, note, options, budget);
   }

--- a/packages/backfill/src/backfill.ts
+++ b/packages/backfill/src/backfill.ts
@@ -21,6 +21,8 @@ const defaultStrategies = [
   "context-auto",
 ] as const satisfies readonly BackfillStrategy[];
 
+const DEFAULT_MAX_DEPTH = 10;
+
 /**
  * Thrown when backfill traversal exceeds the configured request budget.
  *
@@ -317,7 +319,7 @@ async function* getReplyAncestors(
   readonly origin: "in-reply-to";
   readonly depth: number;
 }> {
-  if (options.maxDepth != null && traversal.depth > options.maxDepth) return;
+  if (traversal.depth > (options.maxDepth ?? DEFAULT_MAX_DEPTH)) return;
   for await (
     const target of getReplyTargets(context, object, options, budget)
   ) {
@@ -351,7 +353,7 @@ async function* getReplyDescendants(
   readonly origin: "replies";
   readonly depth: number;
 }> {
-  if (options.maxDepth != null && traversal.depth > options.maxDepth) return;
+  if (traversal.depth > (options.maxDepth ?? DEFAULT_MAX_DEPTH)) return;
   const repliesId = object.repliesId;
   let repliesIdVisited = false;
   if (repliesId != null && !visitReplyTreeCollectionId(repliesId, traversal)) {

--- a/packages/backfill/src/backfill.ts
+++ b/packages/backfill/src/backfill.ts
@@ -167,8 +167,102 @@ async function* getStrategyItems(
       }
     }
   } else if (strategy === "reply-tree") {
-    return;
+    yield* getReplyTreeItems(context, note, options, budget);
   }
+}
+
+async function* getReplyTreeItems(
+  context: BackfillContext,
+  note: APObject,
+  options: BackfillOptions,
+  budget: RequestBudget,
+): AsyncIterable<{
+  readonly object: APObject;
+  readonly strategy: "reply-tree";
+  readonly origin: "in-reply-to";
+  readonly depth: number;
+}> {
+  const visitedIds = new Set<string>();
+  const visitedObjects = new WeakSet<APObject>();
+  if (note.id != null) visitedIds.add(note.id.href);
+  visitedObjects.add(note);
+  yield* getReplyAncestors(context, note, options, budget, {
+    depth: 1,
+    visitedIds,
+    visitedObjects,
+  });
+}
+
+async function* getReplyAncestors(
+  context: BackfillContext,
+  object: APObject,
+  options: BackfillOptions,
+  budget: RequestBudget,
+  traversal: {
+    readonly depth: number;
+    readonly visitedIds: Set<string>;
+    readonly visitedObjects: WeakSet<APObject>;
+  },
+): AsyncIterable<{
+  readonly object: APObject;
+  readonly strategy: "reply-tree";
+  readonly origin: "in-reply-to";
+  readonly depth: number;
+}> {
+  if (options.maxDepth != null && traversal.depth > options.maxDepth) return;
+  for await (
+    const target of getReplyTargets(context, object, options, budget)
+  ) {
+    if (!isContextPostObject(target)) continue;
+    if (!visitReplyTreeObject(target, traversal)) continue;
+    yield {
+      object: target,
+      strategy: "reply-tree",
+      origin: "in-reply-to",
+      depth: traversal.depth,
+    };
+    yield* getReplyAncestors(context, target, options, budget, {
+      depth: traversal.depth + 1,
+      visitedIds: traversal.visitedIds,
+      visitedObjects: traversal.visitedObjects,
+    });
+  }
+}
+
+async function* getReplyTargets(
+  context: BackfillContext,
+  object: APObject,
+  options: BackfillOptions,
+  budget: RequestBudget,
+): AsyncIterable<APObject | Link> {
+  try {
+    yield* object.getReplyTargets({
+      documentLoader: async (url) => {
+        return await loadCollectionItemDocument(context, url, options, budget);
+      },
+      crossOrigin: "trust",
+    });
+  } catch (error) {
+    if (error instanceof MaxRequestsExceeded) throw error;
+    budget.signal?.throwIfAborted();
+  }
+}
+
+function visitReplyTreeObject(
+  object: APObject,
+  traversal: {
+    readonly visitedIds: Set<string>;
+    readonly visitedObjects: WeakSet<APObject>;
+  },
+): boolean {
+  if (object.id != null) {
+    if (traversal.visitedIds.has(object.id.href)) return false;
+    traversal.visitedIds.add(object.id.href);
+  } else {
+    if (traversal.visitedObjects.has(object)) return false;
+  }
+  traversal.visitedObjects.add(object);
+  return true;
 }
 
 async function* getContextBackfillItems(

--- a/packages/backfill/src/backfill.ts
+++ b/packages/backfill/src/backfill.ts
@@ -40,6 +40,14 @@ type StrategyItem = {
   readonly depth: number;
 };
 
+type ReplyTreeTraversal = {
+  readonly depth: number;
+  readonly visitedObjectIds: Set<string>;
+  readonly visitedObjects: WeakSet<APObject>;
+  readonly visitedCollectionIds: Set<string>;
+  readonly visitedCollections: WeakSet<BackfillCollection>;
+};
+
 /**
  * Backfills post-like objects related to a seed object.
  *
@@ -227,19 +235,25 @@ async function* getReplyTreeItems(
   readonly origin: "in-reply-to" | "replies";
   readonly depth: number;
 }> {
-  const visitedIds = new Set<string>();
+  const visitedObjectIds = new Set<string>();
   const visitedObjects = new WeakSet<APObject>();
-  if (note.id != null) visitedIds.add(note.id.href);
+  const visitedCollectionIds = new Set<string>();
+  const visitedCollections = new WeakSet<BackfillCollection>();
+  if (note.id != null) visitedObjectIds.add(note.id.href);
   visitedObjects.add(note);
   yield* getReplyAncestors(context, note, options, budget, {
     depth: 1,
-    visitedIds,
+    visitedObjectIds,
     visitedObjects,
+    visitedCollectionIds,
+    visitedCollections,
   });
   yield* getReplyDescendants(context, note, options, budget, {
     depth: 1,
-    visitedIds,
+    visitedObjectIds,
     visitedObjects,
+    visitedCollectionIds,
+    visitedCollections,
   });
 }
 
@@ -248,11 +262,7 @@ async function* getReplyAncestors(
   object: APObject,
   options: BackfillOptions,
   budget: RequestBudget,
-  traversal: {
-    readonly depth: number;
-    readonly visitedIds: Set<string>;
-    readonly visitedObjects: WeakSet<APObject>;
-  },
+  traversal: ReplyTreeTraversal,
 ): AsyncIterable<{
   readonly object: APObject;
   readonly strategy: "reply-tree";
@@ -273,8 +283,10 @@ async function* getReplyAncestors(
     };
     yield* getReplyAncestors(context, target, options, budget, {
       depth: traversal.depth + 1,
-      visitedIds: traversal.visitedIds,
+      visitedObjectIds: traversal.visitedObjectIds,
       visitedObjects: traversal.visitedObjects,
+      visitedCollectionIds: traversal.visitedCollectionIds,
+      visitedCollections: traversal.visitedCollections,
     });
   }
 }
@@ -284,11 +296,7 @@ async function* getReplyDescendants(
   object: APObject,
   options: BackfillOptions,
   budget: RequestBudget,
-  traversal: {
-    readonly depth: number;
-    readonly visitedIds: Set<string>;
-    readonly visitedObjects: WeakSet<APObject>;
-  },
+  traversal: ReplyTreeTraversal,
 ): AsyncIterable<{
   readonly object: APObject;
   readonly strategy: "reply-tree";
@@ -296,8 +304,19 @@ async function* getReplyDescendants(
   readonly depth: number;
 }> {
   if (options.maxDepth != null && traversal.depth > options.maxDepth) return;
+  const repliesId = object.repliesId;
+  let repliesIdVisited = false;
+  if (repliesId != null && !visitReplyTreeCollectionId(repliesId, traversal)) {
+    return;
+  }
+  repliesIdVisited = repliesId != null;
   const replies = await getRepliesCollection(context, object, options, budget);
   if (replies == null) return;
+  if (repliesIdVisited) {
+    traversal.visitedCollections.add(replies);
+  } else if (!visitReplyTreeCollection(replies, traversal)) {
+    return;
+  }
   for await (
     const reply of getCollectionItems(context, replies, options, budget)
   ) {
@@ -311,8 +330,10 @@ async function* getReplyDescendants(
     };
     yield* getReplyDescendants(context, reply, options, budget, {
       depth: traversal.depth + 1,
-      visitedIds: traversal.visitedIds,
+      visitedObjectIds: traversal.visitedObjectIds,
       visitedObjects: traversal.visitedObjects,
+      visitedCollectionIds: traversal.visitedCollectionIds,
+      visitedCollections: traversal.visitedCollections,
     });
   }
 }
@@ -358,18 +379,37 @@ async function getRepliesCollection(
 
 function visitReplyTreeObject(
   object: APObject,
-  traversal: {
-    readonly visitedIds: Set<string>;
-    readonly visitedObjects: WeakSet<APObject>;
-  },
+  traversal: ReplyTreeTraversal,
 ): boolean {
   if (object.id != null) {
-    if (traversal.visitedIds.has(object.id.href)) return false;
-    traversal.visitedIds.add(object.id.href);
+    if (traversal.visitedObjectIds.has(object.id.href)) return false;
+    traversal.visitedObjectIds.add(object.id.href);
   } else {
     if (traversal.visitedObjects.has(object)) return false;
   }
   traversal.visitedObjects.add(object);
+  return true;
+}
+
+function visitReplyTreeCollection(
+  collection: BackfillCollection,
+  traversal: ReplyTreeTraversal,
+): boolean {
+  if (collection.id != null) {
+    return visitReplyTreeCollectionId(collection.id, traversal);
+  } else {
+    if (traversal.visitedCollections.has(collection)) return false;
+  }
+  traversal.visitedCollections.add(collection);
+  return true;
+}
+
+function visitReplyTreeCollectionId(
+  id: URL,
+  traversal: ReplyTreeTraversal,
+): boolean {
+  if (traversal.visitedCollectionIds.has(id.href)) return false;
+  traversal.visitedCollectionIds.add(id.href);
   return true;
 }
 

--- a/packages/backfill/src/backfill.ts
+++ b/packages/backfill/src/backfill.ts
@@ -95,6 +95,7 @@ export async function* backfill<
           contextStrategies,
           options,
           budget,
+          seenIds,
         );
       } else {
         items = getStrategyItems(
@@ -103,6 +104,7 @@ export async function* backfill<
           strategy,
           options,
           budget,
+          seenIds,
         );
       }
 
@@ -185,6 +187,7 @@ async function* getContextStrategyItems(
   strategies: readonly Exclude<BackfillStrategy, "reply-tree">[],
   options: BackfillOptions,
   budget: RequestBudget,
+  seenIds: ReadonlySet<string>,
 ): AsyncIterable<{
   readonly object: APObject;
   readonly strategy: Exclude<BackfillStrategy, "reply-tree">;
@@ -196,7 +199,13 @@ async function* getContextStrategyItems(
   const collection = await loadObject(context, contextId, options, budget);
   if (!isCollection(collection)) return;
   for await (
-    const object of getCollectionItems(context, collection, options, budget)
+    const object of getCollectionItems(
+      context,
+      collection,
+      options,
+      budget,
+      seenIds,
+    )
   ) {
     for (const strategy of strategies) {
       for await (
@@ -225,6 +234,7 @@ async function* getStrategyItems(
   strategy: BackfillStrategy,
   options: BackfillOptions,
   budget: RequestBudget,
+  seenIds: ReadonlySet<string>,
 ): AsyncIterable<{
   readonly object: APObject;
   readonly strategy: BackfillStrategy;
@@ -232,7 +242,14 @@ async function* getStrategyItems(
   readonly depth: number;
 }> {
   if (isContextStrategy(strategy)) {
-    yield* getContextStrategyItems(context, note, [strategy], options, budget);
+    yield* getContextStrategyItems(
+      context,
+      note,
+      [strategy],
+      options,
+      budget,
+      seenIds,
+    );
   } else if (strategy === "reply-tree") {
     yield* getReplyTreeItems(context, note, options, budget);
   }
@@ -471,10 +488,17 @@ async function* getCollectionItems(
   collection: BackfillCollection,
   options: BackfillOptions,
   budget: RequestBudget,
+  skipIds?: ReadonlySet<string>,
 ): AsyncIterable<APObject | Link> {
   yield* collection.getItems({
     documentLoader: async (url) => {
-      return await loadCollectionItemDocument(context, url, options, budget);
+      return await loadCollectionItemDocument(
+        context,
+        url,
+        options,
+        budget,
+        skipIds,
+      );
     },
     crossOrigin: "trust",
   });
@@ -506,12 +530,15 @@ async function loadCollectionItemDocument(
   url: string,
   options: BackfillOptions,
   budget: RequestBudget,
+  skipIds?: ReadonlySet<string>,
 ) {
   let object: APObject | null;
   try {
+    const iri = new URL(url);
+    if (skipIds?.has(iri.href)) return skippedCollectionItemDocument(url);
     object = await loadObject(
       context,
-      new URL(url),
+      iri,
       options,
       budget,
       true,

--- a/packages/backfill/src/backfill.ts
+++ b/packages/backfill/src/backfill.ts
@@ -13,6 +13,7 @@ import type {
   BackfillContext,
   BackfillItem,
   BackfillOptions,
+  BackfillOrigin,
   BackfillStrategy,
 } from "./types.ts";
 
@@ -51,9 +52,6 @@ export async function* backfill<
   const strategies = normalizeStrategies(options.strategies);
   if (strategies.length < 1) return;
 
-  const contextId = note.contextIds[0];
-  if (contextId == null) return;
-
   const budget: RequestBudget = {
     signal: options.signal,
     requestCount: 0,
@@ -61,19 +59,14 @@ export async function* backfill<
   const seenIds = new Set<string>();
   if (note.id != null) seenIds.add(note.id.href);
 
-  const collection = await loadObject(context, contextId, options, budget);
-  if (!isCollection(collection)) return;
-
   let yielded = 0;
   try {
-    for await (
-      const object of getCollectionItems(context, collection, options, budget)
-    ) {
+    for (const strategy of strategies) {
       for await (
-        const item of getBackfillItems(
+        const item of getStrategyItems(
           context,
-          object,
-          strategies,
+          note,
+          strategy,
           options,
           budget,
         )
@@ -89,8 +82,8 @@ export async function* backfill<
           object: item.object as TObject,
           id,
           strategy: item.strategy,
-          origin: "collection",
-          depth: 0,
+          origin: item.origin,
+          depth: item.depth,
         };
 
         yielded++;
@@ -106,24 +99,102 @@ export async function* backfill<
 function normalizeStrategies(
   strategies: readonly BackfillStrategy[] = defaultStrategies,
 ): readonly BackfillStrategy[] {
-  if (strategies.includes("context-auto")) return ["context-auto"];
-  return Array.from(new Set(strategies));
+  const normalized: BackfillStrategy[] = [];
+  for (const strategy of strategies) {
+    if (strategy === "context-auto") {
+      for (let i = normalized.length - 1; i >= 0; i--) {
+        if (isContextStrategy(normalized[i])) normalized.splice(i, 1);
+      }
+      if (!normalized.includes(strategy)) normalized.push(strategy);
+    } else if (isContextStrategy(strategy)) {
+      if (
+        !normalized.includes("context-auto") && !normalized.includes(
+          strategy,
+        )
+      ) {
+        normalized.push(strategy);
+      }
+    } else if (!normalized.includes(strategy)) {
+      normalized.push(strategy);
+    }
+  }
+  return normalized;
 }
 
-async function* getBackfillItems(
+function isContextStrategy(
+  strategy: BackfillStrategy,
+): strategy is Exclude<BackfillStrategy, "reply-tree"> {
+  return strategy === "context-objects" ||
+    strategy === "context-activities" ||
+    strategy === "context-auto";
+}
+
+async function* getStrategyItems(
   context: BackfillContext,
-  object: APObject | Link,
-  strategies: readonly BackfillStrategy[],
+  note: APObject,
+  strategy: BackfillStrategy,
   options: BackfillOptions,
   budget: RequestBudget,
 ): AsyncIterable<{
   readonly object: APObject;
   readonly strategy: BackfillStrategy;
+  readonly origin: BackfillOrigin;
+  readonly depth: number;
 }> {
-  for (const strategy of strategies) {
-    if (strategy === "context-objects" && isContextPostObject(object)) {
-      yield { object, strategy };
-    } else if (strategy === "context-activities") {
+  if (isContextStrategy(strategy)) {
+    const contextId = note.contextIds[0];
+    if (contextId == null) return;
+    const collection = await loadObject(context, contextId, options, budget);
+    if (!isCollection(collection)) return;
+    for await (
+      const object of getCollectionItems(context, collection, options, budget)
+    ) {
+      for await (
+        const item of getContextBackfillItems(
+          context,
+          object,
+          strategy,
+          options,
+          budget,
+        )
+      ) {
+        yield {
+          object: item.object,
+          strategy: item.strategy,
+          origin: "collection",
+          depth: 0,
+        };
+      }
+    }
+  } else if (strategy === "reply-tree") {
+    return;
+  }
+}
+
+async function* getContextBackfillItems(
+  context: BackfillContext,
+  object: APObject | Link,
+  strategy: Exclude<BackfillStrategy, "reply-tree">,
+  options: BackfillOptions,
+  budget: RequestBudget,
+): AsyncIterable<{
+  readonly object: APObject;
+  readonly strategy: Exclude<BackfillStrategy, "reply-tree">;
+}> {
+  if (strategy === "context-objects" && isContextPostObject(object)) {
+    yield { object, strategy };
+  } else if (strategy === "context-activities") {
+    const activityObject = await getCreateActivityObject(
+      context,
+      object,
+      options,
+      budget,
+    );
+    if (activityObject != null && isContextPostObject(activityObject)) {
+      yield { object: activityObject, strategy };
+    }
+  } else if (strategy === "context-auto") {
+    if (object instanceof Activity) {
       const activityObject = await getCreateActivityObject(
         context,
         object,
@@ -133,20 +204,8 @@ async function* getBackfillItems(
       if (activityObject != null && isContextPostObject(activityObject)) {
         yield { object: activityObject, strategy };
       }
-    } else if (strategy === "context-auto") {
-      if (object instanceof Activity) {
-        const activityObject = await getCreateActivityObject(
-          context,
-          object,
-          options,
-          budget,
-        );
-        if (activityObject != null && isContextPostObject(activityObject)) {
-          yield { object: activityObject, strategy };
-        }
-      } else if (isContextPostObject(object)) {
-        yield { object, strategy };
-      }
+    } else if (isContextPostObject(object)) {
+      yield { object, strategy };
     }
   }
 }

--- a/packages/backfill/src/types.ts
+++ b/packages/backfill/src/types.ts
@@ -61,7 +61,8 @@ export type BackfillDocumentLoader = (
  */
 export interface BackfillContext {
   /**
-   * Dereferences context collections and collection item IRIs.
+   * Dereferences context collections, collection item IRIs, reply targets,
+   * and replies collections.
    */
   readonly documentLoader: BackfillDocumentLoader;
 }
@@ -91,15 +92,20 @@ export interface BackfillOptions<
   readonly maxItems?: number;
 
   /**
-   * Maximum traversal depth.  This is reserved for future reply-tree traversal;
+   * Maximum reply-tree traversal depth.
+   *
+   * Immediate `inReplyTo` targets and direct `replies` collection items have
+   * depth 1.  Their parents or replies have depth 2, and so on.  Context
+   * collection items are depth 0 and are not limited by this option.
    */
   readonly maxDepth?: number;
 
   /**
    * Maximum number of calls to {@link BackfillContext.documentLoader}.
    *
-   * Dereferencing the note context, collection item IRIs, and future page IRIs
-   * all count as requests.  Embedded collection items do not count.
+   * Dereferencing the note context, collection item IRIs, reply target IRIs,
+   * replies collection IRIs, and future page IRIs all count as requests.
+   * Embedded objects and collections do not count.
    */
   readonly maxRequests?: number;
 
@@ -148,8 +154,11 @@ export interface BackfillItem<
   readonly origin: BackfillOrigin;
 
   /**
-   * Traversal depth.  Direct context collection items are depth 0; deeper
-   * values are reserved for future reply-tree traversal.
+   * Traversal depth.
+   *
+   * Direct context collection items are depth 0.  Reply-tree items use depth
+   * 1 for immediate `inReplyTo` targets and direct `replies` collection items,
+   * depth 2 for the next level, and so on.
    */
   readonly depth?: number;
 }

--- a/packages/backfill/src/types.ts
+++ b/packages/backfill/src/types.ts
@@ -68,7 +68,7 @@ export interface BackfillContext {
 }
 
 /**
- * Controls direct context collection backfill traversal.
+ * Controls backfill traversal.
  *
  * @since 2.x.0
  */
@@ -77,6 +77,10 @@ export interface BackfillOptions<
 > {
   /**
    * Backfill strategies to run.
+   *
+   * Strategies run in order and share request, item, abort, and deduplication
+   * state.  If multiple strategies discover the same object ID, the first
+   * strategy keeps its {@link BackfillItem} metadata.
    *
    * Defaults to `["context-auto"]`.
    * If `"context-auto"` is included, it absorbs other context collection
@@ -104,8 +108,8 @@ export interface BackfillOptions<
    * Maximum number of calls to {@link BackfillContext.documentLoader}.
    *
    * Dereferencing the note context, collection item IRIs, reply target IRIs,
-   * replies collection IRIs, and future page IRIs all count as requests.
-   * Embedded objects and collections do not count.
+   * replies collection IRIs, and future page IRIs all count as requests across
+   * all strategies.  Embedded objects and collections do not count.
    */
   readonly maxRequests?: number;
 

--- a/packages/backfill/src/types.ts
+++ b/packages/backfill/src/types.ts
@@ -11,7 +11,7 @@ import type { Object as APObject } from "@fedify/vocab";
  *    handling direct post-like objects and supported `Create` activities.
  *    If included, it absorbs other context collection strategies.
  * -  `"reply-tree"` walks the reply graph through `inReplyTo` ancestors and
- *    `replies` descendants.
+ *    `replies` descendants, yielding discovered post-like objects.
  *
  * @since 2.x.0
  */

--- a/packages/backfill/src/types.ts
+++ b/packages/backfill/src/types.ts
@@ -101,6 +101,8 @@ export interface BackfillOptions<
    * Immediate `inReplyTo` targets and direct `replies` collection items have
    * depth 1.  Their parents or replies have depth 2, and so on.  Context
    * collection items are depth 0 and are not limited by this option.
+   *
+   * Defaults to 10.
    */
   readonly maxDepth?: number;
 

--- a/packages/backfill/src/types.ts
+++ b/packages/backfill/src/types.ts
@@ -9,21 +9,28 @@ import type { Object as APObject } from "@fedify/vocab";
  *    activities in the context collection.
  * -  `"context-auto"` classifies context collection items automatically,
  *    handling direct post-like objects and supported `Create` activities.
- *    If included, it absorbs all other strategies.
+ *    If included, it absorbs other context collection strategies.
+ * -  `"reply-tree"` walks the reply graph through `inReplyTo` ancestors and
+ *    `replies` descendants.
  *
  * @since 2.x.0
  */
 export type BackfillStrategy =
   | "context-objects"
   | "context-activities"
-  | "context-auto";
+  | "context-auto"
+  | "reply-tree";
 
 /**
  * Source relation that produced a backfilled object.
  *
  * @since 2.x.0
  */
-export type BackfillOrigin = "context" | "collection";
+export type BackfillOrigin =
+  | "context"
+  | "collection"
+  | "in-reply-to"
+  | "replies";
 
 /**
  * Options passed to {@link BackfillDocumentLoader}.
@@ -71,7 +78,8 @@ export interface BackfillOptions<
    * Backfill strategies to run.
    *
    * Defaults to `["context-auto"]`.
-   * If `"context-auto"` is included, it absorbs all other strategies.
+   * If `"context-auto"` is included, it absorbs other context collection
+   * strategies.
    *
    * @since 2.x.0
    */


### PR DESCRIPTION
## Summary

This PR adds the `reply-tree` strategy to `@fedify/backfill`, last feature of the #275 

The strategy walks reply relationships from a seed object by following `inReplyTo` ancestors and `replies` descendants. It is opt-in, so the default remains the cheaper FEP-f228 context collection path via `context-auto`.

This also wires ordered multi-strategy execution for hybrid usage such as `["context-auto", "reply-tree"]`. Strategies share item/request budgets, abort state, deduplication, and a traversal-local document cache.

Related #275 

## Details

- Add `reply-tree` strategy
- Walk `inReplyTo` ancestors
- Walk `replies` descendants
- Respect `maxDepth` for reply-tree traversal
- Preserve ordered strategy semantics
- Share `maxItems`, `maxRequests`, `interval`, and `signal` across strategies
- Deduplicate yielded objects globally by object ID
- Avoid repeated dereferences with traversal-local caching
- Skip already-seen context collection URL items before dereferencing
- Document reply-tree usage and ordered strategy behavior

## Notes

`reply-tree` remains opt-in because it can be more network-heavy than context collection traversal.

This PR does not impose default `maxDepth` or `maxRequests`; callers are expected to choose limits appropriate for their use case.

The cache is traversal-local only. Persistent/shared caching can be layered outside `@fedify/backfill` through the supplied `documentLoader`.

## Verification

- `deno task -f @fedify/backfill check`
- `deno task -f @fedify/backfill test`
- `mise exec -- pnpm --filter @fedify/backfill test`
- `mise exec -- pnpm --filter @fedify/backfill test:bun`

## AI usage

Assisted-by: Codex:gpt-5.5