### PR TITLE
Fall back when Linked Data signing hits JSON-LD processing errors

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,16 @@ Version 2.0.21
 
 To be released.
 
+### @fedify/fedify
+
+ -  Fixed outbound activity delivery aborting when Linked Data Signature
+    creation fails during JSON-LD canonicalization.  Fedify now logs the
+    signing failure and continues delivery without the Linked Data Signature
+    for JSON-LD processing failures, while still surfacing key, configuration,
+    and programming errors from signing.  [[#824]]
+
+[#824]: https://github.com/fedify-dev/fedify/issues/824
+
 
 Version 2.0.20
 --------------

--- a/packages/fedify/src/federation/middleware.ts
+++ b/packages/fedify/src/federation/middleware.ts
@@ -184,24 +184,34 @@ function isLinkedDataSignatureJsonLdProcessingError(
   error: unknown,
 ): error is Error {
   if (!(error instanceof Error)) return false;
-  if (error.message.startsWith("Maximum deep iterations exceeded")) {
+  const errorName = (error as Error & { name?: unknown }).name;
+  const errorMessage = (error as Error & { message?: unknown }).message;
+  if (
+    typeof errorMessage === "string" &&
+    errorMessage.startsWith("Maximum deep iterations exceeded")
+  ) {
     return true;
   }
   const details = (error as Error & {
     details?: { code?: unknown; cause?: unknown };
   }).details;
+  const errorCause = (error as Error & { cause?: unknown }).cause;
+  const cause = errorCause instanceof Error ? errorCause : details?.cause;
   if (
-    error.name === "jsonld.InvalidUrl" &&
+    errorName === "jsonld.InvalidUrl" &&
     details?.code === "loading remote context failed" &&
-    details.cause instanceof Error
+    cause instanceof Error
   ) {
-    return details.cause.message.startsWith(
-      "Maximum deep iterations exceeded",
-    ) || details.cause.name.startsWith("jsonld.") ||
-      details.cause.name === "UnsafeJsonLdError";
+    const causeName = (cause as Error & { name?: unknown }).name;
+    const causeMessage = (cause as Error & { message?: unknown }).message;
+    return (
+      typeof causeMessage === "string" &&
+      causeMessage.startsWith("Maximum deep iterations exceeded")
+    ) || (typeof causeName === "string" && causeName.startsWith("jsonld."));
   }
-  return error.name.startsWith("jsonld.") ||
-    error.name === "UnsafeJsonLdError";
+  return errorName !== "jsonld.InvalidUrl" &&
+    typeof errorName === "string" &&
+    errorName.startsWith("jsonld.");
 }
 
 /**

--- a/packages/fedify/src/federation/middleware.ts
+++ b/packages/fedify/src/federation/middleware.ts
@@ -180,38 +180,39 @@ function isPermanentInboxParseError(error: unknown): error is Error {
         isInvalidUrlTypeError(error)));
 }
 
-function isLinkedDataSignatureJsonLdProcessingError(
-  error: unknown,
-): error is Error {
-  if (!(error instanceof Error)) return false;
-  const errorName = (error as Error & { name?: unknown }).name;
-  const errorMessage = (error as Error & { message?: unknown }).message;
+type LinkedDataSignatureJsonLdProcessingError = Error & {
+  details?: { code?: unknown; cause?: unknown };
+  cause?: unknown;
+};
+
+function hasLinkedDataSignatureJsonLdProcessingError(
+  error: LinkedDataSignatureJsonLdProcessingError,
+): boolean {
   if (
-    typeof errorMessage === "string" &&
-    errorMessage.startsWith("Maximum deep iterations exceeded")
+    error.message.startsWith("Maximum deep iterations exceeded")
   ) {
     return true;
   }
-  const details = (error as Error & {
-    details?: { code?: unknown; cause?: unknown };
-  }).details;
-  const errorCause = (error as Error & { cause?: unknown }).cause;
-  const cause = errorCause instanceof Error ? errorCause : details?.cause;
+  const cause = error.cause instanceof Error
+    ? error.cause
+    : error.details?.cause;
   if (
-    errorName === "jsonld.InvalidUrl" &&
-    details?.code === "loading remote context failed" &&
+    error.name === "jsonld.InvalidUrl" &&
+    error.details?.code === "loading remote context failed" &&
     cause instanceof Error
   ) {
-    const causeName = (cause as Error & { name?: unknown }).name;
-    const causeMessage = (cause as Error & { message?: unknown }).message;
     return (
-      typeof causeMessage === "string" &&
-      causeMessage.startsWith("Maximum deep iterations exceeded")
-    ) || (typeof causeName === "string" && causeName.startsWith("jsonld."));
+      cause.message.startsWith("Maximum deep iterations exceeded")
+    ) || cause.name.startsWith("jsonld.");
   }
-  return errorName !== "jsonld.InvalidUrl" &&
-    typeof errorName === "string" &&
-    errorName.startsWith("jsonld.");
+  return error.name !== "jsonld.InvalidUrl" && error.name.startsWith("jsonld.");
+}
+
+function isLinkedDataSignatureJsonLdProcessingError(
+  error: unknown,
+): error is LinkedDataSignatureJsonLdProcessingError {
+  return error instanceof Error &&
+    hasLinkedDataSignatureJsonLdProcessingError(error);
 }
 
 /**

--- a/packages/fedify/src/federation/middleware.ts
+++ b/packages/fedify/src/federation/middleware.ts
@@ -180,6 +180,30 @@ function isPermanentInboxParseError(error: unknown): error is Error {
         isInvalidUrlTypeError(error)));
 }
 
+function isLinkedDataSignatureJsonLdProcessingError(
+  error: unknown,
+): error is Error {
+  if (!(error instanceof Error)) return false;
+  if (error.message.startsWith("Maximum deep iterations exceeded")) {
+    return true;
+  }
+  const details = (error as Error & {
+    details?: { code?: unknown; cause?: unknown };
+  }).details;
+  if (
+    error.name === "jsonld.InvalidUrl" &&
+    details?.code === "loading remote context failed" &&
+    details.cause instanceof Error
+  ) {
+    return details.cause.message.startsWith(
+      "Maximum deep iterations exceeded",
+    ) || details.cause.name.startsWith("jsonld.") ||
+      details.cause.name === "UnsafeJsonLdError";
+  }
+  return error.name.startsWith("jsonld.") ||
+    error.name === "UnsafeJsonLdError";
+}
+
 /**
  * Options for {@link createFederation} function.
  * @template TContextData The type of the context data.
@@ -1325,10 +1349,20 @@ export class FederationImpl<TContextData>
         },
       );
     } else {
-      jsonLd = await signJsonLd(jsonLd, rsaKey.privateKey, rsaKey.keyId, {
-        contextLoader,
-        tracerProvider: this.tracerProvider,
-      });
+      try {
+        jsonLd = await signJsonLd(jsonLd, rsaKey.privateKey, rsaKey.keyId, {
+          contextLoader,
+          tracerProvider: this.tracerProvider,
+        });
+      } catch (error) {
+        if (!isLinkedDataSignatureJsonLdProcessingError(error)) throw error;
+        logger.warn(
+          "Failed to create a Linked Data signature for the activity " +
+            "{activityId}.  The activity will be sent without a Linked " +
+            "Data signature.",
+          { activityId, error },
+        );
+      }
     }
     if (!proofCreated) {
       logger.warn(


### PR DESCRIPTION
## Description

Fixes #824

This changes outbound activity delivery to continue without an optional Linked Data Signature when JSON-LD canonicalization/processing fails during signing. These failures are logged as warnings.

Other signing failures, such as key, configuration, or programming errors, still fail.

## AI Usage

Codex (GPT-5.5) was used after the implementation for self-review.