### PR TITLE
Refactor mise.toml to use native deps and hooks

### DIFF
--- a/.agents/skills/create-integration-package/SKILL.md
+++ b/.agents/skills/create-integration-package/SKILL.md
@@ -78,7 +78,7 @@ files, and ensuring the code is compatible with both Deno and Node.js/Bun
 environments.
 
 After writing *deno.json* and *package.json* (or whenever you add or
-change dependencies), run `mise run install` to update both *deno.lock*
+change dependencies), run `mise deps` to update both *deno.lock*
 and *pnpm-lock.yaml*.  This ensures all lockfiles stay in sync.
 
 Add additional definitions as appropriate based on context.  Aside from the
@@ -238,7 +238,7 @@ At a minimum, test the following scenarios (see
 3.  Write *README.md*
 4.  Write *deno.json* (if publishing to JSR is intended)
 5.  Write *package.json* (if publishing to npm is intended)
-6.  Run `mise run install`
+6.  Run `mise deps`
 7.  Write *tsdown.config.ts* (if Node.js and Bun are supported)
 8.  Write tests if possible
 9.  Perform remaining updates per the “Adding a new package” section in

--- a/.devcontainer/bin/postCreateCommand.sh
+++ b/.devcontainer/bin/postCreateCommand.sh
@@ -18,4 +18,7 @@ cat << 'EOF' >> ~/.bashrc
 eval "$(mise activate bash)"
 EOF
 
-mise run install
+# Install project dependencies via mise's deps providers (codegen, Deno
+# pre-cache, and `pnpm install`, which builds all packages through its
+# `prepare` lifecycle script).
+mise deps

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -5,7 +5,7 @@
   "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
   "features": {
     "ghcr.io/devcontainers-extra/features/mise:1": {
-      "version": "2025.12.12"
+      "version": "2026.6.12"
     }
   },
   "postCreateCommand": ".devcontainer/bin/postCreateCommand.sh",

--- a/.github/actions/setup-mise/action.yaml
+++ b/.github/actions/setup-mise/action.yaml
@@ -6,6 +6,9 @@ runs:
   steps:
   - uses: jdx/mise-action@v4
     with:
-      version: 2025.12.12
-  - run: mise run install
+      version: 2026.6.12
+  # Install project dependencies (codegen, Deno pre-cache, and `pnpm install`,
+  # whose `prepare` lifecycle script builds all packages) via mise's deps
+  # providers.  See the [deps.*] sections in mise.toml.
+  - run: mise deps
     shell: bash

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -78,6 +78,9 @@ jobs:
     - uses: ./.github/actions/setup-mise
     - name: Enable RabbitMQ consistent hash exchange plugin
       run: docker exec ${{ job.services.rabbitmq.id }} rabbitmq-plugins enable rabbitmq_consistent_hash_exchange
+    # Dependencies (codegen, install, and the build via pnpm's `prepare`) are
+    # already provisioned by the setup-mise action's `mise deps`; `--skip-deps`
+    # runs only the test task itself.
     - run: mise run --skip-deps test:deno -- --coverage=.cov --junit-path=.test-report.xml
       env:
         RUST_BACKTRACE: ${{ runner.debug }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -45,10 +45,14 @@ Development environment
  -  Primary environment: [Deno]
  -  Additional test environments: [Node.js] and [Bun]
  -  Recommended editor: [Visual Studio Code] with [Deno extension]
- -  **CRITICAL**: Run `mise run install` (or `pnpm install`) after checkout.
-    This automatically runs code generation and builds all packages.
- -  Lockfiles: Both *deno.lock* and *pnpm-lock.yaml* are committed.
-    Update them when changing dependencies.
+ -  **CRITICAL**: Run `mise install` once after checkout.  A `postinstall` hook
+    then runs `mise deps`, which generates code, installs dependencies, and
+    builds all packages, so the checkout is ready to use.
+ -  Run development scripts through mise (`mise tasks` to list,
+    `mise run <task>` to invoke).  Don't call `pnpm` or `npm` directly for dev
+    workflows.
+ -  Lockfiles: Both *deno.lock* and *pnpm-lock.yaml* are committed.  Run
+    `mise deps` to update them when changing dependencies.
 
 [mise]: https://mise.jdx.dev/
 [Deno]: https://deno.com/
@@ -124,11 +128,14 @@ Code patterns and principles
 Development workflow
 --------------------
 
- -  **Code Generation**: Run `mise run codegen` whenever vocabulary YAML files
-    or code generation scripts change.
- -  **Building Packages**: After installation, all packages are automatically
-    built. To rebuild a specific package and its dependencies, run `pnpm build`
-    in that package's directory.
+ -  **Code Generation**: Vocabulary types are regenerated automatically before
+    any mise task (a `mise deps` provider watches the vocab YAML and
+    `@fedify/vocab-tools`).  Run `mise run codegen` to force it, e.g. to refresh
+    the editor/LSP after editing YAML.
+ -  **Building Packages**: All packages are built automatically as part of
+    setup.  Run `mise run build` to rebuild everything, or
+    `mise run prepare-each <pkg>` to rebuild just one (without the `@fedify/`
+    prefix).
  -  **Checking Code**: Run `mise run check` before committing.
  -  **Running Tests**: Use `mise run test:deno` for Deno tests or
     `mise run test` for all environments.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -302,7 +302,7 @@ changes.
 To update both lockfiles at once, run:
 
 ~~~~ bash
-mise run install
+mise deps
 ~~~~
 
 When reviewing pull requests, please check that lockfile changes are included
@@ -500,8 +500,10 @@ mise trust
 mise install
 ~~~~
 
-This will install [Deno], [Node.js], and [Bun] with the correct versions
-specified in *mise.toml*.
+This installs [Deno], [Node.js], [Bun], and the other tools with the correct
+versions specified in *mise.toml*.  A `postinstall` hook then runs `mise deps`,
+which generates code, installs dependencies, builds all packages, and (on first
+setup) installs the Git pre-commit hook, so the checkout is ready to use.
 
 The recommended editor for Fedify is [Visual Studio Code] with
 the [Deno extension] installed.  Or you can use any editor that supports Deno;
@@ -510,35 +512,28 @@ see the [*Set Up Your Environment* section][1] in the Deno manual.
 > [!CAUTION]
 >
 > Fedify heavily depends on code generation and all packages must be built
-> before coding or testing. Running `mise run install` (or `pnpm install`)
-> automatically handles code generation and builds all packages.
+> before coding or testing. The `mise install` step above handles code
+> generation and builds all packages for you.
 
-Assuming you have Deno and Visual Studio Code installed, you can open
-the repository in Visual Studio Code and get ready to hack on Fedify by running
-the following commands at the *root* of the repository:
+With the tools and dependencies installed by the setup commands above, open the
+repository in Visual Studio Code to get ready to hack on Fedify:
 
 ~~~~ bash
-mise run install  # This runs codegen and builds all packages
 code .
 ~~~~
 
 > [!TIP]
-> It is recommended to install Git pre-commit hooks after cloning the
-> repository to ensure code quality checks run automatically before each
-> commit:
+> The Git pre-commit hook, which runs `mise run check` before each commit, is
+> installed automatically by `mise install` (unless one is already present).
+> To (re)install it explicitly, run:
 >
 > ~~~~ bash
 > mise run hooks:install
 > ~~~~
 
-Note that the `mise run install` command is required to run only once at
-the very first time after checkout. When you update dependencies or code
-generation scripts, run `mise run install` again. Otherwise, you can skip
-the command and just run:
-
-~~~~ bash
-code .
-~~~~
+You only need to run `mise install` once, right after checkout. When you change
+dependencies or code generation inputs, mise's deps providers pick the change
+up automatically before the next task runs (or run `mise deps` explicitly).
 
 Since this is a monorepo, you can also work on individual packages by
 navigating to their directories and using package-specific tasks.
@@ -679,7 +674,7 @@ in the browser.  To do that, you need to install [Node.js] and [pnpm] first.
 Then you can run the following commands at the repository root:
 
 ~~~~ bash
-mise run install
+mise install
 mise run docs
 ~~~~
 

--- a/deno.json
+++ b/deno.json
@@ -117,78 +117,7 @@
   },
   "nodeModulesDir": "auto",
   "tasks": {
-    "build": {
-      "command": "pnpm --recursive --filter '@fedify/*' --parallel --silent build",
-      "dependencies": [
-        "install"
-      ]
-    },
-    "codegen": "deno task -f @fedify/vocab compile",
-    "check-versions": "deno run --allow-read --allow-write scripts/check_versions.ts",
-    "check-all": {
-      "command": "deno fmt --check && deno lint && deno check $(deno eval 'import m from \"./deno.json\" with { type: \"json\" }; for (let p of m.workspace) console.log(p)')",
-      "dependencies": [
-        "check-versions",
-        "codegen"
-      ]
-    },
-    "install": {
-      "command": "deno run --allow-read --allow-env --allow-run scripts/install.ts && pnpm install",
-      "dependencies": [
-        "codegen"
-      ]
-    },
-    "pnpm:build-vocab-runtime": {
-      "command": "pnpm -C packages/vocab-runtime build"
-    },
-    "pnpm:build-vocab-tools": {
-      "command": "pnpm -C packages/vocab-tools build"
-    },
-    "pnpm:build-fixture": {
-      "command": "pnpm -C packages/fixture build"
-    },
-    "pnpm:build-webfinger": {
-      "command": "pnpm -C packages/webfinger build"
-    },
-    "pnpm:build-vocab": {
-      "command": "pnpm -C packages/vocab build",
-      "dependencies": [
-        "install",
-        "pnpm:build-vocab-runtime",
-        "pnpm:build-vocab-tools",
-        "pnpm:build-fixture",
-        "pnpm:build-webfinger"
-      ]
-    },
-    "test": {
-      "command": "deno test --check --doc --allow-all --unstable-kv --trace-leaks --parallel",
-      "dependencies": [
-        "codegen"
-      ]
-    },
-    "test:node": {
-      "command": "pnpm run --recursive --filter '!{docs}' test",
-      "dependencies": [
-        "build"
-      ]
-    },
-    "test:bun": {
-      "command": "pnpm run --recursive --filter '!{docs}' test:bun",
-      "dependencies": [
-        "build"
-      ]
-    },
-    "test-all": {
-      "dependencies": [
-        "check-all",
-        "test",
-        "test:node",
-        "test:bun"
-      ]
-    },
-    "cli": "deno task -f @fedify/cli run",
-    "hooks:install": "mise generate git-pre-commit --write --task=check",
-    "hooks:pre-commit": "mise run check"
+    "cli": "deno task -f @fedify/cli run"
   },
   "test": {
     "include": [

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,21 +4,17 @@ Fedify docs
 This directory contains the source files of the Fedify docs.  The docs are
 written in Markdown format and are built with [VitePress].
 
-In order to build the docs locally, you need to install [Node.js] and [pnpm]
-first. Then you can run the following commands (assuming you are in
-the *docs/* directory):
+To build the docs locally, start the development server from the repository
+root (mise provisions the required tools and dependencies for you):
 
 ~~~~ bash
-pnpm install
-pnpm dev
+mise run docs
 ~~~~
 
 Once the development server is running, you can open your browser and navigate
 to *http://localhost:5173/* to view the docs.
 
 [VitePress]: https://vitepress.dev/
-[Node.js]: https://nodejs.org/
-[pnpm]: https://pnpm.io/
 
 
 VitePress documentation conventions

--- a/examples/actor-lookup-cli/README.md
+++ b/examples/actor-lookup-cli/README.md
@@ -12,6 +12,6 @@ Usage
 -----
 
 ~~~~ sh
-deno task codegen  # At very first time only
+mise run codegen  # At very first time only
 deno run -A ./main.ts @fedify@hollo.social
 ~~~~

--- a/examples/custom-collections/README.md
+++ b/examples/custom-collections/README.md
@@ -20,7 +20,7 @@ The script demonstrates three patterns:
 Run it from this directory:
 
 ~~~~ sh
-deno task codegen  # Only the first time
+mise run codegen  # Only the first time
 deno run -A ./main.ts
 ~~~~
 

--- a/examples/fresh/README.md
+++ b/examples/fresh/README.md
@@ -24,7 +24,7 @@ Running the example
 
     ~~~~ sh
     cd fedify
-    deno task build
+    mise install
     ~~~~
 
 3.  Move to example folder

--- a/examples/rfc-9421-test/README.md
+++ b/examples/rfc-9421-test/README.md
@@ -9,7 +9,7 @@ Prerequisites
 -------------
 
  -  [Deno] installed
- -  Run `mise run install` (or `pnpm install`) from the repo root
+ -  Run `mise install` from the repo root
  -  A public tunnel for testing (e.g., `fedify tunnel`)
 
 [Deno]: https://deno.com/

--- a/mise.toml
+++ b/mise.toml
@@ -1,3 +1,10 @@
+# Require a mise new enough for the [deps] providers and the [hooks.postinstall]
+# table form used below; older versions fail to parse this file.  Environments
+# that intentionally ship an older mise and don't need this tooling (e.g. the
+# Netlify build for the static schema site) opt out by setting
+# MISE_IGNORED_CONFIG_PATHS to this file's path; see schema/netlify.toml.
+min_version = "2026.6.12"
+
 [settings]
 # Required by the [deps] dependency providers below, which are still an
 # experimental mise feature.

--- a/mise.toml
+++ b/mise.toml
@@ -208,7 +208,11 @@ for pkg in ($env.usage_packages | split row " ") {
   }
   deno fmt --check $dir
   deno lint $dir
-  deno check ...(glob $"($dir)/**/*.ts")
+  # Guard against an empty glob: `deno check` with no file arguments would
+  # fall back to type-checking the whole workspace, which is slow and not
+  # what a per-package check intends.
+  let ts_files = ((glob $"($dir)/**/*.ts") ++ (glob $"($dir)/**/*.tsx"))
+  if ($ts_files | is-not-empty) { deno check ...$ts_files }
 }
 '''
 

--- a/mise.toml
+++ b/mise.toml
@@ -123,6 +123,7 @@ env = { CI = "true" } # Prevent pnpm from prompting for confirmation
 shell = "nu -c"
 sources = [
   "packages/*/src/**/*.ts",
+  "packages/*/src/**/*.tsx",
   "packages/*/tsdown.config.ts",
   "packages/*/package.json",
   "packages/*/deno.json",

--- a/mise.toml
+++ b/mise.toml
@@ -53,7 +53,14 @@ run = "deno task -f @fedify/vocab compile"
 [deps.deno-cache]
 auto = true
 depends = ["codegen"]
-sources = ["deno.lock", "deno.json", "packages/*/deno.json"]
+sources = [
+  "deno.lock",
+  "deno.json",
+  "packages/*/deno.json",
+  "examples/*/deno.json",
+  "examples/*/*/deno.json",
+  "test/smoke/harness/deno.json",
+]
 outputs = ["node_modules/.cache/fedify-deno-precache.stamp"]
 run = "deno run --allow-read --allow-env --allow-run --allow-write scripts/install.ts"
 

--- a/mise.toml
+++ b/mise.toml
@@ -111,6 +111,11 @@ run = "deno task -f @fedify/vocab compile"
 [tasks.build]
 description = "Build all packages"
 env = { CI = "true" } # Prevent pnpm from prompting for confirmation
+# Run through Nushell so the single-quoted pnpm filter is parsed consistently on
+# every platform.  With the default shell, Windows `cmd` does not strip the
+# single quotes, so pnpm would receive the literal `'!./examples/**'`, match no
+# projects, and turn the build into a silent no-op.
+shell = "nu -c"
 sources = [
   "packages/*/src/**/*.ts",
   "packages/*/tsdown.config.ts",
@@ -210,11 +215,15 @@ run = "deno test --check --doc --allow-all --unstable-kv --trace-leaks --paralle
 [tasks."test:node"]
 description = "Run the test suite using Node.js"
 depends = ["build"]
+# See the note on `build`: Nushell keeps the single-quoted pnpm filter working
+# on Windows, where `cmd` would otherwise pass it through literally.
+shell = "nu -c"
 run = "pnpm run --recursive --parallel --filter '!{docs}' --config.enable-pre-post-scripts=false test"
 
 [tasks."test:bun"]
 description = "Run the test suite using Bun"
 depends = ["build"]
+shell = "nu -c"
 run = "pnpm run --recursive --parallel --filter '!{docs}' --config.enable-pre-post-scripts=false test:bun"
 
 [tasks.test]

--- a/mise.toml
+++ b/mise.toml
@@ -120,16 +120,12 @@ if (which git | is-not-empty) {
 # Code generation
 [tasks.codegen]
 description = "Generate ActivityPub vocabulary types from YAML definitions"
-sources = [
-  "packages/vocab/src/**/*.yaml",
-  "packages/vocab/scripts/codegen.ts",
-  # The generator itself: changes to @fedify/vocab-tools (its code or its
-  # schema) change the generated vocab.ts, so track its sources too.
-  "packages/vocab-tools/src/**/*.ts",
-  "packages/vocab-tools/src/**/*.yaml",
-]
-outputs = ["packages/vocab/src/vocab.ts"]
-run = "deno task -f @fedify/vocab compile"
+# Delegate to the [deps.codegen] provider above rather than repeating its
+# sources/outputs here, so the freshness inputs live in one place.  --force
+# re-runs the provider even when mise considers it fresh; the codegen script
+# itself still self-skips when vocab.ts is already up to date, so an explicit
+# `mise run codegen` stays fast.
+run = "mise deps --force codegen"
 
 # Build
 #

--- a/mise.toml
+++ b/mise.toml
@@ -1,8 +1,17 @@
+[settings]
+# Required by the [deps] dependency providers below, which are still an
+# experimental mise feature.
+experimental = true
+
 [tools]
 bun = "1.2.22"
 deno = "2.8.3"
 node = "22"
 pnpm = "10.28.0"
+# Nushell powers the cross-platform orchestration tasks (prepare-each,
+# check-each, test-each, check-versions) so they run identically on Windows,
+# macOS, and Linux without Bash.
+"aqua:nushell/nushell" = "0.113.1"
 
 [tools."github:dahlia/hongdown"]
 version = "0.5.0"
@@ -11,30 +20,109 @@ version = "0.5.0"
 linux-x64 = "hongdown-*-x86_64-unknown-linux-musl.tar.bz2"
 linux-arm64 = "hongdown-*-aarch64-unknown-linux-musl.tar.bz2"
 
-# Installation and setup
-[tasks.install]
-description = "Install all dependencies and set up the development environment"
-run = "deno task install"
+# Dependency providers <https://mise.jdx.dev/dev-tools/deps.html>
+#
+# These replace the old hand-rolled `install` task.  With `auto = true` mise
+# runs them automatically before any `mise run`/`mise x`, and the
+# `sources`/`outputs` make each one a no-op once it is up to date.  The
+# `postinstall` hook below also runs them, so a fresh checkout is fully set up
+# by a single `mise install`.
 
+# Generate the ActivityPub vocabulary types from their YAML definitions.
+[deps.codegen]
+auto = true
+sources = [
+  "packages/vocab/src/**/*.yaml",
+  "packages/vocab/scripts/codegen.ts",
+  # The generator itself: changes to @fedify/vocab-tools (its code or its
+  # schema) change the generated vocab.ts, so track its sources too.
+  "packages/vocab-tools/src/**/*.ts",
+  "packages/vocab-tools/src/**/*.yaml",
+]
+outputs = ["packages/vocab/src/vocab.ts"]
+run = "deno task -f @fedify/vocab compile"
+
+# Pre-cache every workspace member's Deno exports (writes a freshness stamp).
+[deps.deno-cache]
+auto = true
+depends = ["codegen"]
+sources = ["deno.lock", "deno.json", "packages/*/deno.json"]
+outputs = ["node_modules/.cache/fedify-deno-precache.stamp"]
+run = "deno run --allow-read --allow-env --allow-run --allow-write scripts/install.ts"
+
+# Install Node.js dependencies with pnpm (built-in provider).  pnpm's root
+# `prepare` lifecycle script builds all packages, so this also produces the
+# initial dist/ output.
+[deps.pnpm]
+auto = true
+
+# Hooks <https://mise.jdx.dev/hooks.html>
+#
+# After tools are installed/updated, finish bootstrapping the checkout so that
+# `mise install` alone leaves a fresh clone ready to use:
+#
+#  1. install project dependencies via the deps providers above, and
+#  2. install the Git pre-commit hook, but only when one is not already present
+#     -- this keeps repeat `mise install` runs quiet and never clobbers an
+#     existing hook.  Use `mise run hooks:install` to (re)install it explicitly.
+[hooks.postinstall]
+shell = "nu -c"
+run = '''
+mise deps
+if (git rev-parse --is-inside-work-tree | complete | get exit_code) == 0 {
+  let hook = (git rev-parse --git-path hooks/pre-commit | str trim)
+  if not ($hook | path exists) {
+    print "Installing Git pre-commit hook..."
+    mise generate git-pre-commit --write --task=check
+  }
+}
+'''
+
+# Code generation
 [tasks.codegen]
 description = "Generate ActivityPub vocabulary types from YAML definitions"
-run = "deno task codegen"
+sources = [
+  "packages/vocab/src/**/*.yaml",
+  "packages/vocab/scripts/codegen.ts",
+  # The generator itself: changes to @fedify/vocab-tools (its code or its
+  # schema) change the generated vocab.ts, so track its sources too.
+  "packages/vocab-tools/src/**/*.ts",
+  "packages/vocab-tools/src/**/*.yaml",
+]
+outputs = ["packages/vocab/src/vocab.ts"]
+run = "deno task -f @fedify/vocab compile"
 
-[tasks.prepare]
-description = "Prepare the development environment (codegen, install, build fixtures)"
+# Build
+#
+# No explicit `depends = ["codegen"]`: the auto [deps.codegen] provider already
+# ensures vocab.ts exists before any task, and @fedify/vocab's own `build:self`
+# regenerates it.  Depending on `codegen` here would defeat the
+# `sources`/`outputs` cache below, because the codegen script self-skips without
+# rewriting its output, so mise always considers that task non-fresh and would
+# re-run this build with it.  The outputs glob ends in `/**/*` (not a bare
+# `/**`) so mise's freshness check matches the emitted files.
+[tasks.build]
+description = "Build all packages"
 env = { CI = "true" } # Prevent pnpm from prompting for confirmation
-depends = ["install"]
-run = "pnpm -r run build:self"
+sources = [
+  "packages/*/src/**/*.ts",
+  "packages/*/tsdown.config.ts",
+  "packages/*/package.json",
+  "packages/*/deno.json",
+]
+outputs = ["packages/*/dist/**/*"]
+run = "pnpm --recursive --filter='!./examples/**' run build:self"
 
 [tasks.prepare-each]
-description = "Prepare specific package(s)"
+description = "Build specific package(s)"
 usage = 'arg "<packages>" help="Package name(s) (without @fedify/ prefix)" var=#true var_min=1'
 env = { CI = "true" }
+shell = "nu -c"
 run = '''
-for PACKAGE in ${usage_packages}; do
-  echo "Preparing package: $PACKAGE"
-  pnpm --filter "@fedify/$PACKAGE" build
-done
+for pkg in ($env.usage_packages | split row " ") {
+  print $"Preparing package: ($pkg)"
+  pnpm --filter $"@fedify/($pkg)" build
+}
 '''
 
 # Code quality
@@ -46,24 +134,22 @@ depends = [
   "check:types",
   "check:md",
   "check-versions",
-  "check:manifest:workspace-protocol",
+  "check:workspace-protocol",
   "check:fixture-usage",
 ]
 
 [tasks."check:fmt"]
 description = "Check code formatting"
-wait_for = ["install"]
 run = "deno fmt --check"
 
 [tasks."check:lint"]
 description = "Check code linting"
-wait_for = ["install"]
 run = "deno lint"
 
 [tasks."check:types"]
 description = "Check TypeScript types"
-wait_for = ["install"]
-run = "deno check $(deno eval 'import m from \"./deno.json\" with { type: \"json\" }; for (let p of m.workspace) console.log(p)')"
+depends = ["codegen"]
+run = "deno run --allow-read --allow-env --allow-run --allow-sys scripts/check_types.ts"
 
 [tasks."check:md"]
 description = "Check Markdown formatting"
@@ -72,92 +158,56 @@ run = "hongdown --check"
 [tasks.check-versions]
 description = "Check that all package versions are consistent across the monorepo"
 usage = 'flag "--fix" help="Automatically fix version mismatches"'
-wait_for = ["install"]
+shell = "nu -c"
 run = '''
-if [ "${usage_fix}" = "true" ]; then
-  deno run --allow-read --allow-write scripts/check_versions.ts --fix
-else
-  deno task check-versions
-fi
+let args = if (($env.usage_fix? | default "false") == "true") { ["--fix"] } else { [] }
+deno run --allow-read --allow-write scripts/check_versions.ts ...$args
 '''
 
 [tasks."check:fixture-usage"]
 description = "Ensure @fedify/fixture is only used in **/*.test.ts files"
-wait_for = ["install"]
 run = "deno run --allow-read scripts/check_fixture_usage.ts"
 
-[tasks."check:manifest:workspace-protocol"]
+[tasks."check:workspace-protocol"]
 description = "Check for invalid workspace: specifiers without version (*, ^, ~)"
-run = '''
-found=0
-for file in $(find . -name 'package.json' -not -path '*/node_modules/*'); do
-  invalid=$(jq -r '
-    [
-      (.dependencies // {}),
-      (.devDependencies // {}),
-      (.peerDependencies // {}),
-      (.optionalDependencies // {})
-    ]
-    | add
-    | to_entries[]
-    | select(.value == "workspace:")
-    | "  \(.key)"
-  ' "$file" 2>/dev/null)
-  if [ -n "$invalid" ]; then
-    if [ "$found" -eq 0 ]; then
-      echo "Error: Found invalid workspace: specifiers (missing *, ^, or ~):"
-      echo ""
-    fi
-    echo "$file:"
-    echo "$invalid"
-    found=1
-  fi
-done
-
-if [ "$found" -eq 1 ]; then
-  echo ""
-  echo "Valid formats: workspace:*, workspace:^, workspace:~"
-  exit 1
-fi
-echo "All workspace: specifiers are valid"
-'''
+run = "deno run --allow-read scripts/check_workspace_protocol.ts"
 
 [tasks.fmt]
 description = "Format the codebase"
-run = "deno fmt && hongdown --write"
+run = ["deno fmt", "hongdown --write"]
 
 [tasks.check-each]
 description = "Check code quality for specific package(s)"
 usage = 'arg "<packages>" help="Package name(s) (without @fedify/ prefix)" var=#true var_min=1'
+shell = "nu -c"
 run = '''
-for PACKAGE in ${usage_packages}; do
-  echo "Checking package: $PACKAGE"
-  PACKAGE_DIR="packages/$PACKAGE"
-  if [ ! -d "$PACKAGE_DIR" ]; then
-    echo "Error: Package directory $PACKAGE_DIR not found"
+for pkg in ($env.usage_packages | split row " ") {
+  print $"Checking package: ($pkg)"
+  let dir = $"packages/($pkg)"
+  if not ($dir | path exists) {
+    print --stderr $"Error: Package directory ($dir) not found"
     exit 1
-  fi
-
-  deno fmt --check "$PACKAGE_DIR"
-  deno lint "$PACKAGE_DIR"
-  deno check "$PACKAGE_DIR"/**/*.ts
-done
+  }
+  deno fmt --check $dir
+  deno lint $dir
+  deno check ...(glob $"($dir)/**/*.ts")
+}
 '''
 
 # Testing
 [tasks."test:deno"]
 description = "Run the test suite using Deno"
-depends = ["prepare"]
+depends = ["build"]
 run = "deno test --check --doc --allow-all --unstable-kv --trace-leaks --parallel"
 
 [tasks."test:node"]
 description = "Run the test suite using Node.js"
-depends = ["prepare"]
+depends = ["build"]
 run = "pnpm run --recursive --parallel --filter '!{docs}' --config.enable-pre-post-scripts=false test"
 
 [tasks."test:bun"]
 description = "Run the test suite using Bun"
-depends = ["prepare"]
+depends = ["build"]
 run = "pnpm run --recursive --parallel --filter '!{docs}' --config.enable-pre-post-scripts=false test:bun"
 
 [tasks.test]
@@ -167,24 +217,25 @@ depends = ["check", "test:deno", "test:node", "test:bun"]
 [tasks.test-each]
 description = "Run tests for a specific package across all environments"
 usage = 'arg "<packages>" help="Package name(s) (without @fedify/ prefix)" var=#true var_min=1'
+shell = "nu -c"
 run = '''
-mise run prepare-each ${usage_packages}
-mise run check-each ${usage_packages}
-
-for PACKAGE in ${usage_packages}; do
-  echo "Running tests for package: $PACKAGE"
-  deno task --filter "@fedify/$PACKAGE" test
-  pnpm --filter "@fedify/$PACKAGE" test
-  pnpm --filter "@fedify/$PACKAGE" test:bun
-done
+let pkgs = ($env.usage_packages | split row " ")
+mise run prepare-each ...$pkgs
+mise run check-each ...$pkgs
+for pkg in $pkgs {
+  print $"Running tests for package: ($pkg)"
+  deno task --filter $"@fedify/($pkg)" test
+  pnpm --filter $"@fedify/($pkg)" test
+  pnpm --filter $"@fedify/($pkg)" test:bun
+}
 '''
 
 [tasks."test:examples"]
 description = "Run tests for all example projects"
-# `prepare` builds @fedify/lint's dist/oxlint.js loader (via build:self) and,
-# through its `install` dependency, provisions the prebuilt oxlint native
-# binary into node_modules — both are needed by the lint/oxlint example.
-depends = ["prepare"]
+# `build` produces @fedify/lint's dist/oxlint.js loader and provisions the
+# prebuilt oxlint native binary into node_modules (via the pnpm deps provider) —
+# both are needed by the lint/oxlint example.
+depends = ["build"]
 run = "deno run -A examples/test-examples/mod.ts"
 
 [tasks."test:monitoring"]
@@ -193,18 +244,18 @@ run = "deno run -A examples/monitoring/validate.ts"
 
 [tasks."test:init"]
 description = "Run tests for the init package"
+depends = ["build"]
 run = "deno task -f @fedify/init test-init"
-depends = ["prepare"]
 
 # Snapshot updates
 # Note: vocab uses @std/testing/snapshot which only works on Deno
 # vocab-tools has separate snapshots for each runtime
 [tasks."test:deno:update_snapshots"]
 description = "Update test snapshots for Deno"
-run = '''
-deno task -f @fedify/vocab-tools test -- --update
-deno task -f @fedify/vocab test -- --update
-'''
+run = [
+  "deno task -f @fedify/vocab-tools test -- --update",
+  "deno task -f @fedify/vocab test -- --update",
+]
 
 [tasks."test:node:update_snapshots"]
 description = "Update test snapshots for Node.js"
@@ -243,11 +294,11 @@ run = "deno task -f @fedify/fedify bench"
 # CLI and utilities
 [tasks.cli]
 description = "Run the Fedify CLI tool"
-run = "deno task cli"
+run = "deno task -f @fedify/cli run"
 
 [tasks.tunnel]
 description = "Tunnel port with the Fedify CLI"
-run = "deno task cli tunnel"
+run = "deno task -f @fedify/cli run tunnel"
 
 [tasks.update-init-deps]
 description = "Update third-party dependency versions in fedify init templates"

--- a/mise.toml
+++ b/mise.toml
@@ -59,9 +59,13 @@ run = "deno run --allow-read --allow-env --allow-run --allow-write scripts/insta
 
 # Install Node.js dependencies with pnpm (built-in provider).  pnpm's root
 # `prepare` lifecycle script builds all packages, so this also produces the
-# initial dist/ output.
+# initial dist/ output.  Depend on `deno-cache` (which depends on `codegen`) so
+# the providers run serially (codegen, then the Deno pre-cache, then pnpm
+# install) instead of pnpm racing codegen over node_modules under Deno's
+# `nodeModulesDir: auto`.
 [deps.pnpm]
 auto = true
+depends = ["deno-cache"]
 
 # Hooks <https://mise.jdx.dev/hooks.html>
 #

--- a/mise.toml
+++ b/mise.toml
@@ -122,8 +122,10 @@ env = { CI = "true" } # Prevent pnpm from prompting for confirmation
 # projects, and turn the build into a silent no-op.
 shell = "nu -c"
 sources = [
-  "packages/*/src/**/*.ts",
-  "packages/*/src/**/*.tsx",
+  # Everything under src/, not just *.ts(x): some packages copy non-TypeScript
+  # assets into dist (e.g. @fedify/init's templates and @fedify/fixture's JSON
+  # fixtures), and those are real build inputs too.
+  "packages/*/src/**/*",
   "packages/*/tsdown.config.ts",
   "packages/*/package.json",
   "packages/*/deno.json",

--- a/mise.toml
+++ b/mise.toml
@@ -139,7 +139,7 @@ usage = 'arg "<packages>" help="Package name(s) (without @fedify/ prefix)" var=#
 env = { CI = "true" }
 shell = "nu -c"
 run = '''
-for pkg in ($env.usage_packages | split row " ") {
+for pkg in ($env.usage_packages | split row " " | where ($it | is-not-empty)) {
   print $"Preparing package: ($pkg)"
   pnpm --filter $"@fedify/($pkg)" build
 }
@@ -201,7 +201,7 @@ description = "Check code quality for specific package(s)"
 usage = 'arg "<packages>" help="Package name(s) (without @fedify/ prefix)" var=#true var_min=1'
 shell = "nu -c"
 run = '''
-for pkg in ($env.usage_packages | split row " ") {
+for pkg in ($env.usage_packages | split row " " | where ($it | is-not-empty)) {
   print $"Checking package: ($pkg)"
   let dir = $"packages/($pkg)"
   if not ($dir | path exists) {
@@ -247,7 +247,7 @@ description = "Run tests for a specific package across all environments"
 usage = 'arg "<packages>" help="Package name(s) (without @fedify/ prefix)" var=#true var_min=1'
 shell = "nu -c"
 run = '''
-let pkgs = ($env.usage_packages | split row " ")
+let pkgs = ($env.usage_packages | split row " " | where ($it | is-not-empty))
 mise run prepare-each ...$pkgs
 mise run check-each ...$pkgs
 for pkg in $pkgs {

--- a/mise.toml
+++ b/mise.toml
@@ -57,15 +57,31 @@ sources = ["deno.lock", "deno.json", "packages/*/deno.json"]
 outputs = ["node_modules/.cache/fedify-deno-precache.stamp"]
 run = "deno run --allow-read --allow-env --allow-run --allow-write scripts/install.ts"
 
-# Install Node.js dependencies with pnpm (built-in provider).  pnpm's root
-# `prepare` lifecycle script builds all packages, so this also produces the
-# initial dist/ output.  Depend on `deno-cache` (which depends on `codegen`) so
-# the providers run serially (codegen, then the Deno pre-cache, then pnpm
-# install) instead of pnpm racing codegen over node_modules under Deno's
-# `nodeModulesDir: auto`.
-[deps.pnpm]
+# Install Node.js dependencies with pnpm.  pnpm's root `prepare` lifecycle
+# script builds all packages, so this also produces the initial dist/ output.
+# Depend on `deno-cache` (which depends on `codegen`) so the providers run
+# serially (codegen, then the Deno pre-cache, then pnpm install) instead of pnpm
+# racing codegen over node_modules under Deno's `nodeModulesDir: auto`.
+#
+# This is a custom provider (not named `pnpm`, which is a reserved built-in
+# provider whose freshness only watches the root package.json and lockfile) so
+# its freshness tracks every workspace manifest.  Otherwise a change to a
+# `packages/*/package.json` or to `pnpm-workspace.yaml` (e.g. before the lockfile
+# is regenerated) would be missed and `mise deps` would wrongly skip the install.
+[deps.pnpm-install]
 auto = true
 depends = ["deno-cache"]
+sources = [
+  "package.json",
+  "pnpm-workspace.yaml",
+  "pnpm-lock.yaml",
+  "packages/*/package.json",
+  "docs/package.json",
+  "examples/*/package.json",
+  "examples/*/*/package.json",
+]
+outputs = ["node_modules/.modules.yaml"]
+run = "pnpm install"
 
 # Hooks <https://mise.jdx.dev/hooks.html>
 #

--- a/mise.toml
+++ b/mise.toml
@@ -39,12 +39,16 @@ linux-arm64 = "hongdown-*-aarch64-unknown-linux-musl.tar.bz2"
 [deps.codegen]
 auto = true
 sources = [
+  # loadSchemaFiles() matches /\.ya?ml$/i, so track both extensions: a schema
+  # added or renamed with the .yml spelling must still invalidate this cache.
   "packages/vocab/src/**/*.yaml",
+  "packages/vocab/src/**/*.yml",
   "packages/vocab/scripts/codegen.ts",
   # The generator itself: changes to @fedify/vocab-tools (its code or its
   # schema) change the generated vocab.ts, so track its sources too.
   "packages/vocab-tools/src/**/*.ts",
   "packages/vocab-tools/src/**/*.yaml",
+  "packages/vocab-tools/src/**/*.yml",
 ]
 outputs = ["packages/vocab/src/vocab.ts"]
 run = "deno task -f @fedify/vocab compile"

--- a/mise.toml
+++ b/mise.toml
@@ -76,11 +76,16 @@ auto = true
 shell = "nu -c"
 run = '''
 mise deps
-if (git rev-parse --is-inside-work-tree | complete | get exit_code) == 0 {
-  let hook = (git rev-parse --git-path hooks/pre-commit | str trim)
-  if not ($hook | path exists) {
-    print "Installing Git pre-commit hook..."
-    mise generate git-pre-commit --write --task=check
+# Only touch the Git hook when git is actually available; in minimal
+# environments (e.g. some containers) git may be missing, and invoking it
+# unguarded would fail the whole postinstall hook.
+if (which git | is-not-empty) {
+  if (git rev-parse --is-inside-work-tree | complete | get exit_code) == 0 {
+    let hook = (git rev-parse --git-path hooks/pre-commit | str trim)
+    if not ($hook | path exists) {
+      print "Installing Git pre-commit hook..."
+      mise generate git-pre-commit --write --task=check
+    }
   }
 }
 '''

--- a/packages/fedify/deno.json
+++ b/packages/fedify/deno.json
@@ -88,12 +88,7 @@
       ]
     },
     "pnpm:install": "pnpm install --silent",
-    "pnpm:build": {
-      "command": "pnpm exec tsdown",
-      "dependencies": [
-        "pnpm:build-vocab"
-      ]
-    },
+    "pnpm:build": "pnpm --filter @fedify/fedify... run build:self",
     "test:node": {
       "command": "cd dist/ && node --test",
       "dependencies": [

--- a/packages/fixture/README.md
+++ b/packages/fixture/README.md
@@ -40,8 +40,8 @@ dependency to the package that needs it:
 For Deno, the `imports` entry resolves to the in-tree source through the
 workspace at the repository root, so you don't need to add it to *deno.json*.
 For Node.js and Bun, pnpm links the local package by virtue of the `workspace:`
-specifier; remember to run `mise run install` (or `pnpm install`) at the
-repository root after the edit.
+specifier; remember to run `mise install` at the repository root after the
+edit.
 
 
 Usage
@@ -162,7 +162,7 @@ test("lookupObject() resolves a fixture", async () => {
     [`src/fixtures/<host>/<path>.json`](src/fixtures/).  The path must mirror
     the URL exactly: e.g. `https://w3id.org/security/v1` becomes
     *src/fixtures/w3id.org/security/v1.json*.
-2.  Run `pnpm --filter @fedify/fixture build` once so that the fixture is
+2.  Run `mise run prepare-each fixture` once so that the fixture is
     copied into *dist/fixtures/* — Node.js and Bun consumers import the file
     through the `./fixtures/*` subpath export, which points at the *dist/*
     copy.  (The `pretest` and `prepack` scripts do this automatically.)

--- a/packages/init/README.md
+++ b/packages/init/README.md
@@ -72,22 +72,16 @@ scaffolding logic.  It tests the project initialization by running
 `fedify init` across all combinations of supported options on temporary
 directories, verifying that the generated projects are valid.
 
-To run the test using Deno:
+To run the test, use the mise task from the repository root:
 
 ~~~~ sh
-deno task test-init
-~~~~
-
-Or using pnpm:
-
-~~~~ sh
-pnpm test-init
+mise run test:init
 ~~~~
 
 You can also filter specific options to test a subset of combinations:
 
 ~~~~ sh
-deno task test-init -w hono -p deno
+mise run test:init -w hono -p deno
 ~~~~
 
 Use `--no-dry-run` to test with actual file creation and dependency

--- a/packages/lint/src/lib/oxlint.ts
+++ b/packages/lint/src/lib/oxlint.ts
@@ -68,7 +68,7 @@ export function warnOxlintSkipped(): void {
   }
   console.warn(
     `Skipping oxlint tests — missing: ${missing.join(", ")}.\n` +
-      "To enable them, run `mise run install && mise run prepare-each lint` " +
+      "To enable them, run `mise install && mise run prepare-each lint` " +
       "from the repository root so both the loader and the oxlint binary " +
       "are available. Prefer `mise run test` (full suite) or " +
       "`mise run test-each lint` (this package) to run tests — those tasks " +

--- a/packages/vocab/scripts/codegen.ts
+++ b/packages/vocab/scripts/codegen.ts
@@ -43,7 +43,8 @@ async function isUpToDate(
 ): Promise<boolean> {
   try {
     const [sourceMtime, generatedStat] = await Promise.all([
-      getLatestMtimeUnder(schemaDir, [".yaml"]),
+      // Match loadSchemaFiles()'s /\.ya?ml$/i: a .yml schema is a real input.
+      getLatestMtimeUnder(schemaDir, [".yaml", ".yml"]),
       generatedPath.stat(),
     ]);
     if (!generatedStat?.mtime) return false;
@@ -136,7 +137,7 @@ async function codegen() {
     const generatorMtime = Math.max(
       await getLatestMtimeUnder(
         packageDir.parent()!.join("vocab-tools", "src"),
-        [".ts", ".yaml"],
+        [".ts", ".yaml", ".yml"],
       ),
       await getLatestMtimeUnder(scriptsDir, [".ts"]),
     );

--- a/packages/vocab/scripts/codegen.ts
+++ b/packages/vocab/scripts/codegen.ts
@@ -7,23 +7,6 @@ const LOCK_RETRY_MS = 100;
 const LOCK_TIMEOUT_MS = 60 * 1000; // 1 minute
 
 /**
- * Get the latest mtime from all YAML files in the schema directory.
- */
-async function getLatestSourceMtime(schemaDir: Path): Promise<number> {
-  let latestMtime = 0;
-  for await (const entry of schemaDir.readDir()) {
-    if (!entry.isFile) continue;
-    if (!entry.name.match(/\.ya?ml$/i)) continue;
-    if (entry.name === "schema.yaml") continue;
-    const fileStat = await schemaDir.join(entry.name).stat();
-    if (fileStat?.mtime && fileStat.mtime.getTime() > latestMtime) {
-      latestMtime = fileStat.mtime.getTime();
-    }
-  }
-  return latestMtime;
-}
-
-/**
  * Get the latest mtime among files under a directory tree (recursively),
  * limited to the given file extensions.  Returns 0 if the directory is absent.
  */
@@ -60,7 +43,7 @@ async function isUpToDate(
 ): Promise<boolean> {
   try {
     const [sourceMtime, generatedStat] = await Promise.all([
-      getLatestSourceMtime(schemaDir),
+      getLatestMtimeUnder(schemaDir, [".yaml"]),
       generatedPath.stat(),
     ]);
     if (!generatedStat?.mtime) return false;

--- a/packages/vocab/scripts/codegen.ts
+++ b/packages/vocab/scripts/codegen.ts
@@ -143,19 +143,21 @@ async function codegen() {
   const realPath = schemaDir.join("vocab.ts");
   const lockPath = packageDir.join(".vocab-codegen.lock");
 
-  // The generated vocab.ts depends not only on the YAML schemas but on the
-  // generator itself: @fedify/vocab-tools and this codegen script.
-  const generatorMtime = Math.max(
-    await getLatestMtimeUnder(
-      packageDir.parent()!.join("vocab-tools", "src"),
-      [".ts", ".yaml"],
-    ),
-    await getLatestMtimeUnder(scriptsDir, [".ts"]),
-  );
-
   // Acquire lock to prevent concurrent codegen
   const lock = await acquireLock(lockPath);
   try {
+    // The generated vocab.ts depends not only on the YAML schemas but on the
+    // generator itself: @fedify/vocab-tools and this codegen script.  Sample
+    // its mtime inside the lock so that a generator edit made while we were
+    // waiting for the lock is not missed by the freshness check below.
+    const generatorMtime = Math.max(
+      await getLatestMtimeUnder(
+        packageDir.parent()!.join("vocab-tools", "src"),
+        [".ts", ".yaml"],
+      ),
+      await getLatestMtimeUnder(scriptsDir, [".ts"]),
+    );
+
     // Check if regeneration is needed (after acquiring lock)
     if (await isUpToDate(schemaDir, realPath, generatorMtime)) {
       $.log("vocab.ts is up to date, skipping codegen");

--- a/packages/vocab/scripts/codegen.ts
+++ b/packages/vocab/scripts/codegen.ts
@@ -24,11 +24,39 @@ async function getLatestSourceMtime(schemaDir: Path): Promise<number> {
 }
 
 /**
- * Check if the generated file is up to date compared to source files.
+ * Get the latest mtime among files under a directory tree (recursively),
+ * limited to the given file extensions.  Returns 0 if the directory is absent.
+ */
+async function getLatestMtimeUnder(
+  dir: Path,
+  exts: readonly string[],
+): Promise<number> {
+  if (!(await dir.exists())) return 0;
+  let latestMtime = 0;
+  for await (const entry of Deno.readDir(dir.toString())) {
+    const child = dir.join(entry.name);
+    if (entry.isDirectory) {
+      const mtime = await getLatestMtimeUnder(child, exts);
+      if (mtime > latestMtime) latestMtime = mtime;
+    } else if (entry.isFile && exts.some((ext) => entry.name.endsWith(ext))) {
+      const fileStat = await child.stat();
+      const mtime = fileStat?.mtime?.getTime() ?? 0;
+      if (mtime > latestMtime) latestMtime = mtime;
+    }
+  }
+  return latestMtime;
+}
+
+/**
+ * Check if the generated file is up to date compared to its source files,
+ * including the generator itself (`@fedify/vocab-tools` and this codegen
+ * script): changing the generator changes the generated output, so the
+ * generated file must be at least as new as those too.
  */
 async function isUpToDate(
   schemaDir: Path,
   generatedPath: Path,
+  generatorMtime: number,
 ): Promise<boolean> {
   try {
     const [sourceMtime, generatedStat] = await Promise.all([
@@ -36,7 +64,8 @@ async function isUpToDate(
       generatedPath.stat(),
     ]);
     if (!generatedStat?.mtime) return false;
-    return generatedStat.mtime.getTime() >= sourceMtime;
+    return generatedStat.mtime.getTime() >=
+      Math.max(sourceMtime, generatorMtime);
   } catch {
     // If generated file doesn't exist, it's not up to date
     return false;
@@ -114,11 +143,21 @@ async function codegen() {
   const realPath = schemaDir.join("vocab.ts");
   const lockPath = packageDir.join(".vocab-codegen.lock");
 
+  // The generated vocab.ts depends not only on the YAML schemas but on the
+  // generator itself: @fedify/vocab-tools and this codegen script.
+  const generatorMtime = Math.max(
+    await getLatestMtimeUnder(
+      packageDir.parent()!.join("vocab-tools", "src"),
+      [".ts", ".yaml"],
+    ),
+    await getLatestMtimeUnder(scriptsDir, [".ts"]),
+  );
+
   // Acquire lock to prevent concurrent codegen
   const lock = await acquireLock(lockPath);
   try {
     // Check if regeneration is needed (after acquiring lock)
-    if (await isUpToDate(schemaDir, realPath)) {
+    if (await isUpToDate(schemaDir, realPath, generatorMtime)) {
       $.log("vocab.ts is up to date, skipping codegen");
       return;
     }

--- a/schema/netlify.toml
+++ b/schema/netlify.toml
@@ -9,6 +9,15 @@
 [build]
   publish = "."
 
+[build.environment]
+  # This site serves static JSON Schema files and needs no build tooling, but
+  # Netlify's build image bundles an older mise that reads the repository's root
+  # mise.toml during dependency installation and fails to parse its newer
+  # `[deps]`/`[hooks]` features.  Tell that mise to ignore the root config
+  # entirely so the install step is a no-op.  Netlify checks the repo out at
+  # /opt/build/repo, so the root config lives at /opt/build/repo/mise.toml.
+  MISE_IGNORED_CONFIG_PATHS = "/opt/build/repo/mise.toml"
+
 [[headers]]
   for = "/bench/*"
   [headers.values]

--- a/scripts/check_types.ts
+++ b/scripts/check_types.ts
@@ -1,0 +1,12 @@
+/**
+ * Type-checks every workspace member listed in the root *deno.json*.
+ *
+ * It replaces the previous `deno check $(deno eval ...)` shell substitution,
+ * which does not work under Windows `cmd`/`pwsh`, with a portable Deno script
+ * that reads the workspace list directly and forwards it to `deno check`.
+ */
+import $ from "@david/dax";
+import deno from "../deno.json" with { type: "json" };
+
+const result = await $`deno check ${deno.workspace}`.noThrow();
+Deno.exit(result.code);

--- a/scripts/check_versions.ts
+++ b/scripts/check_versions.ts
@@ -4,7 +4,7 @@ import workspaceMetadata from "../deno.json" with { type: "json" };
 import fedifyMetadata from "../packages/fedify/deno.json" with { type: "json" };
 
 if (Deno.args.includes("--help") || Deno.args.includes("-h")) {
-  console.log("Usage: deno task check-versions [--help|-h] [--fix|-f]");
+  console.log("Usage: mise run check-versions [--help|-h] [--fix|-f]");
   console.log("Checks that all workspace members have the same version.");
   console.log(
     "If --fix or -f is provided, it will attempt to fix version mismatches.",

--- a/scripts/check_workspace_protocol.ts
+++ b/scripts/check_workspace_protocol.ts
@@ -33,7 +33,15 @@ for await (
 ) {
   let manifest: Record<string, unknown>;
   try {
-    manifest = JSON.parse(await Deno.readTextFile(entry.path));
+    const parsed = JSON.parse(await Deno.readTextFile(entry.path));
+    // A package.json could be `null`, a string, a number, or an array; skip
+    // anything that is not a plain object so the field lookups below are safe.
+    if (
+      parsed === null || typeof parsed !== "object" || Array.isArray(parsed)
+    ) {
+      continue;
+    }
+    manifest = parsed as Record<string, unknown>;
   } catch {
     continue;
   }

--- a/scripts/check_workspace_protocol.ts
+++ b/scripts/check_workspace_protocol.ts
@@ -52,7 +52,10 @@ for await (
   const invalid: string[] = [];
   for (const field of DEPENDENCY_FIELDS) {
     const deps = manifest[field];
-    if (deps == null || typeof deps !== "object") continue;
+    // typeof [] is "object", so exclude arrays explicitly before iterating.
+    if (deps == null || typeof deps !== "object" || Array.isArray(deps)) {
+      continue;
+    }
     for (
       const [name, spec] of Object.entries(deps as Record<string, unknown>)
     ) {

--- a/scripts/check_workspace_protocol.ts
+++ b/scripts/check_workspace_protocol.ts
@@ -1,0 +1,68 @@
+/**
+ * This script flags `workspace:` dependency specifiers that omit a version
+ * range marker (`*`, `^`, or `~`).  A bare `workspace:` is invalid for
+ * publishing because pnpm cannot rewrite it to a concrete version on `pnpm
+ * pack`/`publish`, so every workspace dependency must use `workspace:*`,
+ * `workspace:^`, or `workspace:~`.
+ *
+ * It replaces the previous Bash + `find` + `jq` implementation so the check
+ * runs identically on Windows, macOS, and Linux without external tools.
+ */
+import { walk } from "@std/fs/walk";
+import { dirname, fromFileUrl, relative, resolve, SEPARATOR } from "@std/path";
+
+const DEPENDENCY_FIELDS = [
+  "dependencies",
+  "devDependencies",
+  "peerDependencies",
+  "optionalDependencies",
+] as const;
+
+const projectRoot = resolve(dirname(fromFileUrl(import.meta.url)), "..");
+
+let found = false;
+for await (
+  const entry of walk(projectRoot, {
+    includeDirs: false,
+    match: [new RegExp(`(?:^|${SEPARATOR})package\\.json$`)],
+    skip: [new RegExp(`(?:^|${SEPARATOR})node_modules(?:${SEPARATOR}|$)`)],
+  })
+) {
+  let manifest: Record<string, unknown>;
+  try {
+    manifest = JSON.parse(await Deno.readTextFile(entry.path));
+  } catch {
+    continue;
+  }
+
+  const invalid: string[] = [];
+  for (const field of DEPENDENCY_FIELDS) {
+    const deps = manifest[field];
+    if (deps == null || typeof deps !== "object") continue;
+    for (
+      const [name, spec] of Object.entries(deps as Record<string, unknown>)
+    ) {
+      if (spec === "workspace:") invalid.push(name);
+    }
+  }
+
+  if (invalid.length > 0) {
+    if (!found) {
+      console.error(
+        "Error: Found invalid workspace: specifiers (missing *, ^, or ~):",
+      );
+      console.error("");
+      found = true;
+    }
+    console.error(`${relative(projectRoot, entry.path)}:`);
+    for (const name of invalid) console.error(`  ${name}`);
+  }
+}
+
+if (found) {
+  console.error("");
+  console.error("Valid formats: workspace:*, workspace:^, workspace:~");
+  Deno.exit(1);
+}
+
+console.log("All workspace: specifiers are valid");

--- a/scripts/check_workspace_protocol.ts
+++ b/scripts/check_workspace_protocol.ts
@@ -28,7 +28,10 @@ for await (
     // valid on Windows too, where @std/path's SEPARATOR is a backslash and
     // would corrupt a dynamically built RegExp (e.g. `(?:^|\)package\.json$`).
     match: [/(?:^|[/\\])package\.json$/],
-    skip: [/(?:^|[/\\])node_modules(?:[/\\]|$)/],
+    skip: [
+      /(?:^|[/\\])node_modules(?:[/\\]|$)/,
+      /(?:^|[/\\])\.git(?:[/\\]|$)/,
+    ],
   })
 ) {
   let manifest: Record<string, unknown>;

--- a/scripts/check_workspace_protocol.ts
+++ b/scripts/check_workspace_protocol.ts
@@ -9,7 +9,7 @@
  * runs identically on Windows, macOS, and Linux without external tools.
  */
 import { walk } from "@std/fs/walk";
-import { dirname, fromFileUrl, relative, resolve, SEPARATOR } from "@std/path";
+import { dirname, fromFileUrl, relative, resolve } from "@std/path";
 
 const DEPENDENCY_FIELDS = [
   "dependencies",
@@ -24,8 +24,11 @@ let found = false;
 for await (
   const entry of walk(projectRoot, {
     includeDirs: false,
-    match: [new RegExp(`(?:^|${SEPARATOR})package\\.json$`)],
-    skip: [new RegExp(`(?:^|${SEPARATOR})node_modules(?:${SEPARATOR}|$)`)],
+    // Match the path separator with a character class so these patterns stay
+    // valid on Windows too, where @std/path's SEPARATOR is a backslash and
+    // would corrupt a dynamically built RegExp (e.g. `(?:^|\)package\.json$`).
+    match: [/(?:^|[/\\])package\.json$/],
+    skip: [/(?:^|[/\\])node_modules(?:[/\\]|$)/],
   })
 ) {
   let manifest: Record<string, unknown>;

--- a/scripts/install.ts
+++ b/scripts/install.ts
@@ -20,3 +20,12 @@ for (const member of workspace) {
 }
 
 await $`deno cache ${files}`;
+
+// Write a freshness stamp so the `deno-cache` deps provider in mise.toml can
+// skip re-caching when no deno.json/deno.lock has changed (see `outputs`).
+const stampDir = join(root, "node_modules", ".cache");
+await Deno.mkdir(stampDir, { recursive: true });
+await Deno.writeTextFile(
+  join(stampDir, "fedify-deno-precache.stamp"),
+  new Date().toISOString() + "\n",
+);


### PR DESCRIPTION
The *mise.toml* had grown to duplicate the root *deno.json* orchestration tasks and embedded non-portable Bash (`find` + `jq`, a `deno eval` subshell, and several `for`-loops), so project setup relied on a hand-rolled `install` task and almost nothing was incrementally cached.

Replace that `install` task with mise's native dependency providers for `codegen`, the Deno pre-cache, and pnpm.  They run automatically before tasks and stay fresh via [`sources`]/[`outputs`].  A [`postinstall`] hook then makes a single `mise install` fully bootstrap a checkout, including the Git pre-commit hook when one is not already present.

Move the data-processing checks into cross-platform Deno scripts (*check_workspace_protocol.ts* and *check_types.ts*) and rewrite the per-package loop and flag-conditional tasks in [Nushell], so every task runs on Windows without Bash, `find`, or `jq`.

Add `sources`/`outputs` caching to the `codegen` and `build` tasks.  The `codegen` `sources` also track *@fedify/vocab-tools*, since changes to the generator itself change the generated code.

Trim the root *deno.json* to just the `cli` task, realign the CI setup action and the devcontainer scripts to `mise deps`, and update the contributor docs (*CONTRIBUTING.md*, *AGENTS.md*, and several *README*s) to drive every development workflow through mise instead of pnpm.

[`sources`]: https://mise.jdx.dev/tasks/task-configuration.html#sources
[`outputs`]: https://mise.jdx.dev/tasks/task-configuration.html#outputs
[`postinstall`]: https://mise.jdx.dev/hooks.html#preinstall-postinstall-hook
[Nushell]: https://www.nushell.sh/