### PR TITLE
Treat malformed actor keys as lookup failures

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,13 @@ To be released.
     for JSON-LD processing failures, while still surfacing key, configuration,
     and programming errors from signing.  [[#824], [#842] by Lee ByeongJun]
 
+ -  Fixed inbox verification crashing when a remote actor document contains a
+    malformed `publicKey` entry.  Fedify now treats the malformed key as a
+    failed key lookup so HTTP signature verification fails normally instead of
+    returning a server error.  [[#825] by Lee ByeongJun]
+
 [#824]: https://github.com/fedify-dev/fedify/issues/824
+[#825]: https://github.com/fedify-dev/fedify/issues/825
 [#842]: https://github.com/fedify-dev/fedify/pull/842
 
 

--- a/packages/fedify/src/sig/key.test.ts
+++ b/packages/fedify/src/sig/key.test.ts
@@ -353,11 +353,12 @@ test("fetchKey()", async () => {
 });
 
 test("fetchKey() returns null for a malformed actor publicKey", async () => {
+  const actorId = "https://example.com/malformed-public-key";
   const keyId = "https://example.com/malformed-public-key#main-key";
   const cache: Record<string, CryptographicKey | Multikey | null> = {};
   const options: FetchKeyOptions = {
     async documentLoader(resource) {
-      if (resource === keyId) {
+      if (resource === actorId) {
         return {
           contextUrl: null,
           documentUrl: resource,
@@ -366,15 +367,22 @@ test("fetchKey() returns null for a malformed actor publicKey", async () => {
               "https://www.w3.org/ns/activitystreams",
               "https://w3id.org/security/v1",
             ],
-            id: "https://example.com/malformed-public-key",
+            id: actorId,
             type: "Person",
-            publicKey: {
-              "@context": "https://w3id.org/security/v1",
-              id: keyId,
-              type: "Key",
-              owner: "https://example.com/malformed-public-key",
-              publicKeyPem: "not a public key",
-            },
+            publicKey: keyId,
+          },
+        };
+      }
+      if (resource === keyId) {
+        return {
+          contextUrl: null,
+          documentUrl: resource,
+          document: {
+            "@context": "https://w3id.org/security/v1",
+            id: keyId,
+            type: "Key",
+            owner: actorId,
+            publicKeyPem: "not a public key",
           },
         };
       }
@@ -392,12 +400,12 @@ test("fetchKey() returns null for a malformed actor publicKey", async () => {
     } satisfies KeyCache,
   };
 
-  assertEquals(await fetchKey(keyId, CryptographicKey, options), {
+  assertEquals(await fetchKey(actorId, CryptographicKey, options), {
     key: null,
     cached: false,
   });
-  assertEquals(cache, { [keyId]: null });
-  assertEquals(await fetchKey(keyId, CryptographicKey, options), {
+  assertEquals(cache, { [actorId]: null });
+  assertEquals(await fetchKey(actorId, CryptographicKey, options), {
     key: null,
     cached: true,
   });

--- a/packages/fedify/src/sig/key.test.ts
+++ b/packages/fedify/src/sig/key.test.ts
@@ -351,3 +351,54 @@ test("fetchKey()", async () => {
     },
   );
 });
+
+test("fetchKey() returns null for a malformed actor publicKey", async () => {
+  const keyId = "https://example.com/malformed-public-key#main-key";
+  const cache: Record<string, CryptographicKey | Multikey | null> = {};
+  const options: FetchKeyOptions = {
+    async documentLoader(resource) {
+      if (resource === keyId) {
+        return {
+          contextUrl: null,
+          documentUrl: resource,
+          document: {
+            "@context": [
+              "https://www.w3.org/ns/activitystreams",
+              "https://w3id.org/security/v1",
+            ],
+            id: "https://example.com/malformed-public-key",
+            type: "Person",
+            publicKey: {
+              "@context": "https://w3id.org/security/v1",
+              id: keyId,
+              type: "Key",
+              owner: "https://example.com/malformed-public-key",
+              publicKeyPem: "not a public key",
+            },
+          },
+        };
+      }
+      return await mockDocumentLoader(resource);
+    },
+    contextLoader: mockDocumentLoader,
+    keyCache: {
+      get(keyId) {
+        return Promise.resolve(cache[keyId.href]);
+      },
+      set(keyId, key) {
+        cache[keyId.href] = key;
+        return Promise.resolve();
+      },
+    } satisfies KeyCache,
+  };
+
+  assertEquals(await fetchKey(keyId, CryptographicKey, options), {
+    key: null,
+    cached: false,
+  });
+  assertEquals(cache, { [keyId]: null });
+  assertEquals(await fetchKey(keyId, CryptographicKey, options), {
+    key: null,
+    cached: true,
+  });
+});

--- a/packages/fedify/src/sig/key.ts
+++ b/packages/fedify/src/sig/key.ts
@@ -325,23 +325,34 @@ async function fetchKeyInternal<T extends CryptographicKey | Multikey>(
   let key: T | null = null;
   if (object instanceof cls) key = object;
   else if (isActor(object)) {
+    // Treat malformed remote actor keys as missing keys.
     // @ts-ignore: cls is either CryptographicKey or Multikey
     const keys = cls === CryptographicKey
-      ? object.getPublicKeys({ documentLoader, contextLoader, tracerProvider })
+      ? object.getPublicKeys({
+        documentLoader,
+        contextLoader,
+        suppressError: true,
+        tracerProvider,
+      })
       : object.getAssertionMethods({
         documentLoader,
         contextLoader,
+        suppressError: true,
         tracerProvider,
       });
     let length = 0;
     let lastKey: T | null = null;
-    for await (const k of keys) {
-      length++;
-      lastKey = k as T;
-      if (k.id?.href === keyId) {
-        key = k as T;
-        break;
+    try {
+      for await (const k of keys) {
+        length++;
+        lastKey = k as T;
+        if (k.id?.href === keyId) {
+          key = k as T;
+          break;
+        }
       }
+    } catch (e) {
+      if (!(e instanceof TypeError)) throw e;
     }
     const keyIdUrl = new URL(keyId);
     if (key == null && keyIdUrl.hash === "" && length === 1) {


### PR DESCRIPTION
## Description

fixes #825 

- Treat malformed actor `publicKey` entries as failed key lookups during inbox signature verification
- Cache the failed lookup as `null` so repeated verification attempts do not reprocess the same malformed key
- Add a regression test for an inline malformed actor `publicKey` object that fails while iterating `getPublicKeys()`

## AI Usage

AI assistance was used to review the fix and write the regression test.