### PR TITLE
Ignore invalid language tags in vocab parsing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,16 @@ Version 2.0.22
 
 To be released.
 
+### @fedify/vocab
+
+ -  Fixed Activity Vocabulary parsing so malformed language tags in remote
+    JSON-LD language maps no longer abort parsing with a `RangeError`.  Fedify
+    now ignores only the malformed language-tagged value and continues parsing
+    the rest of the object.  [[#847], [#848]]
+
+[#847]: https://github.com/fedify-dev/fedify/issues/847
+[#848]: https://github.com/fedify-dev/fedify/pull/848
+
 
 Version 2.0.21
 --------------

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -52,6 +52,7 @@ export class Object {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -80,6 +81,14 @@ export class Object {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -9402,6 +9411,8 @@ get urls(): ((URL | Link))[] {
       options,
     );
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _49BipA5dq9eoH8LX8xdsVumveTca_attachment: (Object | Link | PropertyValue | URL)[] = [];
       const _trust_49BipA5dq9eoH8LX8xdsVumveTca_attachment: Set<number> = new Set();
     
@@ -9443,7 +9454,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _49BipA5dq9eoH8LX8xdsVumveTca_attachment.push(decoded);
       
     }
@@ -9496,7 +9510,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo.push(decoded);
       
     }
@@ -9551,7 +9568,10 @@ get urls(): ((URL | Link))[] {
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
       
     }
@@ -9594,7 +9614,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3mhZzGXSpQ431mBSz2kvych22v4e_context.push(decoded);
       
     }
@@ -9619,7 +9642,10 @@ get urls(): ((URL | Link))[] {
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
       
     }
@@ -9681,7 +9707,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _86xFhmgBapoMvYqjbjRuDPayTrS_generator.push(decoded);
       
     }
@@ -9784,7 +9813,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo.push(decoded);
       
     }
@@ -9827,7 +9859,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _31k5MUZJsnsPNg8dQQJieWaXTFnR_location.push(decoded);
       
     }
@@ -9870,7 +9905,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(decoded);
       
     }
@@ -10053,7 +10091,10 @@ get urls(): ((URL | Link))[] {
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _4LqirZspQbFWWQEbFcXAxm7tTDN1_summary.push(decoded);
       
     }
@@ -10096,7 +10137,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _5chuqj6s95p5gg2sk1HntGfarRf_tag.push(decoded);
       
     }
@@ -10158,7 +10202,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2oPEH9MQ3aj8JVwyYuWkqoVwV865_url.push(decoded);
       
     }
@@ -10377,7 +10424,11 @@ get urls(): ((URL | Link))[] {
     }
     instance.#_42rPnotok1ivQ2RNCKNbeFJgx8b8_proof = _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -11473,7 +11524,13 @@ proofs?: (DataIntegrityProof | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -11909,7 +11966,9 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
     if (!(instance instanceof ChatMessage)) {
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
-    const _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl: (URL)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl: (URL)[] = [];
 
     let _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl__array = values[\\"https://www.w3.org/ns/activitystreams#quoteUrl\\"];
     
@@ -11933,7 +11992,11 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
     }
     instance.#_K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl = _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -14930,6 +14993,8 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor: (Application | Group | Organization | Person | Service | URL)[] = [];
       const _trust_2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor: Set<number> = new Set();
     
@@ -14977,7 +15042,10 @@ instruments?: (Object | URL)[];}
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor.push(decoded);
       
     }
@@ -15133,7 +15201,11 @@ instruments?: (Object | URL)[];}
     }
     instance.#_3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument = _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -15622,7 +15694,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -15677,6 +15755,7 @@ export class PropertyValue {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -15705,6 +15784,14 @@ export class PropertyValue {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -16119,7 +16206,9 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
       { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
-    const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
 
     let _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name__array = values[\\"https://www.w3.org/ns/activitystreams#name\\"];
     
@@ -16139,7 +16228,10 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
       
     }
@@ -16164,13 +16256,20 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value.push(decoded);
       
     }
     instance.#_2cSy2magg4iZ7zLaG8U7DiJMoCkx_value = _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -16284,6 +16383,7 @@ export class DidService {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -16312,6 +16412,14 @@ export class DidService {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -16668,7 +16776,9 @@ get endpoints(): (URL)[] {
       { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
-    const _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint: (URL)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint: (URL)[] = [];
 
     let _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint__array = values[\\"https://www.w3.org/ns/did#serviceEndpoint\\"];
     
@@ -16699,7 +16809,11 @@ get endpoints(): (URL)[] {
     }
     instance.#_2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint = _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -17020,7 +17134,13 @@ endpoints?: (URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -17077,6 +17197,7 @@ export class DataIntegrityProof {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -17105,6 +17226,14 @@ export class DataIntegrityProof {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -17832,7 +17961,9 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
-    const _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite: (\\"eddsa-jcs-2022\\")[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite: (\\"eddsa-jcs-2022\\")[] = [];
 
     let _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite__array = values[\\"https://w3id.org/security#cryptosuite\\"];
     
@@ -17927,7 +18058,11 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
     }
     instance.#_3qzP3ukEZoUziK5FEiA1RhU4aqac = _3qzP3ukEZoUziK5FEiA1RhU4aqac;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -18097,6 +18232,7 @@ export class CryptographicKey {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -18125,6 +18261,14 @@ export class CryptographicKey {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -18783,6 +18927,8 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       options,
     );
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner: (Application | Group | Organization | Person | Service | URL)[] = [];
       const _trust_5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner: Set<number> = new Set();
     
@@ -18830,7 +18976,10 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner.push(decoded);
       
     }
@@ -18851,7 +19000,11 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
     }
     instance.#_2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem = _2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -18965,6 +19118,7 @@ export class Multikey {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -18993,6 +19147,14 @@ export class Multikey {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -19658,6 +19820,8 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       options,
     );
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller: (Application | Group | Organization | Person | Service | URL)[] = [];
       const _trust_2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller: Set<number> = new Set();
     
@@ -19705,7 +19869,10 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller.push(decoded);
       
     }
@@ -19726,7 +19893,11 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
     }
     instance.#_4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase = _4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -20120,7 +20291,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -20456,7 +20633,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -20791,7 +20974,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -26303,7 +26492,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
     if (!(instance instanceof Application)) {
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
-    const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
 
     let _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername__array = values[\\"https://www.w3.org/ns/activitystreams#preferredUsername\\"];
     
@@ -26323,7 +26514,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
     }
@@ -26439,7 +26633,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
     }
@@ -26480,7 +26677,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
     }
@@ -26791,7 +26991,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
     }
@@ -26844,7 +27047,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
     }
@@ -26910,7 +27116,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -27729,7 +27939,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -28064,7 +28280,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -28495,7 +28717,9 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
     if (!(instance instanceof Article)) {
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
-    const _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl: (URL)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl: (URL)[] = [];
 
     let _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl__array = values[\\"https://www.w3.org/ns/activitystreams#quoteUrl\\"];
     
@@ -28519,7 +28743,11 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
     }
     instance.#_K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl = _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -29043,7 +29271,9 @@ proofs?: (DataIntegrityProof | URL)[];width?: number | null;height?: number | nu
     if (!(instance instanceof Document)) {
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
-    const _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width: (number)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width: (number)[] = [];
 
     let _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width__array = values[\\"https://www.w3.org/ns/activitystreams#width\\"];
     
@@ -29074,7 +29304,11 @@ proofs?: (DataIntegrityProof | URL)[];width?: number | null;height?: number | nu
     }
     instance.#_2cGKFeFJMmiNpGZFEF75mCwFQsKb_height = _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -29451,7 +29685,13 @@ proofs?: (DataIntegrityProof | URL)[];width?: number | null;height?: number | nu
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -29789,7 +30029,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -30125,7 +30371,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -33935,7 +34187,9 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
     if (!(instance instanceof Collection)) {
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
-    const _XDbmNDuWHmrhqH712zqtecdbv1V_totalItems: (number)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _XDbmNDuWHmrhqH712zqtecdbv1V_totalItems: (number)[] = [];
 
     let _XDbmNDuWHmrhqH712zqtecdbv1V_totalItems__array = values[\\"https://www.w3.org/ns/activitystreams#totalItems\\"];
     
@@ -34078,7 +34332,10 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
       
     }
@@ -34324,7 +34581,11 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
     }
     instance.#_2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf = _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -35767,6 +36028,8 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf: (Collection | URL)[] = [];
       const _trust_2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf: Set<number> = new Set();
     
@@ -35857,7 +36120,11 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
     }
     instance.#_3b8yG8tDNzQFFEnWhCc13G8eHooA_prev = _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -36249,7 +36516,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -36583,7 +36856,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -36915,7 +37194,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -36970,6 +37255,7 @@ export class Endpoints {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -36998,6 +37284,14 @@ export class Endpoints {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -37703,7 +37997,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
       { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
-    const _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl: (URL)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl: (URL)[] = [];
 
     let _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl__array = values[\\"https://www.w3.org/ns/activitystreams#proxyUrl\\"];
     
@@ -37884,7 +38180,11 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
     }
     instance.#_3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox = _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -38356,7 +38656,13 @@ proofs?: (DataIntegrityProof | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -38691,7 +38997,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -39027,7 +39339,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -44539,7 +44857,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
     if (!(instance instanceof Group)) {
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
-    const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
 
     let _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername__array = values[\\"https://www.w3.org/ns/activitystreams#preferredUsername\\"];
     
@@ -44559,7 +44879,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
     }
@@ -44675,7 +44998,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
     }
@@ -44716,7 +45042,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
     }
@@ -45027,7 +45356,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
     }
@@ -45080,7 +45412,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
     }
@@ -45146,7 +45481,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -45681,6 +46020,7 @@ export class Link {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -45709,6 +46049,14 @@ export class Link {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -46921,7 +47269,9 @@ get names(): ((string | LanguageString))[] {
       { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
-    const _pVjLsybKQdmkjuU7MHjiVmNnuj7_href: (URL)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _pVjLsybKQdmkjuU7MHjiVmNnuj7_href: (URL)[] = [];
 
     let _pVjLsybKQdmkjuU7MHjiVmNnuj7_href__array = values[\\"https://www.w3.org/ns/activitystreams#href\\"];
     
@@ -47001,7 +47351,10 @@ get names(): ((string | LanguageString))[] {
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
       
     }
@@ -47089,13 +47442,20 @@ get names(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(decoded);
       
     }
     instance.#_gCVTegXxWWCw6wWRxa1QF65zusg_preview = _gCVTegXxWWCw6wWRxa1QF65zusg_preview;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -47585,7 +47945,13 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -47922,7 +48288,13 @@ proofs?: (DataIntegrityProof | URL)[];width?: number | null;height?: number | nu
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -48261,7 +48633,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -48595,7 +48973,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -48929,7 +49313,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -49263,7 +49653,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -49597,7 +49993,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -49929,7 +50331,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -50227,7 +50635,13 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -50562,7 +50976,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -50995,7 +51415,9 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
     if (!(instance instanceof Note)) {
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
-    const _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl: (URL)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl: (URL)[] = [];
 
     let _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl__array = values[\\"https://www.w3.org/ns/activitystreams#quoteUrl\\"];
     
@@ -51019,7 +51441,11 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
     }
     instance.#_K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl = _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -51683,6 +52109,8 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items: (Object | Link | URL)[] = [];
       const _trust_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items: Set<number> = new Set();
     
@@ -51720,13 +52148,20 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
       
     }
     instance.#_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items = _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -52469,6 +52904,8 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items: (Object | Link | URL)[] = [];
       const _trust_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items: Set<number> = new Set();
     
@@ -52506,7 +52943,10 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
       
     }
@@ -52527,7 +52967,11 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
     }
     instance.#_2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex = _2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -58081,7 +58525,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
     if (!(instance instanceof Organization)) {
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
-    const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
 
     let _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername__array = values[\\"https://www.w3.org/ns/activitystreams#preferredUsername\\"];
     
@@ -58101,7 +58547,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
     }
@@ -58217,7 +58666,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
     }
@@ -58258,7 +58710,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
     }
@@ -58569,7 +59024,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
     }
@@ -58622,7 +59080,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
     }
@@ -58688,7 +59149,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -59497,7 +59962,13 @@ proofs?: (DataIntegrityProof | URL)[];width?: number | null;height?: number | nu
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -65009,7 +65480,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
     if (!(instance instanceof Person)) {
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
-    const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
 
     let _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername__array = values[\\"https://www.w3.org/ns/activitystreams#preferredUsername\\"];
     
@@ -65029,7 +65502,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
     }
@@ -65145,7 +65621,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
     }
@@ -65186,7 +65665,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
     }
@@ -65497,7 +65979,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
     }
@@ -65550,7 +66035,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
     }
@@ -65616,7 +66104,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -66880,7 +67372,9 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
     if (!(instance instanceof Place)) {
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
-    const _3UCsHnBHvDAXJnBuzw3zw1VVs3Ne_accuracy: (number)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _3UCsHnBHvDAXJnBuzw3zw1VVs3Ne_accuracy: (number)[] = [];
 
     let _3UCsHnBHvDAXJnBuzw3zw1VVs3Ne_accuracy__array = values[\\"https://www.w3.org/ns/activitystreams#accuracy\\"];
     
@@ -66989,13 +67483,20 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
       
     }
     instance.#_oKrwxU4V8wiKhMW1QEYQibcJh8c_units = _oKrwxU4V8wiKhMW1QEYQibcJh8c_units;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -67737,6 +68238,8 @@ proofs?: (DataIntegrityProof | URL)[];describes?: Object | URL | null;}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes: (Object | URL)[] = [];
       const _trust_3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes: Set<number> = new Set();
     
@@ -67767,7 +68270,11 @@ proofs?: (DataIntegrityProof | URL)[];describes?: Object | URL | null;}
     }
     instance.#_3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes = _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -68868,6 +69375,8 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf: (Object | URL)[] = [];
       const _trust_2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf: Set<number> = new Set();
     
@@ -68953,7 +69462,10 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       ) : typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"boolean\\" ? v[\\"@value\\"] : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3KronwL8DiiKBRcJFKQPiEHm8xb6_closed.push(decoded);
       
     }
@@ -68997,7 +69509,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
     }
     instance.#_K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl = _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -69434,7 +69950,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -69772,7 +70294,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -71264,6 +71792,8 @@ relationships?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject: (Object | URL)[] = [];
       const _trust_2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject: Set<number> = new Set();
     
@@ -71354,7 +71884,11 @@ relationships?: (Object | URL)[];}
     }
     instance.#_4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship = _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -71760,7 +72294,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -77272,7 +77812,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
     if (!(instance instanceof Service)) {
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
-    const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
 
     let _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername__array = values[\\"https://www.w3.org/ns/activitystreams#preferredUsername\\"];
     
@@ -77292,7 +77834,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
     }
@@ -77408,7 +77953,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
     }
@@ -77449,7 +77997,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
     }
@@ -77760,7 +78311,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
     }
@@ -77813,7 +78367,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
     }
@@ -77879,7 +78436,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -78406,6 +78967,7 @@ export class Source {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -78434,6 +78996,14 @@ export class Source {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -78891,7 +79461,9 @@ get contents(): ((string | LanguageString))[] {
       { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
-    const _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content: ((string | LanguageString))[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content: ((string | LanguageString))[] = [];
 
     let _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content__array = values[\\"https://www.w3.org/ns/activitystreams#content\\"];
     
@@ -78911,7 +79483,10 @@ get contents(): ((string | LanguageString))[] {
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
       
     }
@@ -78932,7 +79507,11 @@ get contents(): ((string | LanguageString))[] {
     }
     instance.#_3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType = _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -79327,7 +79906,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -79661,7 +80246,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -80076,7 +80667,9 @@ proofs?: (DataIntegrityProof | URL)[];deleted?: Temporal.Instant | null;}
     if (!(instance instanceof Tombstone)) {
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
-    const _8g8g4LiVMhFTXskuDEqx4ascxUr_deleted: (Temporal.Instant)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _8g8g4LiVMhFTXskuDEqx4ascxUr_deleted: (Temporal.Instant)[] = [];
 
     let _8g8g4LiVMhFTXskuDEqx4ascxUr_deleted__array = values[\\"https://www.w3.org/ns/activitystreams#deleted\\"];
     
@@ -80096,7 +80689,11 @@ proofs?: (DataIntegrityProof | URL)[];deleted?: Temporal.Instant | null;}
     }
     instance.#_8g8g4LiVMhFTXskuDEqx4ascxUr_deleted = _8g8g4LiVMhFTXskuDEqx4ascxUr_deleted;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -80452,7 +81049,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -80791,7 +81394,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -81128,7 +81737,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -81465,7 +82080,13 @@ proofs?: (DataIntegrityProof | URL)[];width?: number | null;height?: number | nu
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -81798,7 +82419,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -90,6 +90,12 @@ export class Object {
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
     }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== \\"object\\") return true;
+      if (!(\\"_shouldCacheJsonLd\\" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
+    }
     
     /**
      * The type URI of {@link Object}: \`https://www.w3.org/ns/activitystreams#Object\`.
@@ -9438,7 +9444,7 @@ get urls(): ((URL | Link))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -9454,12 +9460,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _49BipA5dq9eoH8LX8xdsVumveTca_attachment.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _49BipA5dq9eoH8LX8xdsVumveTca_attachment.push(decoded);
+    
     }
     instance.#_49BipA5dq9eoH8LX8xdsVumveTca_attachment = _49BipA5dq9eoH8LX8xdsVumveTca_attachment;
     
@@ -9488,7 +9499,7 @@ get urls(): ((URL | Link))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -9510,12 +9521,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo.push(decoded);
+    
     }
     instance.#_42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo = _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo;
     
@@ -9542,10 +9558,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
+    
     }
     instance.#_3ocC3VVi88cEd5sPWL8djkZsvTN6_audience = _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience;
     const _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content: ((string | LanguageString))[] = [];
@@ -9562,18 +9587,23 @@ get urls(): ((URL | Link))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
+    
     }
     instance.#_4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content = _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content;
     
@@ -9602,7 +9632,7 @@ get urls(): ((URL | Link))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -9614,12 +9644,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3mhZzGXSpQ431mBSz2kvych22v4e_context.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3mhZzGXSpQ431mBSz2kvych22v4e_context.push(decoded);
+    
     }
     instance.#_3mhZzGXSpQ431mBSz2kvych22v4e_context = _3mhZzGXSpQ431mBSz2kvych22v4e_context;
     const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
@@ -9636,18 +9671,23 @@ get urls(): ((URL | Link))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
+    
     }
     instance.#_4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name = _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name;
     const _219RwDanjScTv5tYCjwGZVCM7KZ9_endTime: (Temporal.Instant)[] = [];
@@ -9662,11 +9702,20 @@ get urls(): ((URL | Link))[] {
         : _219RwDanjScTv5tYCjwGZVCM7KZ9_endTime__array
     ) {
       if (v == null) continue;
-    _219RwDanjScTv5tYCjwGZVCM7KZ9_endTime.push(Temporal.Instant.from(
+    
+      const decoded =
+    Temporal.Instant.from(
         v[\\"@value\\"].substring(19).match(/[Z+-]/)
           ? v[\\"@value\\"]
           : v[\\"@value\\"] + \\"Z\\"
-      ))
+      )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _219RwDanjScTv5tYCjwGZVCM7KZ9_endTime.push(decoded);
+    
     }
     instance.#_219RwDanjScTv5tYCjwGZVCM7KZ9_endTime = _219RwDanjScTv5tYCjwGZVCM7KZ9_endTime;
     
@@ -9695,7 +9744,7 @@ get urls(): ((URL | Link))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -9707,12 +9756,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _86xFhmgBapoMvYqjbjRuDPayTrS_generator.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _86xFhmgBapoMvYqjbjRuDPayTrS_generator.push(decoded);
+    
     }
     instance.#_86xFhmgBapoMvYqjbjRuDPayTrS_generator = _86xFhmgBapoMvYqjbjRuDPayTrS_generator;
     
@@ -9739,10 +9793,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(await Image.fromJsonLd(
+      
+      const decoded =
+    await Image.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
+    
     }
     instance.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon;
     
@@ -9769,10 +9832,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(await Image.fromJsonLd(
+      
+      const decoded =
+    await Image.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
+    
     }
     instance.#_3dXrUdkARxwyJLtJcYi1AJ92H41U_image = _3dXrUdkARxwyJLtJcYi1AJ92H41U_image;
     
@@ -9801,7 +9873,7 @@ get urls(): ((URL | Link))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -9813,12 +9885,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo.push(decoded);
+    
     }
     instance.#_3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo = _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo;
     
@@ -9847,7 +9924,7 @@ get urls(): ((URL | Link))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -9859,12 +9936,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _31k5MUZJsnsPNg8dQQJieWaXTFnR_location.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _31k5MUZJsnsPNg8dQQJieWaXTFnR_location.push(decoded);
+    
     }
     instance.#_31k5MUZJsnsPNg8dQQJieWaXTFnR_location = _31k5MUZJsnsPNg8dQQJieWaXTFnR_location;
     
@@ -9893,7 +9975,7 @@ get urls(): ((URL | Link))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
@@ -9905,12 +9987,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(decoded);
+    
     }
     instance.#_gCVTegXxWWCw6wWRxa1QF65zusg_preview = _gCVTegXxWWCw6wWRxa1QF65zusg_preview;
     const _5e258TDXtuhaFRPZiGoDfEpjdMr_published: (Temporal.Instant)[] = [];
@@ -9925,11 +10012,20 @@ get urls(): ((URL | Link))[] {
         : _5e258TDXtuhaFRPZiGoDfEpjdMr_published__array
     ) {
       if (v == null) continue;
-    _5e258TDXtuhaFRPZiGoDfEpjdMr_published.push(Temporal.Instant.from(
+    
+      const decoded =
+    Temporal.Instant.from(
         v[\\"@value\\"].substring(19).match(/[Z+-]/)
           ? v[\\"@value\\"]
           : v[\\"@value\\"] + \\"Z\\"
-      ))
+      )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _5e258TDXtuhaFRPZiGoDfEpjdMr_published.push(decoded);
+    
     }
     instance.#_5e258TDXtuhaFRPZiGoDfEpjdMr_published = _5e258TDXtuhaFRPZiGoDfEpjdMr_published;
     
@@ -9956,10 +10052,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _7UpwM3JWcXhADcscukEehBorf6k_replies.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
+    
     }
     instance.#_7UpwM3JWcXhADcscukEehBorf6k_replies = _7UpwM3JWcXhADcscukEehBorf6k_replies;
     
@@ -9986,10 +10091,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
+    
     }
     instance.#_3kAfck9PcEYt2L7xug5y99YPbANs_shares = _3kAfck9PcEYt2L7xug5y99YPbANs_shares;
     
@@ -10016,10 +10130,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
+    
     }
     instance.#_S3ceDnpMdzoTRCccB9FkJWrEzYW_likes = _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes;
     
@@ -10046,10 +10169,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
+    
     }
     instance.#_kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions = _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions;
     const _2w3Jmue4up8iVDUA51WZqomEF438_startTime: (Temporal.Instant)[] = [];
@@ -10064,11 +10196,20 @@ get urls(): ((URL | Link))[] {
         : _2w3Jmue4up8iVDUA51WZqomEF438_startTime__array
     ) {
       if (v == null) continue;
-    _2w3Jmue4up8iVDUA51WZqomEF438_startTime.push(Temporal.Instant.from(
+    
+      const decoded =
+    Temporal.Instant.from(
         v[\\"@value\\"].substring(19).match(/[Z+-]/)
           ? v[\\"@value\\"]
           : v[\\"@value\\"] + \\"Z\\"
-      ))
+      )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2w3Jmue4up8iVDUA51WZqomEF438_startTime.push(decoded);
+    
     }
     instance.#_2w3Jmue4up8iVDUA51WZqomEF438_startTime = _2w3Jmue4up8iVDUA51WZqomEF438_startTime;
     const _4LqirZspQbFWWQEbFcXAxm7tTDN1_summary: ((string | LanguageString))[] = [];
@@ -10085,18 +10226,23 @@ get urls(): ((URL | Link))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _4LqirZspQbFWWQEbFcXAxm7tTDN1_summary.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4LqirZspQbFWWQEbFcXAxm7tTDN1_summary.push(decoded);
+    
     }
     instance.#_4LqirZspQbFWWQEbFcXAxm7tTDN1_summary = _4LqirZspQbFWWQEbFcXAxm7tTDN1_summary;
     
@@ -10125,7 +10271,7 @@ get urls(): ((URL | Link))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -10137,12 +10283,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _5chuqj6s95p5gg2sk1HntGfarRf_tag.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _5chuqj6s95p5gg2sk1HntGfarRf_tag.push(decoded);
+    
     }
     instance.#_5chuqj6s95p5gg2sk1HntGfarRf_tag = _5chuqj6s95p5gg2sk1HntGfarRf_tag;
     const _385aB7ySixcf5Un6z3VsWmThgCzQ_updated: (Temporal.Instant)[] = [];
@@ -10157,11 +10308,20 @@ get urls(): ((URL | Link))[] {
         : _385aB7ySixcf5Un6z3VsWmThgCzQ_updated__array
     ) {
       if (v == null) continue;
-    _385aB7ySixcf5Un6z3VsWmThgCzQ_updated.push(Temporal.Instant.from(
+    
+      const decoded =
+    Temporal.Instant.from(
         v[\\"@value\\"].substring(19).match(/[Z+-]/)
           ? v[\\"@value\\"]
           : v[\\"@value\\"] + \\"Z\\"
-      ))
+      )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _385aB7ySixcf5Un6z3VsWmThgCzQ_updated.push(decoded);
+    
     }
     instance.#_385aB7ySixcf5Un6z3VsWmThgCzQ_updated = _385aB7ySixcf5Un6z3VsWmThgCzQ_updated;
     const _2oPEH9MQ3aj8JVwyYuWkqoVwV865_url: ((URL | Link))[] = [];
@@ -10178,7 +10338,7 @@ get urls(): ((URL | Link))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@id\\" in v
+    typeof v === \\"object\\" && \\"@id\\" in v
         && typeof v[\\"@id\\"] === \\"string\\"
         && v[\\"@id\\"] !== \\"\\" ? v[\\"@id\\"].startsWith(\\"at://\\")
         ? new URL(\\"at://\\" +
@@ -10202,12 +10362,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2oPEH9MQ3aj8JVwyYuWkqoVwV865_url.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2oPEH9MQ3aj8JVwyYuWkqoVwV865_url.push(decoded);
+    
     }
     instance.#_2oPEH9MQ3aj8JVwyYuWkqoVwV865_url = _2oPEH9MQ3aj8JVwyYuWkqoVwV865_url;
     
@@ -10234,10 +10399,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
+    
     }
     instance.#_3hFbw7DTpHhq3cvVhkY8njhcsXbd_to = _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to;
     
@@ -10264,10 +10438,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
+    
     }
     instance.#_aLZupjwL8XB7tzdLgCMXdjZ6qej_bto = _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto;
     
@@ -10294,10 +10477,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
+    
     }
     instance.#_42a1SvBs24QSLzKcfjCyNTjW5a1g_cc = _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc;
     
@@ -10324,10 +10516,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
+    
     }
     instance.#_3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc = _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc;
     const _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType: (string)[] = [];
@@ -10342,7 +10543,16 @@ get urls(): ((URL | Link))[] {
         : _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType__array
     ) {
       if (v == null) continue;
-    _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType.push(decoded);
+    
     }
     instance.#_3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType = _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType;
     const _3bNvLMBN1bCJETiTihM3wvi1B2JX_duration: (Temporal.Duration)[] = [];
@@ -10357,7 +10567,16 @@ get urls(): ((URL | Link))[] {
         : _3bNvLMBN1bCJETiTihM3wvi1B2JX_duration__array
     ) {
       if (v == null) continue;
-    _3bNvLMBN1bCJETiTihM3wvi1B2JX_duration.push(Temporal.Duration.from(v[\\"@value\\"]))
+    
+      const decoded =
+    Temporal.Duration.from(v[\\"@value\\"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3bNvLMBN1bCJETiTihM3wvi1B2JX_duration.push(decoded);
+    
     }
     instance.#_3bNvLMBN1bCJETiTihM3wvi1B2JX_duration = _3bNvLMBN1bCJETiTihM3wvi1B2JX_duration;
     const _u8gdcDTtChQ4tbSQMXc4cYWyum7_sensitive: (boolean)[] = [];
@@ -10372,7 +10591,16 @@ get urls(): ((URL | Link))[] {
         : _u8gdcDTtChQ4tbSQMXc4cYWyum7_sensitive__array
     ) {
       if (v == null) continue;
-    _u8gdcDTtChQ4tbSQMXc4cYWyum7_sensitive.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _u8gdcDTtChQ4tbSQMXc4cYWyum7_sensitive.push(decoded);
+    
     }
     instance.#_u8gdcDTtChQ4tbSQMXc4cYWyum7_sensitive = _u8gdcDTtChQ4tbSQMXc4cYWyum7_sensitive;
     const _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source: (Source)[] = [];
@@ -10387,10 +10615,19 @@ get urls(): ((URL | Link))[] {
         : _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source__array
     ) {
       if (v == null) continue;
-    _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(await Source.fromJsonLd(
+    
+      const decoded =
+    await Source.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
+    
     }
     instance.#_2ZwCFoS787v8y8bXKjMoE6MAbrEB_source = _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source;
     
@@ -10417,10 +10654,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(await DataIntegrityProof.fromJsonLd(
+      
+      const decoded =
+    await DataIntegrityProof.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
+    
     }
     instance.#_42rPnotok1ivQ2RNCKNbeFJgx8b8_proof = _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof;
     
@@ -11988,7 +12234,16 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
         : _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl__array
     ) {
       if (v == null) continue;
-    _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl.push(new URL(v[\\"@value\\"]))
+    
+      const decoded =
+    new URL(v[\\"@value\\"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl.push(decoded);
+    
     }
     instance.#_K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl = _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl;
     
@@ -15020,7 +15275,7 @@ instruments?: (Object | URL)[];}
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -15042,12 +15297,17 @@ instruments?: (Object | URL)[];}
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor.push(decoded);
+    
     }
     instance.#_2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor = _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor;
     
@@ -15074,10 +15334,19 @@ instruments?: (Object | URL)[];}
         );
         continue;
       }
-      _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
+    
     }
     instance.#_2MH19yxjn1wnHsNfa5n4JBhJzxyc_object = _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object;
     
@@ -15104,10 +15373,19 @@ instruments?: (Object | URL)[];}
         );
         continue;
       }
-      _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
+    
     }
     instance.#_3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target = _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target;
     
@@ -15134,10 +15412,19 @@ instruments?: (Object | URL)[];}
         );
         continue;
       }
-      _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
+    
     }
     instance.#_u4QGFbRFcYmPEKGbPv1hpBR9r5G_result = _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result;
     
@@ -15164,10 +15451,19 @@ instruments?: (Object | URL)[];}
         );
         continue;
       }
-      _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
+    
     }
     instance.#_25zu2s3VxVujgEKqrDycjE284XQR_origin = _25zu2s3VxVujgEKqrDycjE284XQR_origin;
     
@@ -15194,10 +15490,19 @@ instruments?: (Object | URL)[];}
         );
         continue;
       }
-      _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
+    
     }
     instance.#_3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument = _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument;
     
@@ -15793,6 +16098,12 @@ export class PropertyValue {
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
     }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== \\"object\\") return true;
+      if (!(\\"_shouldCacheJsonLd\\" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
+    }
     
     /**
      * The type URI of {@link PropertyValue}: \`http://schema.org#PropertyValue\`.
@@ -16222,18 +16533,23 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
+    
     }
     instance.#_4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name = _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name;
     const _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value: ((string | LanguageString))[] = [];
@@ -16250,18 +16566,23 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value.push(decoded);
+    
     }
     instance.#_2cSy2magg4iZ7zLaG8U7DiJMoCkx_value = _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value;
     
@@ -16420,6 +16741,12 @@ export class DidService {
 
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
+    }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== \\"object\\") return true;
+      if (!(\\"_shouldCacheJsonLd\\" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
     }
     
     /**
@@ -16790,7 +17117,9 @@ get endpoints(): (URL)[] {
         : _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint__array
     ) {
       if (v == null) continue;
-    _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(v[\\"@id\\"].startsWith(\\"at://\\")
+    
+      const decoded =
+    v[\\"@id\\"].startsWith(\\"at://\\")
         ? new URL(\\"at://\\" +
           encodeURIComponent(
             v[\\"@id\\"].includes(\\"/\\", 5)
@@ -16805,7 +17134,14 @@ get endpoints(): (URL)[] {
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))))
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])))
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
+    
     }
     instance.#_2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint = _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint;
     
@@ -17234,6 +17570,12 @@ export class DataIntegrityProof {
 
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
+    }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== \\"object\\") return true;
+      if (!(\\"_shouldCacheJsonLd\\" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
     }
     
     /**
@@ -17975,7 +18317,16 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         : _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite__array
     ) {
       if (v == null) continue;
-    _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite.push(decoded);
+    
     }
     instance.#_3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite = _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite;
     
@@ -18002,10 +18353,19 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         );
         continue;
       }
-      _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(await Multikey.fromJsonLd(
+      
+      const decoded =
+    await Multikey.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
+    
     }
     instance.#_2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod = _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod;
     const _2AeEnPcAvVrPEuKbpmn9ZKNmWHKb_proofPurpose: (\\"assertionMethod\\" | \\"authentication\\" | \\"capabilityInvocation\\" | \\"capabilityDelegation\\" | \\"keyAgreement\\")[] = [];
@@ -18020,7 +18380,16 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         : _2AeEnPcAvVrPEuKbpmn9ZKNmWHKb_proofPurpose__array
     ) {
       if (v == null) continue;
-    _2AeEnPcAvVrPEuKbpmn9ZKNmWHKb_proofPurpose.push(v[\\"@id\\"].substring(26))
+    
+      const decoded =
+    v[\\"@id\\"].substring(26)
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2AeEnPcAvVrPEuKbpmn9ZKNmWHKb_proofPurpose.push(decoded);
+    
     }
     instance.#_2AeEnPcAvVrPEuKbpmn9ZKNmWHKb_proofPurpose = _2AeEnPcAvVrPEuKbpmn9ZKNmWHKb_proofPurpose;
     const _3CjFK5vfKpX4HQuNh2b18TykoVLq_proofValue: (Uint8Array)[] = [];
@@ -18035,7 +18404,16 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         : _3CjFK5vfKpX4HQuNh2b18TykoVLq_proofValue__array
     ) {
       if (v == null) continue;
-    _3CjFK5vfKpX4HQuNh2b18TykoVLq_proofValue.push(decodeMultibase(v[\\"@value\\"]))
+    
+      const decoded =
+    decodeMultibase(v[\\"@value\\"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3CjFK5vfKpX4HQuNh2b18TykoVLq_proofValue.push(decoded);
+    
     }
     instance.#_3CjFK5vfKpX4HQuNh2b18TykoVLq_proofValue = _3CjFK5vfKpX4HQuNh2b18TykoVLq_proofValue;
     const _3qzP3ukEZoUziK5FEiA1RhU4aqac: (Temporal.Instant)[] = [];
@@ -18050,11 +18428,20 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         : _3qzP3ukEZoUziK5FEiA1RhU4aqac__array
     ) {
       if (v == null) continue;
-    _3qzP3ukEZoUziK5FEiA1RhU4aqac.push(Temporal.Instant.from(
+    
+      const decoded =
+    Temporal.Instant.from(
         v[\\"@value\\"].substring(19).match(/[Z+-]/)
           ? v[\\"@value\\"]
           : v[\\"@value\\"] + \\"Z\\"
-      ))
+      )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3qzP3ukEZoUziK5FEiA1RhU4aqac.push(decoded);
+    
     }
     instance.#_3qzP3ukEZoUziK5FEiA1RhU4aqac = _3qzP3ukEZoUziK5FEiA1RhU4aqac;
     
@@ -18269,6 +18656,12 @@ export class CryptographicKey {
 
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
+    }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== \\"object\\") return true;
+      if (!(\\"_shouldCacheJsonLd\\" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
     }
     
     /**
@@ -18954,7 +19347,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -18976,12 +19369,17 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner.push(decoded);
+    
     }
     instance.#_5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner = _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner;
     const _2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem: (CryptoKey)[] = [];
@@ -18996,7 +19394,16 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         : _2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem__array
     ) {
       if (v == null) continue;
-    _2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem.push(await importPem(v[\\"@value\\"]))
+    
+      const decoded =
+    await importPem(v[\\"@value\\"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem.push(decoded);
+    
     }
     instance.#_2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem = _2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem;
     
@@ -19155,6 +19562,12 @@ export class Multikey {
 
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
+    }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== \\"object\\") return true;
+      if (!(\\"_shouldCacheJsonLd\\" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
     }
     
     /**
@@ -19847,7 +20260,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -19869,12 +20282,17 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller.push(decoded);
+    
     }
     instance.#_2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller = _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller;
     const _4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase: (CryptoKey)[] = [];
@@ -19889,7 +20307,16 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         : _4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase__array
     ) {
       if (v == null) continue;
-    _4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase.push(await importMultibaseKey(v[\\"@value\\"]))
+    
+      const decoded =
+    await importMultibaseKey(v[\\"@value\\"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase.push(decoded);
+    
     }
     instance.#_4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase = _4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase;
     
@@ -26508,18 +26935,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
+    
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -26546,10 +26978,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(await CryptographicKey.fromJsonLd(
+      
+      const decoded =
+    await CryptographicKey.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
+    
     }
     instance.#_axq166E2eZADq34V4MYUc8KMZdC_publicKey = _axq166E2eZADq34V4MYUc8KMZdC_publicKey;
     
@@ -26576,10 +27017,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(await Multikey.fromJsonLd(
+      
+      const decoded =
+    await Multikey.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
+    
     }
     instance.#_4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod = _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod;
     const _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers: (boolean)[] = [];
@@ -26594,7 +27044,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers__array
     ) {
       if (v == null) continue;
-    _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(decoded);
+    
     }
     instance.#_36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers = _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers;
     
@@ -26623,7 +27082,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -26633,12 +27092,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
+    
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -26667,7 +27131,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -26677,12 +27141,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
+    
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -26709,10 +27178,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
+    
     }
     instance.#_3yAv8jymNfNuJUDuBzJ1NQhdbAee_following = _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following;
     
@@ -26739,10 +27217,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
+    
     }
     instance.#_BBCTgfphhsFzpVfKTykGSpBNwoA_followers = _BBCTgfphhsFzpVfKTykGSpBNwoA_followers;
     
@@ -26769,10 +27256,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
+    
     }
     instance.#_3bgkPwJanyTCoVFM9ovRcus8tKkU_liked = _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked;
     
@@ -26799,10 +27295,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
+    
     }
     instance.#_4N1vBJzXDf8NbBumeECQMFvKetja_featured = _4N1vBJzXDf8NbBumeECQMFvKetja_featured;
     
@@ -26829,10 +27334,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
+    
     }
     instance.#_2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags = _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags;
     
@@ -26859,10 +27373,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
+    
     }
     instance.#_3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams = _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams;
     const _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints: (Endpoints)[] = [];
@@ -26877,10 +27400,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints__array
     ) {
       if (v == null) continue;
-    _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(await Endpoints.fromJsonLd(
+    
+      const decoded =
+    await Endpoints.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
+    
     }
     instance.#_sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints = _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints;
     const _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable: (boolean)[] = [];
@@ -26895,7 +27427,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable__array
     ) {
       if (v == null) continue;
-    _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(decoded);
+    
     }
     instance.#_gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable = _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable;
     const _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended: (boolean)[] = [];
@@ -26910,7 +27451,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended__array
     ) {
       if (v == null) continue;
-    _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(decoded);
+    
     }
     instance.#_2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended = _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended;
     const _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial: (boolean)[] = [];
@@ -26925,7 +27475,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial__array
     ) {
       if (v == null) continue;
-    _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(decoded);
+    
     }
     instance.#_79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial = _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial;
     const _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable: (boolean)[] = [];
@@ -26940,7 +27499,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable__array
     ) {
       if (v == null) continue;
-    _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(decoded);
+    
     }
     instance.#_2diCorzqPGQQqftp6e4SrCEwEnyk_indexable = _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable;
     
@@ -26969,7 +27537,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -26991,12 +27559,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
+    
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -27025,7 +27598,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -27047,12 +27620,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
+    
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -27079,10 +27657,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(await DidService.fromJsonLd(
+      
+      const decoded =
+    await DidService.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
+    
     }
     instance.#_4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service = _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service;
     const _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage: (string)[] = [];
@@ -27097,7 +27684,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage__array
     ) {
       if (v == null) continue;
-    _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(decoded);
+    
     }
     instance.#_QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage = _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage;
     const _2xEU4QtkC53RAun67T81Egqt9vmL_isCat: (boolean)[] = [];
@@ -27112,7 +27708,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2xEU4QtkC53RAun67T81Egqt9vmL_isCat__array
     ) {
       if (v == null) continue;
-    _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(decoded);
+    
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
@@ -28739,7 +29344,16 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
         : _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl__array
     ) {
       if (v == null) continue;
-    _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl.push(new URL(v[\\"@value\\"]))
+    
+      const decoded =
+    new URL(v[\\"@value\\"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl.push(decoded);
+    
     }
     instance.#_K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl = _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl;
     
@@ -29285,7 +29899,16 @@ proofs?: (DataIntegrityProof | URL)[];width?: number | null;height?: number | nu
         : _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width__array
     ) {
       if (v == null) continue;
-    _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width.push(decoded);
+    
     }
     instance.#_2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width = _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width;
     const _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height: (number)[] = [];
@@ -29300,7 +29923,16 @@ proofs?: (DataIntegrityProof | URL)[];width?: number | null;height?: number | nu
         : _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height__array
     ) {
       if (v == null) continue;
-    _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height.push(decoded);
+    
     }
     instance.#_2cGKFeFJMmiNpGZFEF75mCwFQsKb_height = _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height;
     
@@ -34201,7 +34833,16 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         : _XDbmNDuWHmrhqH712zqtecdbv1V_totalItems__array
     ) {
       if (v == null) continue;
-    _XDbmNDuWHmrhqH712zqtecdbv1V_totalItems.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _XDbmNDuWHmrhqH712zqtecdbv1V_totalItems.push(decoded);
+    
     }
     instance.#_XDbmNDuWHmrhqH712zqtecdbv1V_totalItems = _XDbmNDuWHmrhqH712zqtecdbv1V_totalItems;
     
@@ -34228,10 +34869,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(await CollectionPage.fromJsonLd(
+      
+      const decoded =
+    await CollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
+    
     }
     instance.#_3UyUdxnyn6cDn53QKrh4MBiearma_current = _3UyUdxnyn6cDn53QKrh4MBiearma_current;
     
@@ -34258,10 +34908,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(await CollectionPage.fromJsonLd(
+      
+      const decoded =
+    await CollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
+    
     }
     instance.#_J52RqweMe6hhv7RnLJMC8BExTE5_first = _J52RqweMe6hhv7RnLJMC8BExTE5_first;
     
@@ -34288,10 +34947,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(await CollectionPage.fromJsonLd(
+      
+      const decoded =
+    await CollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
+    
     }
     instance.#_gyJJnyEFnuNVi1HFZKfAn3Hfn26_last = _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last;
     
@@ -34320,7 +34988,7 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -34332,12 +35000,17 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
+    
     }
     instance.#_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items = _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items;
     
@@ -34364,10 +35037,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
+    
     }
     instance.#_4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf = _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf;
     
@@ -34394,10 +35076,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
+    
     }
     instance.#_3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf = _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf;
     
@@ -34424,10 +35115,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
+    
     }
     instance.#_3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf = _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf;
     
@@ -34454,10 +35154,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
+    
     }
     instance.#_2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf = _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf;
     
@@ -34484,10 +35193,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
+    
     }
     instance.#_4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf = _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf;
     
@@ -34514,10 +35232,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
+    
     }
     instance.#_41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf = _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf;
     
@@ -34544,10 +35271,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
+    
     }
     instance.#_2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf = _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf;
     
@@ -34574,10 +35310,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
+    
     }
     instance.#_2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf = _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf;
     
@@ -36053,10 +36798,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
+    
     }
     instance.#_2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf = _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf;
     
@@ -36083,10 +36837,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(await CollectionPage.fromJsonLd(
+      
+      const decoded =
+    await CollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
+    
     }
     instance.#_3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next = _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next;
     
@@ -36113,10 +36876,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(await CollectionPage.fromJsonLd(
+      
+      const decoded =
+    await CollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
+    
     }
     instance.#_3b8yG8tDNzQFFEnWhCc13G8eHooA_prev = _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev;
     
@@ -37293,6 +38065,12 @@ export class Endpoints {
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
     }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== \\"object\\") return true;
+      if (!(\\"_shouldCacheJsonLd\\" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
+    }
     
     /**
      * The type URI of {@link Endpoints}: \`https://www.w3.org/ns/activitystreams#Endpoints\`.
@@ -38011,7 +38789,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         : _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl__array
     ) {
       if (v == null) continue;
-    _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(v[\\"@id\\"].startsWith(\\"at://\\")
+    
+      const decoded =
+    v[\\"@id\\"].startsWith(\\"at://\\")
         ? new URL(\\"at://\\" +
           encodeURIComponent(
             v[\\"@id\\"].includes(\\"/\\", 5)
@@ -38026,7 +38806,14 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))))
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])))
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
+    
     }
     instance.#_2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl = _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl;
     const _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint: (URL)[] = [];
@@ -38041,7 +38828,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         : _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint__array
     ) {
       if (v == null) continue;
-    _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(v[\\"@id\\"].startsWith(\\"at://\\")
+    
+      const decoded =
+    v[\\"@id\\"].startsWith(\\"at://\\")
         ? new URL(\\"at://\\" +
           encodeURIComponent(
             v[\\"@id\\"].includes(\\"/\\", 5)
@@ -38056,7 +38845,14 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))))
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])))
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
+    
     }
     instance.#_25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint = _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint;
     const _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint: (URL)[] = [];
@@ -38071,7 +38867,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         : _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint__array
     ) {
       if (v == null) continue;
-    _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(v[\\"@id\\"].startsWith(\\"at://\\")
+    
+      const decoded =
+    v[\\"@id\\"].startsWith(\\"at://\\")
         ? new URL(\\"at://\\" +
           encodeURIComponent(
             v[\\"@id\\"].includes(\\"/\\", 5)
@@ -38086,7 +38884,14 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))))
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])))
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
+    
     }
     instance.#_iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint = _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint;
     const _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey: (URL)[] = [];
@@ -38101,7 +38906,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         : _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey__array
     ) {
       if (v == null) continue;
-    _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(v[\\"@id\\"].startsWith(\\"at://\\")
+    
+      const decoded =
+    v[\\"@id\\"].startsWith(\\"at://\\")
         ? new URL(\\"at://\\" +
           encodeURIComponent(
             v[\\"@id\\"].includes(\\"/\\", 5)
@@ -38116,7 +38923,14 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))))
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])))
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
+    
     }
     instance.#_8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey = _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey;
     const _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey: (URL)[] = [];
@@ -38131,7 +38945,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         : _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey__array
     ) {
       if (v == null) continue;
-    _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(v[\\"@id\\"].startsWith(\\"at://\\")
+    
+      const decoded =
+    v[\\"@id\\"].startsWith(\\"at://\\")
         ? new URL(\\"at://\\" +
           encodeURIComponent(
             v[\\"@id\\"].includes(\\"/\\", 5)
@@ -38146,7 +38962,14 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))))
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])))
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
+    
     }
     instance.#_3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey = _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey;
     const _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox: (URL)[] = [];
@@ -38161,7 +38984,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         : _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox__array
     ) {
       if (v == null) continue;
-    _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(v[\\"@id\\"].startsWith(\\"at://\\")
+    
+      const decoded =
+    v[\\"@id\\"].startsWith(\\"at://\\")
         ? new URL(\\"at://\\" +
           encodeURIComponent(
             v[\\"@id\\"].includes(\\"/\\", 5)
@@ -38176,7 +39001,14 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))))
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])))
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
+    
     }
     instance.#_3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox = _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox;
     
@@ -44873,18 +45705,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
+    
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -44911,10 +45748,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(await CryptographicKey.fromJsonLd(
+      
+      const decoded =
+    await CryptographicKey.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
+    
     }
     instance.#_axq166E2eZADq34V4MYUc8KMZdC_publicKey = _axq166E2eZADq34V4MYUc8KMZdC_publicKey;
     
@@ -44941,10 +45787,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(await Multikey.fromJsonLd(
+      
+      const decoded =
+    await Multikey.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
+    
     }
     instance.#_4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod = _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod;
     const _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers: (boolean)[] = [];
@@ -44959,7 +45814,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers__array
     ) {
       if (v == null) continue;
-    _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(decoded);
+    
     }
     instance.#_36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers = _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers;
     
@@ -44988,7 +45852,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -44998,12 +45862,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
+    
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -45032,7 +45901,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -45042,12 +45911,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
+    
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -45074,10 +45948,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
+    
     }
     instance.#_3yAv8jymNfNuJUDuBzJ1NQhdbAee_following = _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following;
     
@@ -45104,10 +45987,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
+    
     }
     instance.#_BBCTgfphhsFzpVfKTykGSpBNwoA_followers = _BBCTgfphhsFzpVfKTykGSpBNwoA_followers;
     
@@ -45134,10 +46026,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
+    
     }
     instance.#_3bgkPwJanyTCoVFM9ovRcus8tKkU_liked = _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked;
     
@@ -45164,10 +46065,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
+    
     }
     instance.#_4N1vBJzXDf8NbBumeECQMFvKetja_featured = _4N1vBJzXDf8NbBumeECQMFvKetja_featured;
     
@@ -45194,10 +46104,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
+    
     }
     instance.#_2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags = _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags;
     
@@ -45224,10 +46143,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
+    
     }
     instance.#_3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams = _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams;
     const _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints: (Endpoints)[] = [];
@@ -45242,10 +46170,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints__array
     ) {
       if (v == null) continue;
-    _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(await Endpoints.fromJsonLd(
+    
+      const decoded =
+    await Endpoints.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
+    
     }
     instance.#_sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints = _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints;
     const _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable: (boolean)[] = [];
@@ -45260,7 +46197,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable__array
     ) {
       if (v == null) continue;
-    _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(decoded);
+    
     }
     instance.#_gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable = _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable;
     const _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended: (boolean)[] = [];
@@ -45275,7 +46221,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended__array
     ) {
       if (v == null) continue;
-    _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(decoded);
+    
     }
     instance.#_2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended = _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended;
     const _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial: (boolean)[] = [];
@@ -45290,7 +46245,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial__array
     ) {
       if (v == null) continue;
-    _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(decoded);
+    
     }
     instance.#_79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial = _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial;
     const _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable: (boolean)[] = [];
@@ -45305,7 +46269,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable__array
     ) {
       if (v == null) continue;
-    _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(decoded);
+    
     }
     instance.#_2diCorzqPGQQqftp6e4SrCEwEnyk_indexable = _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable;
     
@@ -45334,7 +46307,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -45356,12 +46329,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
+    
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -45390,7 +46368,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -45412,12 +46390,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
+    
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -45444,10 +46427,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(await DidService.fromJsonLd(
+      
+      const decoded =
+    await DidService.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
+    
     }
     instance.#_4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service = _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service;
     const _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage: (string)[] = [];
@@ -45462,7 +46454,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage__array
     ) {
       if (v == null) continue;
-    _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(decoded);
+    
     }
     instance.#_QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage = _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage;
     const _2xEU4QtkC53RAun67T81Egqt9vmL_isCat: (boolean)[] = [];
@@ -45477,7 +46478,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2xEU4QtkC53RAun67T81Egqt9vmL_isCat__array
     ) {
       if (v == null) continue;
-    _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(decoded);
+    
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
@@ -46057,6 +47067,12 @@ export class Link {
 
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
+    }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== \\"object\\") return true;
+      if (!(\\"_shouldCacheJsonLd\\" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
     }
     
     /**
@@ -47283,7 +48299,9 @@ get names(): ((string | LanguageString))[] {
         : _pVjLsybKQdmkjuU7MHjiVmNnuj7_href__array
     ) {
       if (v == null) continue;
-    _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(v[\\"@id\\"].startsWith(\\"at://\\")
+    
+      const decoded =
+    v[\\"@id\\"].startsWith(\\"at://\\")
         ? new URL(\\"at://\\" +
           encodeURIComponent(
             v[\\"@id\\"].includes(\\"/\\", 5)
@@ -47298,7 +48316,14 @@ get names(): ((string | LanguageString))[] {
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))))
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])))
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
+    
     }
     instance.#_pVjLsybKQdmkjuU7MHjiVmNnuj7_href = _pVjLsybKQdmkjuU7MHjiVmNnuj7_href;
     const _2a1c5GkfkQsnyyLybF8UXBQfFuHZ_rel: (string)[] = [];
@@ -47313,7 +48338,16 @@ get names(): ((string | LanguageString))[] {
         : _2a1c5GkfkQsnyyLybF8UXBQfFuHZ_rel__array
     ) {
       if (v == null) continue;
-    _2a1c5GkfkQsnyyLybF8UXBQfFuHZ_rel.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2a1c5GkfkQsnyyLybF8UXBQfFuHZ_rel.push(decoded);
+    
     }
     instance.#_2a1c5GkfkQsnyyLybF8UXBQfFuHZ_rel = _2a1c5GkfkQsnyyLybF8UXBQfFuHZ_rel;
     const _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType: (string)[] = [];
@@ -47328,7 +48362,16 @@ get names(): ((string | LanguageString))[] {
         : _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType__array
     ) {
       if (v == null) continue;
-    _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType.push(decoded);
+    
     }
     instance.#_3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType = _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType;
     const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
@@ -47345,18 +48388,23 @@ get names(): ((string | LanguageString))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
+    
     }
     instance.#_4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name = _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name;
     const _f57HKWCp1YRBbTJE8PF12RbDJGf_hreflang: (Intl.Locale)[] = [];
@@ -47371,7 +48419,16 @@ get names(): ((string | LanguageString))[] {
         : _f57HKWCp1YRBbTJE8PF12RbDJGf_hreflang__array
     ) {
       if (v == null) continue;
-    _f57HKWCp1YRBbTJE8PF12RbDJGf_hreflang.push(new Intl.Locale(v[\\"@value\\"]))
+    
+      const decoded =
+    new Intl.Locale(v[\\"@value\\"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _f57HKWCp1YRBbTJE8PF12RbDJGf_hreflang.push(decoded);
+    
     }
     instance.#_f57HKWCp1YRBbTJE8PF12RbDJGf_hreflang = _f57HKWCp1YRBbTJE8PF12RbDJGf_hreflang;
     const _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height: (number)[] = [];
@@ -47386,7 +48443,16 @@ get names(): ((string | LanguageString))[] {
         : _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height__array
     ) {
       if (v == null) continue;
-    _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height.push(decoded);
+    
     }
     instance.#_2cGKFeFJMmiNpGZFEF75mCwFQsKb_height = _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height;
     const _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width: (number)[] = [];
@@ -47401,7 +48467,16 @@ get names(): ((string | LanguageString))[] {
         : _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width__array
     ) {
       if (v == null) continue;
-    _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width.push(decoded);
+    
     }
     instance.#_2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width = _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width;
     
@@ -47430,7 +48505,7 @@ get names(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
@@ -47442,12 +48517,17 @@ get names(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(decoded);
+    
     }
     instance.#_gCVTegXxWWCw6wWRxa1QF65zusg_preview = _gCVTegXxWWCw6wWRxa1QF65zusg_preview;
     
@@ -51437,7 +52517,16 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
         : _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl__array
     ) {
       if (v == null) continue;
-    _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl.push(new URL(v[\\"@value\\"]))
+    
+      const decoded =
+    new URL(v[\\"@value\\"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl.push(decoded);
+    
     }
     instance.#_K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl = _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl;
     
@@ -52136,7 +53225,7 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -52148,12 +53237,17 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
+    
     }
     instance.#_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items = _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items;
     
@@ -52931,7 +54025,7 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -52943,12 +54037,17 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
+    
     }
     instance.#_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items = _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items;
     const _2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex: (number)[] = [];
@@ -52963,7 +54062,16 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         : _2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex__array
     ) {
       if (v == null) continue;
-    _2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex.push(decoded);
+    
     }
     instance.#_2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex = _2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex;
     
@@ -58541,18 +59649,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
+    
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -58579,10 +59692,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(await CryptographicKey.fromJsonLd(
+      
+      const decoded =
+    await CryptographicKey.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
+    
     }
     instance.#_axq166E2eZADq34V4MYUc8KMZdC_publicKey = _axq166E2eZADq34V4MYUc8KMZdC_publicKey;
     
@@ -58609,10 +59731,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(await Multikey.fromJsonLd(
+      
+      const decoded =
+    await Multikey.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
+    
     }
     instance.#_4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod = _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod;
     const _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers: (boolean)[] = [];
@@ -58627,7 +59758,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers__array
     ) {
       if (v == null) continue;
-    _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(decoded);
+    
     }
     instance.#_36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers = _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers;
     
@@ -58656,7 +59796,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -58666,12 +59806,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
+    
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -58700,7 +59845,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -58710,12 +59855,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
+    
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -58742,10 +59892,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
+    
     }
     instance.#_3yAv8jymNfNuJUDuBzJ1NQhdbAee_following = _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following;
     
@@ -58772,10 +59931,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
+    
     }
     instance.#_BBCTgfphhsFzpVfKTykGSpBNwoA_followers = _BBCTgfphhsFzpVfKTykGSpBNwoA_followers;
     
@@ -58802,10 +59970,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
+    
     }
     instance.#_3bgkPwJanyTCoVFM9ovRcus8tKkU_liked = _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked;
     
@@ -58832,10 +60009,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
+    
     }
     instance.#_4N1vBJzXDf8NbBumeECQMFvKetja_featured = _4N1vBJzXDf8NbBumeECQMFvKetja_featured;
     
@@ -58862,10 +60048,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
+    
     }
     instance.#_2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags = _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags;
     
@@ -58892,10 +60087,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
+    
     }
     instance.#_3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams = _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams;
     const _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints: (Endpoints)[] = [];
@@ -58910,10 +60114,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints__array
     ) {
       if (v == null) continue;
-    _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(await Endpoints.fromJsonLd(
+    
+      const decoded =
+    await Endpoints.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
+    
     }
     instance.#_sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints = _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints;
     const _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable: (boolean)[] = [];
@@ -58928,7 +60141,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable__array
     ) {
       if (v == null) continue;
-    _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(decoded);
+    
     }
     instance.#_gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable = _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable;
     const _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended: (boolean)[] = [];
@@ -58943,7 +60165,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended__array
     ) {
       if (v == null) continue;
-    _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(decoded);
+    
     }
     instance.#_2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended = _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended;
     const _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial: (boolean)[] = [];
@@ -58958,7 +60189,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial__array
     ) {
       if (v == null) continue;
-    _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(decoded);
+    
     }
     instance.#_79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial = _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial;
     const _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable: (boolean)[] = [];
@@ -58973,7 +60213,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable__array
     ) {
       if (v == null) continue;
-    _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(decoded);
+    
     }
     instance.#_2diCorzqPGQQqftp6e4SrCEwEnyk_indexable = _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable;
     
@@ -59002,7 +60251,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -59024,12 +60273,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
+    
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -59058,7 +60312,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -59080,12 +60334,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
+    
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -59112,10 +60371,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(await DidService.fromJsonLd(
+      
+      const decoded =
+    await DidService.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
+    
     }
     instance.#_4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service = _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service;
     const _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage: (string)[] = [];
@@ -59130,7 +60398,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage__array
     ) {
       if (v == null) continue;
-    _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(decoded);
+    
     }
     instance.#_QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage = _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage;
     const _2xEU4QtkC53RAun67T81Egqt9vmL_isCat: (boolean)[] = [];
@@ -59145,7 +60422,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2xEU4QtkC53RAun67T81Egqt9vmL_isCat__array
     ) {
       if (v == null) continue;
-    _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(decoded);
+    
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
@@ -65496,18 +66782,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
+    
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -65534,10 +66825,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(await CryptographicKey.fromJsonLd(
+      
+      const decoded =
+    await CryptographicKey.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
+    
     }
     instance.#_axq166E2eZADq34V4MYUc8KMZdC_publicKey = _axq166E2eZADq34V4MYUc8KMZdC_publicKey;
     
@@ -65564,10 +66864,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(await Multikey.fromJsonLd(
+      
+      const decoded =
+    await Multikey.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
+    
     }
     instance.#_4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod = _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod;
     const _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers: (boolean)[] = [];
@@ -65582,7 +66891,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers__array
     ) {
       if (v == null) continue;
-    _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(decoded);
+    
     }
     instance.#_36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers = _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers;
     
@@ -65611,7 +66929,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -65621,12 +66939,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
+    
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -65655,7 +66978,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -65665,12 +66988,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
+    
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -65697,10 +67025,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
+    
     }
     instance.#_3yAv8jymNfNuJUDuBzJ1NQhdbAee_following = _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following;
     
@@ -65727,10 +67064,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
+    
     }
     instance.#_BBCTgfphhsFzpVfKTykGSpBNwoA_followers = _BBCTgfphhsFzpVfKTykGSpBNwoA_followers;
     
@@ -65757,10 +67103,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
+    
     }
     instance.#_3bgkPwJanyTCoVFM9ovRcus8tKkU_liked = _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked;
     
@@ -65787,10 +67142,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
+    
     }
     instance.#_4N1vBJzXDf8NbBumeECQMFvKetja_featured = _4N1vBJzXDf8NbBumeECQMFvKetja_featured;
     
@@ -65817,10 +67181,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
+    
     }
     instance.#_2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags = _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags;
     
@@ -65847,10 +67220,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
+    
     }
     instance.#_3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams = _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams;
     const _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints: (Endpoints)[] = [];
@@ -65865,10 +67247,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints__array
     ) {
       if (v == null) continue;
-    _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(await Endpoints.fromJsonLd(
+    
+      const decoded =
+    await Endpoints.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
+    
     }
     instance.#_sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints = _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints;
     const _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable: (boolean)[] = [];
@@ -65883,7 +67274,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable__array
     ) {
       if (v == null) continue;
-    _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(decoded);
+    
     }
     instance.#_gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable = _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable;
     const _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended: (boolean)[] = [];
@@ -65898,7 +67298,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended__array
     ) {
       if (v == null) continue;
-    _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(decoded);
+    
     }
     instance.#_2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended = _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended;
     const _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial: (boolean)[] = [];
@@ -65913,7 +67322,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial__array
     ) {
       if (v == null) continue;
-    _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(decoded);
+    
     }
     instance.#_79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial = _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial;
     const _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable: (boolean)[] = [];
@@ -65928,7 +67346,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable__array
     ) {
       if (v == null) continue;
-    _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(decoded);
+    
     }
     instance.#_2diCorzqPGQQqftp6e4SrCEwEnyk_indexable = _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable;
     
@@ -65957,7 +67384,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -65979,12 +67406,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
+    
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -66013,7 +67445,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -66035,12 +67467,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
+    
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -66067,10 +67504,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(await DidService.fromJsonLd(
+      
+      const decoded =
+    await DidService.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
+    
     }
     instance.#_4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service = _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service;
     const _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage: (string)[] = [];
@@ -66085,7 +67531,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage__array
     ) {
       if (v == null) continue;
-    _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(decoded);
+    
     }
     instance.#_QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage = _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage;
     const _2xEU4QtkC53RAun67T81Egqt9vmL_isCat: (boolean)[] = [];
@@ -66100,7 +67555,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2xEU4QtkC53RAun67T81Egqt9vmL_isCat__array
     ) {
       if (v == null) continue;
-    _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(decoded);
+    
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
@@ -67386,7 +68850,16 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
         : _3UCsHnBHvDAXJnBuzw3zw1VVs3Ne_accuracy__array
     ) {
       if (v == null) continue;
-    _3UCsHnBHvDAXJnBuzw3zw1VVs3Ne_accuracy.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3UCsHnBHvDAXJnBuzw3zw1VVs3Ne_accuracy.push(decoded);
+    
     }
     instance.#_3UCsHnBHvDAXJnBuzw3zw1VVs3Ne_accuracy = _3UCsHnBHvDAXJnBuzw3zw1VVs3Ne_accuracy;
     const _3Q6KDcFQUJRRaBux1BL2yp5QWiBi_altitude: (number)[] = [];
@@ -67401,7 +68874,16 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
         : _3Q6KDcFQUJRRaBux1BL2yp5QWiBi_altitude__array
     ) {
       if (v == null) continue;
-    _3Q6KDcFQUJRRaBux1BL2yp5QWiBi_altitude.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3Q6KDcFQUJRRaBux1BL2yp5QWiBi_altitude.push(decoded);
+    
     }
     instance.#_3Q6KDcFQUJRRaBux1BL2yp5QWiBi_altitude = _3Q6KDcFQUJRRaBux1BL2yp5QWiBi_altitude;
     const _3g85RoKRnaNjP7DFyLSvsWDg7HGM_latitude: (number)[] = [];
@@ -67416,7 +68898,16 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
         : _3g85RoKRnaNjP7DFyLSvsWDg7HGM_latitude__array
     ) {
       if (v == null) continue;
-    _3g85RoKRnaNjP7DFyLSvsWDg7HGM_latitude.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3g85RoKRnaNjP7DFyLSvsWDg7HGM_latitude.push(decoded);
+    
     }
     instance.#_3g85RoKRnaNjP7DFyLSvsWDg7HGM_latitude = _3g85RoKRnaNjP7DFyLSvsWDg7HGM_latitude;
     const _B2GEYdS9yBAF3ho1pm1rcRg7cSf_longitude: (number)[] = [];
@@ -67431,7 +68922,16 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
         : _B2GEYdS9yBAF3ho1pm1rcRg7cSf_longitude__array
     ) {
       if (v == null) continue;
-    _B2GEYdS9yBAF3ho1pm1rcRg7cSf_longitude.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _B2GEYdS9yBAF3ho1pm1rcRg7cSf_longitude.push(decoded);
+    
     }
     instance.#_B2GEYdS9yBAF3ho1pm1rcRg7cSf_longitude = _B2GEYdS9yBAF3ho1pm1rcRg7cSf_longitude;
     const _3ga86BKHUtRkGx5PHBjRiUXXzwnw_radius: (number)[] = [];
@@ -67446,7 +68946,16 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
         : _3ga86BKHUtRkGx5PHBjRiUXXzwnw_radius__array
     ) {
       if (v == null) continue;
-    _3ga86BKHUtRkGx5PHBjRiUXXzwnw_radius.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3ga86BKHUtRkGx5PHBjRiUXXzwnw_radius.push(decoded);
+    
     }
     instance.#_3ga86BKHUtRkGx5PHBjRiUXXzwnw_radius = _3ga86BKHUtRkGx5PHBjRiUXXzwnw_radius;
     const _oKrwxU4V8wiKhMW1QEYQibcJh8c_units: ((\\"cm\\" | \\"feet\\" | \\"inches\\" | \\"km\\" | \\"m\\" | \\"miles\\" | URL))[] = [];
@@ -67463,7 +68972,7 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
       && (v[\\"@value\\"] == \\"cm\\" || v[\\"@value\\"] == \\"feet\\" || v[\\"@value\\"] == \\"inches\\" || v[\\"@value\\"] == \\"km\\" || v[\\"@value\\"] == \\"m\\" || v[\\"@value\\"] == \\"miles\\") ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@id\\" in v
         && typeof v[\\"@id\\"] === \\"string\\"
         && v[\\"@id\\"] !== \\"\\" ? v[\\"@id\\"].startsWith(\\"at://\\")
@@ -67483,12 +68992,17 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
+    
     }
     instance.#_oKrwxU4V8wiKhMW1QEYQibcJh8c_units = _oKrwxU4V8wiKhMW1QEYQibcJh8c_units;
     
@@ -68263,10 +69777,19 @@ proofs?: (DataIntegrityProof | URL)[];describes?: Object | URL | null;}
         );
         continue;
       }
-      _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
+    
     }
     instance.#_3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes = _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes;
     
@@ -69400,10 +70923,19 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         );
         continue;
       }
-      _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
+    
     }
     instance.#_2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf = _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf;
     
@@ -69430,10 +70962,19 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         );
         continue;
       }
-      _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
+    
     }
     instance.#_2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf = _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf;
     const _3KronwL8DiiKBRcJFKQPiEHm8xb6_closed: ((Temporal.Instant | boolean))[] = [];
@@ -69450,7 +70991,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
         && \\"@value\\" in v && typeof v[\\"@value\\"] === \\"string\\"
         && v[\\"@type\\"] === \\"http://www.w3.org/2001/XMLSchema#dateTime\\"
         // Check if the value is a valid RFC 3339 date-time string
@@ -69462,12 +71003,17 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       ) : typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"boolean\\" ? v[\\"@value\\"] : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3KronwL8DiiKBRcJFKQPiEHm8xb6_closed.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3KronwL8DiiKBRcJFKQPiEHm8xb6_closed.push(decoded);
+    
     }
     instance.#_3KronwL8DiiKBRcJFKQPiEHm8xb6_closed = _3KronwL8DiiKBRcJFKQPiEHm8xb6_closed;
     const _3H4RdST7dxfmghccvE3rKD3KgcxG_votersCount: (number)[] = [];
@@ -69482,7 +71028,16 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         : _3H4RdST7dxfmghccvE3rKD3KgcxG_votersCount__array
     ) {
       if (v == null) continue;
-    _3H4RdST7dxfmghccvE3rKD3KgcxG_votersCount.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3H4RdST7dxfmghccvE3rKD3KgcxG_votersCount.push(decoded);
+    
     }
     instance.#_3H4RdST7dxfmghccvE3rKD3KgcxG_votersCount = _3H4RdST7dxfmghccvE3rKD3KgcxG_votersCount;
     const _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl: (URL)[] = [];
@@ -69505,7 +71060,16 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         : _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl__array
     ) {
       if (v == null) continue;
-    _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl.push(new URL(v[\\"@value\\"]))
+    
+      const decoded =
+    new URL(v[\\"@value\\"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl.push(decoded);
+    
     }
     instance.#_K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl = _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl;
     
@@ -71817,10 +73381,19 @@ relationships?: (Object | URL)[];}
         );
         continue;
       }
-      _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
+    
     }
     instance.#_2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject = _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject;
     
@@ -71847,10 +73420,19 @@ relationships?: (Object | URL)[];}
         );
         continue;
       }
-      _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
+    
     }
     instance.#_2MH19yxjn1wnHsNfa5n4JBhJzxyc_object = _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object;
     
@@ -71877,10 +73459,19 @@ relationships?: (Object | URL)[];}
         );
         continue;
       }
-      _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
+    
     }
     instance.#_4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship = _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship;
     
@@ -77828,18 +79419,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
+    
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -77866,10 +79462,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(await CryptographicKey.fromJsonLd(
+      
+      const decoded =
+    await CryptographicKey.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
+    
     }
     instance.#_axq166E2eZADq34V4MYUc8KMZdC_publicKey = _axq166E2eZADq34V4MYUc8KMZdC_publicKey;
     
@@ -77896,10 +79501,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(await Multikey.fromJsonLd(
+      
+      const decoded =
+    await Multikey.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
+    
     }
     instance.#_4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod = _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod;
     const _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers: (boolean)[] = [];
@@ -77914,7 +79528,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers__array
     ) {
       if (v == null) continue;
-    _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(decoded);
+    
     }
     instance.#_36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers = _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers;
     
@@ -77943,7 +79566,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -77953,12 +79576,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
+    
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -77987,7 +79615,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -77997,12 +79625,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
+    
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -78029,10 +79662,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
+    
     }
     instance.#_3yAv8jymNfNuJUDuBzJ1NQhdbAee_following = _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following;
     
@@ -78059,10 +79701,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
+    
     }
     instance.#_BBCTgfphhsFzpVfKTykGSpBNwoA_followers = _BBCTgfphhsFzpVfKTykGSpBNwoA_followers;
     
@@ -78089,10 +79740,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
+    
     }
     instance.#_3bgkPwJanyTCoVFM9ovRcus8tKkU_liked = _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked;
     
@@ -78119,10 +79779,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
+    
     }
     instance.#_4N1vBJzXDf8NbBumeECQMFvKetja_featured = _4N1vBJzXDf8NbBumeECQMFvKetja_featured;
     
@@ -78149,10 +79818,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
+    
     }
     instance.#_2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags = _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags;
     
@@ -78179,10 +79857,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
+    
     }
     instance.#_3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams = _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams;
     const _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints: (Endpoints)[] = [];
@@ -78197,10 +79884,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints__array
     ) {
       if (v == null) continue;
-    _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(await Endpoints.fromJsonLd(
+    
+      const decoded =
+    await Endpoints.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
+    
     }
     instance.#_sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints = _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints;
     const _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable: (boolean)[] = [];
@@ -78215,7 +79911,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable__array
     ) {
       if (v == null) continue;
-    _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(decoded);
+    
     }
     instance.#_gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable = _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable;
     const _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended: (boolean)[] = [];
@@ -78230,7 +79935,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended__array
     ) {
       if (v == null) continue;
-    _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(decoded);
+    
     }
     instance.#_2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended = _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended;
     const _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial: (boolean)[] = [];
@@ -78245,7 +79959,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial__array
     ) {
       if (v == null) continue;
-    _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(decoded);
+    
     }
     instance.#_79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial = _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial;
     const _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable: (boolean)[] = [];
@@ -78260,7 +79983,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable__array
     ) {
       if (v == null) continue;
-    _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(decoded);
+    
     }
     instance.#_2diCorzqPGQQqftp6e4SrCEwEnyk_indexable = _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable;
     
@@ -78289,7 +80021,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -78311,12 +80043,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
+    
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -78345,7 +80082,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -78367,12 +80104,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
+    
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -78399,10 +80141,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(await DidService.fromJsonLd(
+      
+      const decoded =
+    await DidService.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
+    
     }
     instance.#_4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service = _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service;
     const _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage: (string)[] = [];
@@ -78417,7 +80168,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage__array
     ) {
       if (v == null) continue;
-    _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(decoded);
+    
     }
     instance.#_QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage = _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage;
     const _2xEU4QtkC53RAun67T81Egqt9vmL_isCat: (boolean)[] = [];
@@ -78432,7 +80192,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2xEU4QtkC53RAun67T81Egqt9vmL_isCat__array
     ) {
       if (v == null) continue;
-    _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(decoded);
+    
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
@@ -79005,6 +80774,12 @@ export class Source {
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
     }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== \\"object\\") return true;
+      if (!(\\"_shouldCacheJsonLd\\" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
+    }
     
     /**
      * The type URI of {@link Source}: \`https://www.w3.org/ns/activitystreams#Source\`.
@@ -79477,18 +81252,23 @@ get contents(): ((string | LanguageString))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
+    
     }
     instance.#_4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content = _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content;
     const _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType: (string)[] = [];
@@ -79503,7 +81283,16 @@ get contents(): ((string | LanguageString))[] {
         : _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType__array
     ) {
       if (v == null) continue;
-    _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType.push(decoded);
+    
     }
     instance.#_3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType = _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType;
     
@@ -80681,11 +82470,20 @@ proofs?: (DataIntegrityProof | URL)[];deleted?: Temporal.Instant | null;}
         : _8g8g4LiVMhFTXskuDEqx4ascxUr_deleted__array
     ) {
       if (v == null) continue;
-    _8g8g4LiVMhFTXskuDEqx4ascxUr_deleted.push(Temporal.Instant.from(
+    
+      const decoded =
+    Temporal.Instant.from(
         v[\\"@value\\"].substring(19).match(/[Z+-]/)
           ? v[\\"@value\\"]
           : v[\\"@value\\"] + \\"Z\\"
-      ))
+      )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _8g8g4LiVMhFTXskuDEqx4ascxUr_deleted.push(decoded);
+    
     }
     instance.#_8g8g4LiVMhFTXskuDEqx4ascxUr_deleted = _8g8g4LiVMhFTXskuDEqx4ascxUr_deleted;
     

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.deno.snap
@@ -23,6 +23,16 @@ import {
     isTemporalInstant,
 } from \\"@fedify/vocab-runtime/temporal\\";
 
+function isValidLanguageTag(language: string): boolean {
+  try {
+    new Intl.Locale(language);
+    return true;
+  } catch (error) {
+    if (error instanceof RangeError) return false;
+    throw error;
+  }
+}
+
 
 /** Describes an object of any kind. The Object type serves as the base type for
  * most of the other kinds of objects defined in the Activity Vocabulary,
@@ -9538,7 +9548,8 @@ get urls(): ((URL | Link))[] {
       typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
-        && typeof v[\\"@value\\"] === \\"string\\" ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
+        && typeof v[\\"@value\\"] === \\"string\\"
+        && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
@@ -9605,7 +9616,8 @@ get urls(): ((URL | Link))[] {
       typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
-        && typeof v[\\"@value\\"] === \\"string\\" ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
+        && typeof v[\\"@value\\"] === \\"string\\"
+        && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
@@ -10038,7 +10050,8 @@ get urls(): ((URL | Link))[] {
       typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
-        && typeof v[\\"@value\\"] === \\"string\\" ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
+        && typeof v[\\"@value\\"] === \\"string\\"
+        && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _4LqirZspQbFWWQEbFcXAxm7tTDN1_summary.push(decoded);
@@ -16123,7 +16136,8 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
       typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
-        && typeof v[\\"@value\\"] === \\"string\\" ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
+        && typeof v[\\"@value\\"] === \\"string\\"
+        && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
@@ -16147,7 +16161,8 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
       typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
-        && typeof v[\\"@value\\"] === \\"string\\" ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
+        && typeof v[\\"@value\\"] === \\"string\\"
+        && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value.push(decoded);
@@ -26305,7 +26320,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
-        && typeof v[\\"@value\\"] === \\"string\\" ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
+        && typeof v[\\"@value\\"] === \\"string\\"
+        && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
@@ -44540,7 +44556,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
-        && typeof v[\\"@value\\"] === \\"string\\" ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
+        && typeof v[\\"@value\\"] === \\"string\\"
+        && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
@@ -46981,7 +46998,8 @@ get names(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
-        && typeof v[\\"@value\\"] === \\"string\\" ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
+        && typeof v[\\"@value\\"] === \\"string\\"
+        && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
@@ -58080,7 +58098,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
-        && typeof v[\\"@value\\"] === \\"string\\" ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
+        && typeof v[\\"@value\\"] === \\"string\\"
+        && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
@@ -65007,7 +65026,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
-        && typeof v[\\"@value\\"] === \\"string\\" ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
+        && typeof v[\\"@value\\"] === \\"string\\"
+        && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
@@ -77269,7 +77289,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
-        && typeof v[\\"@value\\"] === \\"string\\" ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
+        && typeof v[\\"@value\\"] === \\"string\\"
+        && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
@@ -78887,7 +78908,8 @@ get contents(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
-        && typeof v[\\"@value\\"] === \\"string\\" ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
+        && typeof v[\\"@value\\"] === \\"string\\"
+        && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
@@ -50,6 +50,7 @@ export class Object {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -78,6 +79,14 @@ export class Object {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -9400,6 +9409,8 @@ get urls(): ((URL | Link))[] {
       options,
     );
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _49BipA5dq9eoH8LX8xdsVumveTca_attachment: (Object | Link | PropertyValue | URL)[] = [];
       const _trust_49BipA5dq9eoH8LX8xdsVumveTca_attachment: Set<number> = new Set();
     
@@ -9441,7 +9452,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _49BipA5dq9eoH8LX8xdsVumveTca_attachment.push(decoded);
       
     }
@@ -9494,7 +9508,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo.push(decoded);
       
     }
@@ -9549,7 +9566,10 @@ get urls(): ((URL | Link))[] {
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
       
     }
@@ -9592,7 +9612,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3mhZzGXSpQ431mBSz2kvych22v4e_context.push(decoded);
       
     }
@@ -9617,7 +9640,10 @@ get urls(): ((URL | Link))[] {
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
       
     }
@@ -9679,7 +9705,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _86xFhmgBapoMvYqjbjRuDPayTrS_generator.push(decoded);
       
     }
@@ -9782,7 +9811,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo.push(decoded);
       
     }
@@ -9825,7 +9857,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _31k5MUZJsnsPNg8dQQJieWaXTFnR_location.push(decoded);
       
     }
@@ -9868,7 +9903,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(decoded);
       
     }
@@ -10051,7 +10089,10 @@ get urls(): ((URL | Link))[] {
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _4LqirZspQbFWWQEbFcXAxm7tTDN1_summary.push(decoded);
       
     }
@@ -10094,7 +10135,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _5chuqj6s95p5gg2sk1HntGfarRf_tag.push(decoded);
       
     }
@@ -10156,7 +10200,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2oPEH9MQ3aj8JVwyYuWkqoVwV865_url.push(decoded);
       
     }
@@ -10375,7 +10422,11 @@ get urls(): ((URL | Link))[] {
     }
     instance.#_42rPnotok1ivQ2RNCKNbeFJgx8b8_proof = _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -11471,7 +11522,13 @@ proofs?: (DataIntegrityProof | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -11907,7 +11964,9 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
     if (!(instance instanceof ChatMessage)) {
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
-    const _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl: (URL)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl: (URL)[] = [];
 
     let _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl__array = values[\\"https://www.w3.org/ns/activitystreams#quoteUrl\\"];
     
@@ -11931,7 +11990,11 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
     }
     instance.#_K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl = _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -14928,6 +14991,8 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor: (Application | Group | Organization | Person | Service | URL)[] = [];
       const _trust_2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor: Set<number> = new Set();
     
@@ -14975,7 +15040,10 @@ instruments?: (Object | URL)[];}
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor.push(decoded);
       
     }
@@ -15131,7 +15199,11 @@ instruments?: (Object | URL)[];}
     }
     instance.#_3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument = _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -15620,7 +15692,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -15675,6 +15753,7 @@ export class PropertyValue {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -15703,6 +15782,14 @@ export class PropertyValue {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -16117,7 +16204,9 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
       { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
-    const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
 
     let _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name__array = values[\\"https://www.w3.org/ns/activitystreams#name\\"];
     
@@ -16137,7 +16226,10 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
       
     }
@@ -16162,13 +16254,20 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value.push(decoded);
       
     }
     instance.#_2cSy2magg4iZ7zLaG8U7DiJMoCkx_value = _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -16282,6 +16381,7 @@ export class DidService {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -16310,6 +16410,14 @@ export class DidService {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -16666,7 +16774,9 @@ get endpoints(): (URL)[] {
       { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
-    const _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint: (URL)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint: (URL)[] = [];
 
     let _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint__array = values[\\"https://www.w3.org/ns/did#serviceEndpoint\\"];
     
@@ -16697,7 +16807,11 @@ get endpoints(): (URL)[] {
     }
     instance.#_2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint = _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -17018,7 +17132,13 @@ endpoints?: (URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -17075,6 +17195,7 @@ export class DataIntegrityProof {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -17103,6 +17224,14 @@ export class DataIntegrityProof {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -17830,7 +17959,9 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
       { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
-    const _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite: (\\"eddsa-jcs-2022\\")[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite: (\\"eddsa-jcs-2022\\")[] = [];
 
     let _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite__array = values[\\"https://w3id.org/security#cryptosuite\\"];
     
@@ -17925,7 +18056,11 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
     }
     instance.#_3qzP3ukEZoUziK5FEiA1RhU4aqac = _3qzP3ukEZoUziK5FEiA1RhU4aqac;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -18095,6 +18230,7 @@ export class CryptographicKey {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -18123,6 +18259,14 @@ export class CryptographicKey {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -18781,6 +18925,8 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       options,
     );
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner: (Application | Group | Organization | Person | Service | URL)[] = [];
       const _trust_5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner: Set<number> = new Set();
     
@@ -18828,7 +18974,10 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner.push(decoded);
       
     }
@@ -18849,7 +18998,11 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
     }
     instance.#_2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem = _2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -18963,6 +19116,7 @@ export class Multikey {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -18991,6 +19145,14 @@ export class Multikey {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -19656,6 +19818,8 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       options,
     );
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller: (Application | Group | Organization | Person | Service | URL)[] = [];
       const _trust_2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller: Set<number> = new Set();
     
@@ -19703,7 +19867,10 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller.push(decoded);
       
     }
@@ -19724,7 +19891,11 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
     }
     instance.#_4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase = _4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -20118,7 +20289,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -20454,7 +20631,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -20789,7 +20972,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -26301,7 +26490,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
     if (!(instance instanceof Application)) {
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
-    const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
 
     let _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername__array = values[\\"https://www.w3.org/ns/activitystreams#preferredUsername\\"];
     
@@ -26321,7 +26512,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
     }
@@ -26437,7 +26631,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
     }
@@ -26478,7 +26675,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
     }
@@ -26789,7 +26989,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
     }
@@ -26842,7 +27045,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
     }
@@ -26908,7 +27114,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -27727,7 +27937,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -28062,7 +28278,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -28493,7 +28715,9 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
     if (!(instance instanceof Article)) {
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
-    const _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl: (URL)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl: (URL)[] = [];
 
     let _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl__array = values[\\"https://www.w3.org/ns/activitystreams#quoteUrl\\"];
     
@@ -28517,7 +28741,11 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
     }
     instance.#_K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl = _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -29041,7 +29269,9 @@ proofs?: (DataIntegrityProof | URL)[];width?: number | null;height?: number | nu
     if (!(instance instanceof Document)) {
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
-    const _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width: (number)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width: (number)[] = [];
 
     let _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width__array = values[\\"https://www.w3.org/ns/activitystreams#width\\"];
     
@@ -29072,7 +29302,11 @@ proofs?: (DataIntegrityProof | URL)[];width?: number | null;height?: number | nu
     }
     instance.#_2cGKFeFJMmiNpGZFEF75mCwFQsKb_height = _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -29449,7 +29683,13 @@ proofs?: (DataIntegrityProof | URL)[];width?: number | null;height?: number | nu
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -29787,7 +30027,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -30123,7 +30369,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -33933,7 +34185,9 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
     if (!(instance instanceof Collection)) {
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
-    const _XDbmNDuWHmrhqH712zqtecdbv1V_totalItems: (number)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _XDbmNDuWHmrhqH712zqtecdbv1V_totalItems: (number)[] = [];
 
     let _XDbmNDuWHmrhqH712zqtecdbv1V_totalItems__array = values[\\"https://www.w3.org/ns/activitystreams#totalItems\\"];
     
@@ -34076,7 +34330,10 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
       
     }
@@ -34322,7 +34579,11 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
     }
     instance.#_2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf = _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -35765,6 +36026,8 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf: (Collection | URL)[] = [];
       const _trust_2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf: Set<number> = new Set();
     
@@ -35855,7 +36118,11 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
     }
     instance.#_3b8yG8tDNzQFFEnWhCc13G8eHooA_prev = _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -36247,7 +36514,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -36581,7 +36854,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -36913,7 +37192,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -36968,6 +37253,7 @@ export class Endpoints {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -36996,6 +37282,14 @@ export class Endpoints {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -37701,7 +37995,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
       { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
-    const _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl: (URL)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl: (URL)[] = [];
 
     let _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl__array = values[\\"https://www.w3.org/ns/activitystreams#proxyUrl\\"];
     
@@ -37882,7 +38178,11 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
     }
     instance.#_3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox = _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -38354,7 +38654,13 @@ proofs?: (DataIntegrityProof | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -38689,7 +38995,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -39025,7 +39337,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -44537,7 +44855,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
     if (!(instance instanceof Group)) {
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
-    const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
 
     let _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername__array = values[\\"https://www.w3.org/ns/activitystreams#preferredUsername\\"];
     
@@ -44557,7 +44877,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
     }
@@ -44673,7 +44996,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
     }
@@ -44714,7 +45040,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
     }
@@ -45025,7 +45354,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
     }
@@ -45078,7 +45410,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
     }
@@ -45144,7 +45479,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -45679,6 +46018,7 @@ export class Link {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -45707,6 +46047,14 @@ export class Link {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -46919,7 +47267,9 @@ get names(): ((string | LanguageString))[] {
       { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
-    const _pVjLsybKQdmkjuU7MHjiVmNnuj7_href: (URL)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _pVjLsybKQdmkjuU7MHjiVmNnuj7_href: (URL)[] = [];
 
     let _pVjLsybKQdmkjuU7MHjiVmNnuj7_href__array = values[\\"https://www.w3.org/ns/activitystreams#href\\"];
     
@@ -46999,7 +47349,10 @@ get names(): ((string | LanguageString))[] {
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
       
     }
@@ -47087,13 +47440,20 @@ get names(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(decoded);
       
     }
     instance.#_gCVTegXxWWCw6wWRxa1QF65zusg_preview = _gCVTegXxWWCw6wWRxa1QF65zusg_preview;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -47583,7 +47943,13 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -47920,7 +48286,13 @@ proofs?: (DataIntegrityProof | URL)[];width?: number | null;height?: number | nu
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -48259,7 +48631,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -48593,7 +48971,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -48927,7 +49311,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -49261,7 +49651,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -49595,7 +49991,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -49927,7 +50329,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -50225,7 +50633,13 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -50560,7 +50974,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -50993,7 +51413,9 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
     if (!(instance instanceof Note)) {
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
-    const _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl: (URL)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl: (URL)[] = [];
 
     let _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl__array = values[\\"https://www.w3.org/ns/activitystreams#quoteUrl\\"];
     
@@ -51017,7 +51439,11 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
     }
     instance.#_K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl = _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -51681,6 +52107,8 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items: (Object | Link | URL)[] = [];
       const _trust_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items: Set<number> = new Set();
     
@@ -51718,13 +52146,20 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
       
     }
     instance.#_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items = _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -52467,6 +52902,8 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items: (Object | Link | URL)[] = [];
       const _trust_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items: Set<number> = new Set();
     
@@ -52504,7 +52941,10 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
       
     }
@@ -52525,7 +52965,11 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
     }
     instance.#_2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex = _2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -58079,7 +58523,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
     if (!(instance instanceof Organization)) {
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
-    const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
 
     let _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername__array = values[\\"https://www.w3.org/ns/activitystreams#preferredUsername\\"];
     
@@ -58099,7 +58545,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
     }
@@ -58215,7 +58664,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
     }
@@ -58256,7 +58708,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
     }
@@ -58567,7 +59022,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
     }
@@ -58620,7 +59078,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
     }
@@ -58686,7 +59147,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -59495,7 +59960,13 @@ proofs?: (DataIntegrityProof | URL)[];width?: number | null;height?: number | nu
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -65007,7 +65478,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
     if (!(instance instanceof Person)) {
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
-    const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
 
     let _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername__array = values[\\"https://www.w3.org/ns/activitystreams#preferredUsername\\"];
     
@@ -65027,7 +65500,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
     }
@@ -65143,7 +65619,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
     }
@@ -65184,7 +65663,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
     }
@@ -65495,7 +65977,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
     }
@@ -65548,7 +66033,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
     }
@@ -65614,7 +66102,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -66878,7 +67370,9 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
     if (!(instance instanceof Place)) {
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
-    const _3UCsHnBHvDAXJnBuzw3zw1VVs3Ne_accuracy: (number)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _3UCsHnBHvDAXJnBuzw3zw1VVs3Ne_accuracy: (number)[] = [];
 
     let _3UCsHnBHvDAXJnBuzw3zw1VVs3Ne_accuracy__array = values[\\"https://www.w3.org/ns/activitystreams#accuracy\\"];
     
@@ -66987,13 +67481,20 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
       
     }
     instance.#_oKrwxU4V8wiKhMW1QEYQibcJh8c_units = _oKrwxU4V8wiKhMW1QEYQibcJh8c_units;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -67735,6 +68236,8 @@ proofs?: (DataIntegrityProof | URL)[];describes?: Object | URL | null;}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes: (Object | URL)[] = [];
       const _trust_3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes: Set<number> = new Set();
     
@@ -67765,7 +68268,11 @@ proofs?: (DataIntegrityProof | URL)[];describes?: Object | URL | null;}
     }
     instance.#_3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes = _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -68866,6 +69373,8 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf: (Object | URL)[] = [];
       const _trust_2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf: Set<number> = new Set();
     
@@ -68951,7 +69460,10 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       ) : typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"boolean\\" ? v[\\"@value\\"] : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3KronwL8DiiKBRcJFKQPiEHm8xb6_closed.push(decoded);
       
     }
@@ -68995,7 +69507,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
     }
     instance.#_K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl = _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -69432,7 +69948,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -69770,7 +70292,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -71262,6 +71790,8 @@ relationships?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject: (Object | URL)[] = [];
       const _trust_2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject: Set<number> = new Set();
     
@@ -71352,7 +71882,11 @@ relationships?: (Object | URL)[];}
     }
     instance.#_4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship = _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -71758,7 +72292,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -77270,7 +77810,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
     if (!(instance instanceof Service)) {
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
-    const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
 
     let _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername__array = values[\\"https://www.w3.org/ns/activitystreams#preferredUsername\\"];
     
@@ -77290,7 +77832,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
     }
@@ -77406,7 +77951,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
     }
@@ -77447,7 +77995,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
     }
@@ -77758,7 +78309,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
     }
@@ -77811,7 +78365,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
     }
@@ -77877,7 +78434,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -78404,6 +78965,7 @@ export class Source {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -78432,6 +78994,14 @@ export class Source {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -78889,7 +79459,9 @@ get contents(): ((string | LanguageString))[] {
       { id: \\"@id\\" in values ? new URL(values[\\"@id\\"] as string) : undefined },
       options,
     );
-    const _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content: ((string | LanguageString))[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content: ((string | LanguageString))[] = [];
 
     let _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content__array = values[\\"https://www.w3.org/ns/activitystreams#content\\"];
     
@@ -78909,7 +79481,10 @@ get contents(): ((string | LanguageString))[] {
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
-      if (typeof decoded === \\"undefined\\") continue;
+      if (typeof decoded === \\"undefined\\") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
       
     }
@@ -78930,7 +79505,11 @@ get contents(): ((string | LanguageString))[] {
     }
     instance.#_3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType = _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -79325,7 +79904,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -79659,7 +80244,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -80074,7 +80665,9 @@ proofs?: (DataIntegrityProof | URL)[];deleted?: Temporal.Instant | null;}
     if (!(instance instanceof Tombstone)) {
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
-    const _8g8g4LiVMhFTXskuDEqx4ascxUr_deleted: (Temporal.Instant)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _8g8g4LiVMhFTXskuDEqx4ascxUr_deleted: (Temporal.Instant)[] = [];
 
     let _8g8g4LiVMhFTXskuDEqx4ascxUr_deleted__array = values[\\"https://www.w3.org/ns/activitystreams#deleted\\"];
     
@@ -80094,7 +80687,11 @@ proofs?: (DataIntegrityProof | URL)[];deleted?: Temporal.Instant | null;}
     }
     instance.#_8g8g4LiVMhFTXskuDEqx4ascxUr_deleted = _8g8g4LiVMhFTXskuDEqx4ascxUr_deleted;
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -80450,7 +81047,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -80789,7 +81392,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -81126,7 +81735,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -81463,7 +82078,13 @@ proofs?: (DataIntegrityProof | URL)[];width?: number | null;height?: number | nu
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -81796,7 +82417,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError(\\"Unexpected type: \\" + instance.constructor.name);
     }
     
-    if (!(\\"_fromSubclass\\" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!(\\"_fromSubclass\\" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
@@ -21,6 +21,16 @@ import {
     isTemporalInstant,
 } from \\"@fedify/vocab-runtime/temporal\\";
 
+function isValidLanguageTag(language: string): boolean {
+  try {
+    new Intl.Locale(language);
+    return true;
+  } catch (error) {
+    if (error instanceof RangeError) return false;
+    throw error;
+  }
+}
+
 
 /** Describes an object of any kind. The Object type serves as the base type for
  * most of the other kinds of objects defined in the Activity Vocabulary,
@@ -9536,7 +9546,8 @@ get urls(): ((URL | Link))[] {
       typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
-        && typeof v[\\"@value\\"] === \\"string\\" ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
+        && typeof v[\\"@value\\"] === \\"string\\"
+        && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
@@ -9603,7 +9614,8 @@ get urls(): ((URL | Link))[] {
       typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
-        && typeof v[\\"@value\\"] === \\"string\\" ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
+        && typeof v[\\"@value\\"] === \\"string\\"
+        && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
@@ -10036,7 +10048,8 @@ get urls(): ((URL | Link))[] {
       typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
-        && typeof v[\\"@value\\"] === \\"string\\" ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
+        && typeof v[\\"@value\\"] === \\"string\\"
+        && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _4LqirZspQbFWWQEbFcXAxm7tTDN1_summary.push(decoded);
@@ -16121,7 +16134,8 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
       typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
-        && typeof v[\\"@value\\"] === \\"string\\" ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
+        && typeof v[\\"@value\\"] === \\"string\\"
+        && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
@@ -16145,7 +16159,8 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
       typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
-        && typeof v[\\"@value\\"] === \\"string\\" ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
+        && typeof v[\\"@value\\"] === \\"string\\"
+        && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value.push(decoded);
@@ -26303,7 +26318,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
-        && typeof v[\\"@value\\"] === \\"string\\" ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
+        && typeof v[\\"@value\\"] === \\"string\\"
+        && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
@@ -44538,7 +44554,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
-        && typeof v[\\"@value\\"] === \\"string\\" ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
+        && typeof v[\\"@value\\"] === \\"string\\"
+        && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
@@ -46979,7 +46996,8 @@ get names(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
-        && typeof v[\\"@value\\"] === \\"string\\" ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
+        && typeof v[\\"@value\\"] === \\"string\\"
+        && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
@@ -58078,7 +58096,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
-        && typeof v[\\"@value\\"] === \\"string\\" ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
+        && typeof v[\\"@value\\"] === \\"string\\"
+        && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
@@ -65005,7 +65024,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
-        && typeof v[\\"@value\\"] === \\"string\\" ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
+        && typeof v[\\"@value\\"] === \\"string\\"
+        && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
@@ -77267,7 +77287,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
-        && typeof v[\\"@value\\"] === \\"string\\" ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
+        && typeof v[\\"@value\\"] === \\"string\\"
+        && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
@@ -78885,7 +78906,8 @@ get contents(): ((string | LanguageString))[] {
       typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
-        && typeof v[\\"@value\\"] === \\"string\\" ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
+        && typeof v[\\"@value\\"] === \\"string\\"
+        && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
       if (typeof decoded === \\"undefined\\") continue;
       _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.node.snap
@@ -88,6 +88,12 @@ export class Object {
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
     }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== \\"object\\") return true;
+      if (!(\\"_shouldCacheJsonLd\\" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
+    }
     
     /**
      * The type URI of {@link Object}: \`https://www.w3.org/ns/activitystreams#Object\`.
@@ -9436,7 +9442,7 @@ get urls(): ((URL | Link))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -9452,12 +9458,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _49BipA5dq9eoH8LX8xdsVumveTca_attachment.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _49BipA5dq9eoH8LX8xdsVumveTca_attachment.push(decoded);
+    
     }
     instance.#_49BipA5dq9eoH8LX8xdsVumveTca_attachment = _49BipA5dq9eoH8LX8xdsVumveTca_attachment;
     
@@ -9486,7 +9497,7 @@ get urls(): ((URL | Link))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -9508,12 +9519,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo.push(decoded);
+    
     }
     instance.#_42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo = _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo;
     
@@ -9540,10 +9556,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
+    
     }
     instance.#_3ocC3VVi88cEd5sPWL8djkZsvTN6_audience = _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience;
     const _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content: ((string | LanguageString))[] = [];
@@ -9560,18 +9585,23 @@ get urls(): ((URL | Link))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
+    
     }
     instance.#_4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content = _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content;
     
@@ -9600,7 +9630,7 @@ get urls(): ((URL | Link))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -9612,12 +9642,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3mhZzGXSpQ431mBSz2kvych22v4e_context.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3mhZzGXSpQ431mBSz2kvych22v4e_context.push(decoded);
+    
     }
     instance.#_3mhZzGXSpQ431mBSz2kvych22v4e_context = _3mhZzGXSpQ431mBSz2kvych22v4e_context;
     const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
@@ -9634,18 +9669,23 @@ get urls(): ((URL | Link))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
+    
     }
     instance.#_4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name = _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name;
     const _219RwDanjScTv5tYCjwGZVCM7KZ9_endTime: (Temporal.Instant)[] = [];
@@ -9660,11 +9700,20 @@ get urls(): ((URL | Link))[] {
         : _219RwDanjScTv5tYCjwGZVCM7KZ9_endTime__array
     ) {
       if (v == null) continue;
-    _219RwDanjScTv5tYCjwGZVCM7KZ9_endTime.push(Temporal.Instant.from(
+    
+      const decoded =
+    Temporal.Instant.from(
         v[\\"@value\\"].substring(19).match(/[Z+-]/)
           ? v[\\"@value\\"]
           : v[\\"@value\\"] + \\"Z\\"
-      ))
+      )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _219RwDanjScTv5tYCjwGZVCM7KZ9_endTime.push(decoded);
+    
     }
     instance.#_219RwDanjScTv5tYCjwGZVCM7KZ9_endTime = _219RwDanjScTv5tYCjwGZVCM7KZ9_endTime;
     
@@ -9693,7 +9742,7 @@ get urls(): ((URL | Link))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -9705,12 +9754,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _86xFhmgBapoMvYqjbjRuDPayTrS_generator.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _86xFhmgBapoMvYqjbjRuDPayTrS_generator.push(decoded);
+    
     }
     instance.#_86xFhmgBapoMvYqjbjRuDPayTrS_generator = _86xFhmgBapoMvYqjbjRuDPayTrS_generator;
     
@@ -9737,10 +9791,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(await Image.fromJsonLd(
+      
+      const decoded =
+    await Image.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
+    
     }
     instance.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon;
     
@@ -9767,10 +9830,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(await Image.fromJsonLd(
+      
+      const decoded =
+    await Image.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
+    
     }
     instance.#_3dXrUdkARxwyJLtJcYi1AJ92H41U_image = _3dXrUdkARxwyJLtJcYi1AJ92H41U_image;
     
@@ -9799,7 +9871,7 @@ get urls(): ((URL | Link))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -9811,12 +9883,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo.push(decoded);
+    
     }
     instance.#_3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo = _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo;
     
@@ -9845,7 +9922,7 @@ get urls(): ((URL | Link))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -9857,12 +9934,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _31k5MUZJsnsPNg8dQQJieWaXTFnR_location.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _31k5MUZJsnsPNg8dQQJieWaXTFnR_location.push(decoded);
+    
     }
     instance.#_31k5MUZJsnsPNg8dQQJieWaXTFnR_location = _31k5MUZJsnsPNg8dQQJieWaXTFnR_location;
     
@@ -9891,7 +9973,7 @@ get urls(): ((URL | Link))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
@@ -9903,12 +9985,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(decoded);
+    
     }
     instance.#_gCVTegXxWWCw6wWRxa1QF65zusg_preview = _gCVTegXxWWCw6wWRxa1QF65zusg_preview;
     const _5e258TDXtuhaFRPZiGoDfEpjdMr_published: (Temporal.Instant)[] = [];
@@ -9923,11 +10010,20 @@ get urls(): ((URL | Link))[] {
         : _5e258TDXtuhaFRPZiGoDfEpjdMr_published__array
     ) {
       if (v == null) continue;
-    _5e258TDXtuhaFRPZiGoDfEpjdMr_published.push(Temporal.Instant.from(
+    
+      const decoded =
+    Temporal.Instant.from(
         v[\\"@value\\"].substring(19).match(/[Z+-]/)
           ? v[\\"@value\\"]
           : v[\\"@value\\"] + \\"Z\\"
-      ))
+      )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _5e258TDXtuhaFRPZiGoDfEpjdMr_published.push(decoded);
+    
     }
     instance.#_5e258TDXtuhaFRPZiGoDfEpjdMr_published = _5e258TDXtuhaFRPZiGoDfEpjdMr_published;
     
@@ -9954,10 +10050,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _7UpwM3JWcXhADcscukEehBorf6k_replies.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
+    
     }
     instance.#_7UpwM3JWcXhADcscukEehBorf6k_replies = _7UpwM3JWcXhADcscukEehBorf6k_replies;
     
@@ -9984,10 +10089,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
+    
     }
     instance.#_3kAfck9PcEYt2L7xug5y99YPbANs_shares = _3kAfck9PcEYt2L7xug5y99YPbANs_shares;
     
@@ -10014,10 +10128,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
+    
     }
     instance.#_S3ceDnpMdzoTRCccB9FkJWrEzYW_likes = _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes;
     
@@ -10044,10 +10167,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
+    
     }
     instance.#_kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions = _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions;
     const _2w3Jmue4up8iVDUA51WZqomEF438_startTime: (Temporal.Instant)[] = [];
@@ -10062,11 +10194,20 @@ get urls(): ((URL | Link))[] {
         : _2w3Jmue4up8iVDUA51WZqomEF438_startTime__array
     ) {
       if (v == null) continue;
-    _2w3Jmue4up8iVDUA51WZqomEF438_startTime.push(Temporal.Instant.from(
+    
+      const decoded =
+    Temporal.Instant.from(
         v[\\"@value\\"].substring(19).match(/[Z+-]/)
           ? v[\\"@value\\"]
           : v[\\"@value\\"] + \\"Z\\"
-      ))
+      )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2w3Jmue4up8iVDUA51WZqomEF438_startTime.push(decoded);
+    
     }
     instance.#_2w3Jmue4up8iVDUA51WZqomEF438_startTime = _2w3Jmue4up8iVDUA51WZqomEF438_startTime;
     const _4LqirZspQbFWWQEbFcXAxm7tTDN1_summary: ((string | LanguageString))[] = [];
@@ -10083,18 +10224,23 @@ get urls(): ((URL | Link))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _4LqirZspQbFWWQEbFcXAxm7tTDN1_summary.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4LqirZspQbFWWQEbFcXAxm7tTDN1_summary.push(decoded);
+    
     }
     instance.#_4LqirZspQbFWWQEbFcXAxm7tTDN1_summary = _4LqirZspQbFWWQEbFcXAxm7tTDN1_summary;
     
@@ -10123,7 +10269,7 @@ get urls(): ((URL | Link))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -10135,12 +10281,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _5chuqj6s95p5gg2sk1HntGfarRf_tag.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _5chuqj6s95p5gg2sk1HntGfarRf_tag.push(decoded);
+    
     }
     instance.#_5chuqj6s95p5gg2sk1HntGfarRf_tag = _5chuqj6s95p5gg2sk1HntGfarRf_tag;
     const _385aB7ySixcf5Un6z3VsWmThgCzQ_updated: (Temporal.Instant)[] = [];
@@ -10155,11 +10306,20 @@ get urls(): ((URL | Link))[] {
         : _385aB7ySixcf5Un6z3VsWmThgCzQ_updated__array
     ) {
       if (v == null) continue;
-    _385aB7ySixcf5Un6z3VsWmThgCzQ_updated.push(Temporal.Instant.from(
+    
+      const decoded =
+    Temporal.Instant.from(
         v[\\"@value\\"].substring(19).match(/[Z+-]/)
           ? v[\\"@value\\"]
           : v[\\"@value\\"] + \\"Z\\"
-      ))
+      )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _385aB7ySixcf5Un6z3VsWmThgCzQ_updated.push(decoded);
+    
     }
     instance.#_385aB7ySixcf5Un6z3VsWmThgCzQ_updated = _385aB7ySixcf5Un6z3VsWmThgCzQ_updated;
     const _2oPEH9MQ3aj8JVwyYuWkqoVwV865_url: ((URL | Link))[] = [];
@@ -10176,7 +10336,7 @@ get urls(): ((URL | Link))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@id\\" in v
+    typeof v === \\"object\\" && \\"@id\\" in v
         && typeof v[\\"@id\\"] === \\"string\\"
         && v[\\"@id\\"] !== \\"\\" ? v[\\"@id\\"].startsWith(\\"at://\\")
         ? new URL(\\"at://\\" +
@@ -10200,12 +10360,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2oPEH9MQ3aj8JVwyYuWkqoVwV865_url.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2oPEH9MQ3aj8JVwyYuWkqoVwV865_url.push(decoded);
+    
     }
     instance.#_2oPEH9MQ3aj8JVwyYuWkqoVwV865_url = _2oPEH9MQ3aj8JVwyYuWkqoVwV865_url;
     
@@ -10232,10 +10397,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
+    
     }
     instance.#_3hFbw7DTpHhq3cvVhkY8njhcsXbd_to = _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to;
     
@@ -10262,10 +10436,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
+    
     }
     instance.#_aLZupjwL8XB7tzdLgCMXdjZ6qej_bto = _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto;
     
@@ -10292,10 +10475,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
+    
     }
     instance.#_42a1SvBs24QSLzKcfjCyNTjW5a1g_cc = _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc;
     
@@ -10322,10 +10514,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
+    
     }
     instance.#_3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc = _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc;
     const _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType: (string)[] = [];
@@ -10340,7 +10541,16 @@ get urls(): ((URL | Link))[] {
         : _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType__array
     ) {
       if (v == null) continue;
-    _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType.push(decoded);
+    
     }
     instance.#_3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType = _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType;
     const _3bNvLMBN1bCJETiTihM3wvi1B2JX_duration: (Temporal.Duration)[] = [];
@@ -10355,7 +10565,16 @@ get urls(): ((URL | Link))[] {
         : _3bNvLMBN1bCJETiTihM3wvi1B2JX_duration__array
     ) {
       if (v == null) continue;
-    _3bNvLMBN1bCJETiTihM3wvi1B2JX_duration.push(Temporal.Duration.from(v[\\"@value\\"]))
+    
+      const decoded =
+    Temporal.Duration.from(v[\\"@value\\"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3bNvLMBN1bCJETiTihM3wvi1B2JX_duration.push(decoded);
+    
     }
     instance.#_3bNvLMBN1bCJETiTihM3wvi1B2JX_duration = _3bNvLMBN1bCJETiTihM3wvi1B2JX_duration;
     const _u8gdcDTtChQ4tbSQMXc4cYWyum7_sensitive: (boolean)[] = [];
@@ -10370,7 +10589,16 @@ get urls(): ((URL | Link))[] {
         : _u8gdcDTtChQ4tbSQMXc4cYWyum7_sensitive__array
     ) {
       if (v == null) continue;
-    _u8gdcDTtChQ4tbSQMXc4cYWyum7_sensitive.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _u8gdcDTtChQ4tbSQMXc4cYWyum7_sensitive.push(decoded);
+    
     }
     instance.#_u8gdcDTtChQ4tbSQMXc4cYWyum7_sensitive = _u8gdcDTtChQ4tbSQMXc4cYWyum7_sensitive;
     const _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source: (Source)[] = [];
@@ -10385,10 +10613,19 @@ get urls(): ((URL | Link))[] {
         : _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source__array
     ) {
       if (v == null) continue;
-    _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(await Source.fromJsonLd(
+    
+      const decoded =
+    await Source.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
+    
     }
     instance.#_2ZwCFoS787v8y8bXKjMoE6MAbrEB_source = _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source;
     
@@ -10415,10 +10652,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(await DataIntegrityProof.fromJsonLd(
+      
+      const decoded =
+    await DataIntegrityProof.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
+    
     }
     instance.#_42rPnotok1ivQ2RNCKNbeFJgx8b8_proof = _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof;
     
@@ -11986,7 +12232,16 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
         : _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl__array
     ) {
       if (v == null) continue;
-    _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl.push(new URL(v[\\"@value\\"]))
+    
+      const decoded =
+    new URL(v[\\"@value\\"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl.push(decoded);
+    
     }
     instance.#_K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl = _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl;
     
@@ -15018,7 +15273,7 @@ instruments?: (Object | URL)[];}
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -15040,12 +15295,17 @@ instruments?: (Object | URL)[];}
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor.push(decoded);
+    
     }
     instance.#_2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor = _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor;
     
@@ -15072,10 +15332,19 @@ instruments?: (Object | URL)[];}
         );
         continue;
       }
-      _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
+    
     }
     instance.#_2MH19yxjn1wnHsNfa5n4JBhJzxyc_object = _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object;
     
@@ -15102,10 +15371,19 @@ instruments?: (Object | URL)[];}
         );
         continue;
       }
-      _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
+    
     }
     instance.#_3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target = _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target;
     
@@ -15132,10 +15410,19 @@ instruments?: (Object | URL)[];}
         );
         continue;
       }
-      _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
+    
     }
     instance.#_u4QGFbRFcYmPEKGbPv1hpBR9r5G_result = _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result;
     
@@ -15162,10 +15449,19 @@ instruments?: (Object | URL)[];}
         );
         continue;
       }
-      _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
+    
     }
     instance.#_25zu2s3VxVujgEKqrDycjE284XQR_origin = _25zu2s3VxVujgEKqrDycjE284XQR_origin;
     
@@ -15192,10 +15488,19 @@ instruments?: (Object | URL)[];}
         );
         continue;
       }
-      _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
+    
     }
     instance.#_3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument = _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument;
     
@@ -15791,6 +16096,12 @@ export class PropertyValue {
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
     }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== \\"object\\") return true;
+      if (!(\\"_shouldCacheJsonLd\\" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
+    }
     
     /**
      * The type URI of {@link PropertyValue}: \`http://schema.org#PropertyValue\`.
@@ -16220,18 +16531,23 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
+    
     }
     instance.#_4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name = _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name;
     const _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value: ((string | LanguageString))[] = [];
@@ -16248,18 +16564,23 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value.push(decoded);
+    
     }
     instance.#_2cSy2magg4iZ7zLaG8U7DiJMoCkx_value = _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value;
     
@@ -16418,6 +16739,12 @@ export class DidService {
 
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
+    }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== \\"object\\") return true;
+      if (!(\\"_shouldCacheJsonLd\\" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
     }
     
     /**
@@ -16788,7 +17115,9 @@ get endpoints(): (URL)[] {
         : _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint__array
     ) {
       if (v == null) continue;
-    _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(v[\\"@id\\"].startsWith(\\"at://\\")
+    
+      const decoded =
+    v[\\"@id\\"].startsWith(\\"at://\\")
         ? new URL(\\"at://\\" +
           encodeURIComponent(
             v[\\"@id\\"].includes(\\"/\\", 5)
@@ -16803,7 +17132,14 @@ get endpoints(): (URL)[] {
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))))
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])))
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
+    
     }
     instance.#_2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint = _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint;
     
@@ -17232,6 +17568,12 @@ export class DataIntegrityProof {
 
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
+    }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== \\"object\\") return true;
+      if (!(\\"_shouldCacheJsonLd\\" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
     }
     
     /**
@@ -17973,7 +18315,16 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         : _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite__array
     ) {
       if (v == null) continue;
-    _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite.push(decoded);
+    
     }
     instance.#_3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite = _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite;
     
@@ -18000,10 +18351,19 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         );
         continue;
       }
-      _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(await Multikey.fromJsonLd(
+      
+      const decoded =
+    await Multikey.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
+    
     }
     instance.#_2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod = _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod;
     const _2AeEnPcAvVrPEuKbpmn9ZKNmWHKb_proofPurpose: (\\"assertionMethod\\" | \\"authentication\\" | \\"capabilityInvocation\\" | \\"capabilityDelegation\\" | \\"keyAgreement\\")[] = [];
@@ -18018,7 +18378,16 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         : _2AeEnPcAvVrPEuKbpmn9ZKNmWHKb_proofPurpose__array
     ) {
       if (v == null) continue;
-    _2AeEnPcAvVrPEuKbpmn9ZKNmWHKb_proofPurpose.push(v[\\"@id\\"].substring(26))
+    
+      const decoded =
+    v[\\"@id\\"].substring(26)
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2AeEnPcAvVrPEuKbpmn9ZKNmWHKb_proofPurpose.push(decoded);
+    
     }
     instance.#_2AeEnPcAvVrPEuKbpmn9ZKNmWHKb_proofPurpose = _2AeEnPcAvVrPEuKbpmn9ZKNmWHKb_proofPurpose;
     const _3CjFK5vfKpX4HQuNh2b18TykoVLq_proofValue: (Uint8Array)[] = [];
@@ -18033,7 +18402,16 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         : _3CjFK5vfKpX4HQuNh2b18TykoVLq_proofValue__array
     ) {
       if (v == null) continue;
-    _3CjFK5vfKpX4HQuNh2b18TykoVLq_proofValue.push(decodeMultibase(v[\\"@value\\"]))
+    
+      const decoded =
+    decodeMultibase(v[\\"@value\\"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3CjFK5vfKpX4HQuNh2b18TykoVLq_proofValue.push(decoded);
+    
     }
     instance.#_3CjFK5vfKpX4HQuNh2b18TykoVLq_proofValue = _3CjFK5vfKpX4HQuNh2b18TykoVLq_proofValue;
     const _3qzP3ukEZoUziK5FEiA1RhU4aqac: (Temporal.Instant)[] = [];
@@ -18048,11 +18426,20 @@ cryptosuite?: \\"eddsa-jcs-2022\\" | null;verificationMethod?: Multikey | URL | 
         : _3qzP3ukEZoUziK5FEiA1RhU4aqac__array
     ) {
       if (v == null) continue;
-    _3qzP3ukEZoUziK5FEiA1RhU4aqac.push(Temporal.Instant.from(
+    
+      const decoded =
+    Temporal.Instant.from(
         v[\\"@value\\"].substring(19).match(/[Z+-]/)
           ? v[\\"@value\\"]
           : v[\\"@value\\"] + \\"Z\\"
-      ))
+      )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3qzP3ukEZoUziK5FEiA1RhU4aqac.push(decoded);
+    
     }
     instance.#_3qzP3ukEZoUziK5FEiA1RhU4aqac = _3qzP3ukEZoUziK5FEiA1RhU4aqac;
     
@@ -18267,6 +18654,12 @@ export class CryptographicKey {
 
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
+    }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== \\"object\\") return true;
+      if (!(\\"_shouldCacheJsonLd\\" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
     }
     
     /**
@@ -18952,7 +19345,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -18974,12 +19367,17 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner.push(decoded);
+    
     }
     instance.#_5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner = _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner;
     const _2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem: (CryptoKey)[] = [];
@@ -18994,7 +19392,16 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         : _2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem__array
     ) {
       if (v == null) continue;
-    _2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem.push(await importPem(v[\\"@value\\"]))
+    
+      const decoded =
+    await importPem(v[\\"@value\\"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem.push(decoded);
+    
     }
     instance.#_2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem = _2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem;
     
@@ -19153,6 +19560,12 @@ export class Multikey {
 
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
+    }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== \\"object\\") return true;
+      if (!(\\"_shouldCacheJsonLd\\" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
     }
     
     /**
@@ -19845,7 +20258,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -19867,12 +20280,17 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller.push(decoded);
+    
     }
     instance.#_2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller = _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller;
     const _4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase: (CryptoKey)[] = [];
@@ -19887,7 +20305,16 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         : _4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase__array
     ) {
       if (v == null) continue;
-    _4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase.push(await importMultibaseKey(v[\\"@value\\"]))
+    
+      const decoded =
+    await importMultibaseKey(v[\\"@value\\"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase.push(decoded);
+    
     }
     instance.#_4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase = _4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase;
     
@@ -26506,18 +26933,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
+    
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -26544,10 +26976,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(await CryptographicKey.fromJsonLd(
+      
+      const decoded =
+    await CryptographicKey.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
+    
     }
     instance.#_axq166E2eZADq34V4MYUc8KMZdC_publicKey = _axq166E2eZADq34V4MYUc8KMZdC_publicKey;
     
@@ -26574,10 +27015,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(await Multikey.fromJsonLd(
+      
+      const decoded =
+    await Multikey.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
+    
     }
     instance.#_4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod = _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod;
     const _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers: (boolean)[] = [];
@@ -26592,7 +27042,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers__array
     ) {
       if (v == null) continue;
-    _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(decoded);
+    
     }
     instance.#_36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers = _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers;
     
@@ -26621,7 +27080,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -26631,12 +27090,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
+    
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -26665,7 +27129,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -26675,12 +27139,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
+    
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -26707,10 +27176,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
+    
     }
     instance.#_3yAv8jymNfNuJUDuBzJ1NQhdbAee_following = _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following;
     
@@ -26737,10 +27215,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
+    
     }
     instance.#_BBCTgfphhsFzpVfKTykGSpBNwoA_followers = _BBCTgfphhsFzpVfKTykGSpBNwoA_followers;
     
@@ -26767,10 +27254,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
+    
     }
     instance.#_3bgkPwJanyTCoVFM9ovRcus8tKkU_liked = _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked;
     
@@ -26797,10 +27293,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
+    
     }
     instance.#_4N1vBJzXDf8NbBumeECQMFvKetja_featured = _4N1vBJzXDf8NbBumeECQMFvKetja_featured;
     
@@ -26827,10 +27332,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
+    
     }
     instance.#_2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags = _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags;
     
@@ -26857,10 +27371,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
+    
     }
     instance.#_3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams = _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams;
     const _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints: (Endpoints)[] = [];
@@ -26875,10 +27398,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints__array
     ) {
       if (v == null) continue;
-    _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(await Endpoints.fromJsonLd(
+    
+      const decoded =
+    await Endpoints.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
+    
     }
     instance.#_sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints = _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints;
     const _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable: (boolean)[] = [];
@@ -26893,7 +27425,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable__array
     ) {
       if (v == null) continue;
-    _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(decoded);
+    
     }
     instance.#_gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable = _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable;
     const _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended: (boolean)[] = [];
@@ -26908,7 +27449,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended__array
     ) {
       if (v == null) continue;
-    _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(decoded);
+    
     }
     instance.#_2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended = _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended;
     const _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial: (boolean)[] = [];
@@ -26923,7 +27473,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial__array
     ) {
       if (v == null) continue;
-    _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(decoded);
+    
     }
     instance.#_79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial = _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial;
     const _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable: (boolean)[] = [];
@@ -26938,7 +27497,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable__array
     ) {
       if (v == null) continue;
-    _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(decoded);
+    
     }
     instance.#_2diCorzqPGQQqftp6e4SrCEwEnyk_indexable = _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable;
     
@@ -26967,7 +27535,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -26989,12 +27557,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
+    
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -27023,7 +27596,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -27045,12 +27618,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
+    
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -27077,10 +27655,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(await DidService.fromJsonLd(
+      
+      const decoded =
+    await DidService.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
+    
     }
     instance.#_4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service = _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service;
     const _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage: (string)[] = [];
@@ -27095,7 +27682,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage__array
     ) {
       if (v == null) continue;
-    _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(decoded);
+    
     }
     instance.#_QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage = _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage;
     const _2xEU4QtkC53RAun67T81Egqt9vmL_isCat: (boolean)[] = [];
@@ -27110,7 +27706,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2xEU4QtkC53RAun67T81Egqt9vmL_isCat__array
     ) {
       if (v == null) continue;
-    _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(decoded);
+    
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
@@ -28737,7 +29342,16 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
         : _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl__array
     ) {
       if (v == null) continue;
-    _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl.push(new URL(v[\\"@value\\"]))
+    
+      const decoded =
+    new URL(v[\\"@value\\"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl.push(decoded);
+    
     }
     instance.#_K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl = _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl;
     
@@ -29283,7 +29897,16 @@ proofs?: (DataIntegrityProof | URL)[];width?: number | null;height?: number | nu
         : _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width__array
     ) {
       if (v == null) continue;
-    _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width.push(decoded);
+    
     }
     instance.#_2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width = _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width;
     const _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height: (number)[] = [];
@@ -29298,7 +29921,16 @@ proofs?: (DataIntegrityProof | URL)[];width?: number | null;height?: number | nu
         : _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height__array
     ) {
       if (v == null) continue;
-    _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height.push(decoded);
+    
     }
     instance.#_2cGKFeFJMmiNpGZFEF75mCwFQsKb_height = _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height;
     
@@ -34199,7 +34831,16 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         : _XDbmNDuWHmrhqH712zqtecdbv1V_totalItems__array
     ) {
       if (v == null) continue;
-    _XDbmNDuWHmrhqH712zqtecdbv1V_totalItems.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _XDbmNDuWHmrhqH712zqtecdbv1V_totalItems.push(decoded);
+    
     }
     instance.#_XDbmNDuWHmrhqH712zqtecdbv1V_totalItems = _XDbmNDuWHmrhqH712zqtecdbv1V_totalItems;
     
@@ -34226,10 +34867,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(await CollectionPage.fromJsonLd(
+      
+      const decoded =
+    await CollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
+    
     }
     instance.#_3UyUdxnyn6cDn53QKrh4MBiearma_current = _3UyUdxnyn6cDn53QKrh4MBiearma_current;
     
@@ -34256,10 +34906,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(await CollectionPage.fromJsonLd(
+      
+      const decoded =
+    await CollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
+    
     }
     instance.#_J52RqweMe6hhv7RnLJMC8BExTE5_first = _J52RqweMe6hhv7RnLJMC8BExTE5_first;
     
@@ -34286,10 +34945,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(await CollectionPage.fromJsonLd(
+      
+      const decoded =
+    await CollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
+    
     }
     instance.#_gyJJnyEFnuNVi1HFZKfAn3Hfn26_last = _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last;
     
@@ -34318,7 +34986,7 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -34330,12 +34998,17 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
+    
     }
     instance.#_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items = _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items;
     
@@ -34362,10 +35035,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
+    
     }
     instance.#_4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf = _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf;
     
@@ -34392,10 +35074,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
+    
     }
     instance.#_3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf = _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf;
     
@@ -34422,10 +35113,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
+    
     }
     instance.#_3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf = _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf;
     
@@ -34452,10 +35152,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
+    
     }
     instance.#_2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf = _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf;
     
@@ -34482,10 +35191,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
+    
     }
     instance.#_4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf = _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf;
     
@@ -34512,10 +35230,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
+    
     }
     instance.#_41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf = _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf;
     
@@ -34542,10 +35269,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
+    
     }
     instance.#_2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf = _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf;
     
@@ -34572,10 +35308,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
+    
     }
     instance.#_2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf = _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf;
     
@@ -36051,10 +36796,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
+    
     }
     instance.#_2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf = _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf;
     
@@ -36081,10 +36835,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(await CollectionPage.fromJsonLd(
+      
+      const decoded =
+    await CollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
+    
     }
     instance.#_3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next = _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next;
     
@@ -36111,10 +36874,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(await CollectionPage.fromJsonLd(
+      
+      const decoded =
+    await CollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
+    
     }
     instance.#_3b8yG8tDNzQFFEnWhCc13G8eHooA_prev = _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev;
     
@@ -37291,6 +38063,12 @@ export class Endpoints {
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
     }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== \\"object\\") return true;
+      if (!(\\"_shouldCacheJsonLd\\" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
+    }
     
     /**
      * The type URI of {@link Endpoints}: \`https://www.w3.org/ns/activitystreams#Endpoints\`.
@@ -38009,7 +38787,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         : _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl__array
     ) {
       if (v == null) continue;
-    _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(v[\\"@id\\"].startsWith(\\"at://\\")
+    
+      const decoded =
+    v[\\"@id\\"].startsWith(\\"at://\\")
         ? new URL(\\"at://\\" +
           encodeURIComponent(
             v[\\"@id\\"].includes(\\"/\\", 5)
@@ -38024,7 +38804,14 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))))
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])))
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
+    
     }
     instance.#_2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl = _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl;
     const _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint: (URL)[] = [];
@@ -38039,7 +38826,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         : _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint__array
     ) {
       if (v == null) continue;
-    _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(v[\\"@id\\"].startsWith(\\"at://\\")
+    
+      const decoded =
+    v[\\"@id\\"].startsWith(\\"at://\\")
         ? new URL(\\"at://\\" +
           encodeURIComponent(
             v[\\"@id\\"].includes(\\"/\\", 5)
@@ -38054,7 +38843,14 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))))
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])))
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
+    
     }
     instance.#_25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint = _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint;
     const _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint: (URL)[] = [];
@@ -38069,7 +38865,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         : _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint__array
     ) {
       if (v == null) continue;
-    _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(v[\\"@id\\"].startsWith(\\"at://\\")
+    
+      const decoded =
+    v[\\"@id\\"].startsWith(\\"at://\\")
         ? new URL(\\"at://\\" +
           encodeURIComponent(
             v[\\"@id\\"].includes(\\"/\\", 5)
@@ -38084,7 +38882,14 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))))
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])))
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
+    
     }
     instance.#_iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint = _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint;
     const _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey: (URL)[] = [];
@@ -38099,7 +38904,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         : _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey__array
     ) {
       if (v == null) continue;
-    _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(v[\\"@id\\"].startsWith(\\"at://\\")
+    
+      const decoded =
+    v[\\"@id\\"].startsWith(\\"at://\\")
         ? new URL(\\"at://\\" +
           encodeURIComponent(
             v[\\"@id\\"].includes(\\"/\\", 5)
@@ -38114,7 +38921,14 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))))
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])))
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
+    
     }
     instance.#_8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey = _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey;
     const _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey: (URL)[] = [];
@@ -38129,7 +38943,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         : _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey__array
     ) {
       if (v == null) continue;
-    _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(v[\\"@id\\"].startsWith(\\"at://\\")
+    
+      const decoded =
+    v[\\"@id\\"].startsWith(\\"at://\\")
         ? new URL(\\"at://\\" +
           encodeURIComponent(
             v[\\"@id\\"].includes(\\"/\\", 5)
@@ -38144,7 +38960,14 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))))
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])))
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
+    
     }
     instance.#_3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey = _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey;
     const _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox: (URL)[] = [];
@@ -38159,7 +38982,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         : _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox__array
     ) {
       if (v == null) continue;
-    _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(v[\\"@id\\"].startsWith(\\"at://\\")
+    
+      const decoded =
+    v[\\"@id\\"].startsWith(\\"at://\\")
         ? new URL(\\"at://\\" +
           encodeURIComponent(
             v[\\"@id\\"].includes(\\"/\\", 5)
@@ -38174,7 +38999,14 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))))
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])))
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
+    
     }
     instance.#_3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox = _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox;
     
@@ -44871,18 +45703,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
+    
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -44909,10 +45746,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(await CryptographicKey.fromJsonLd(
+      
+      const decoded =
+    await CryptographicKey.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
+    
     }
     instance.#_axq166E2eZADq34V4MYUc8KMZdC_publicKey = _axq166E2eZADq34V4MYUc8KMZdC_publicKey;
     
@@ -44939,10 +45785,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(await Multikey.fromJsonLd(
+      
+      const decoded =
+    await Multikey.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
+    
     }
     instance.#_4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod = _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod;
     const _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers: (boolean)[] = [];
@@ -44957,7 +45812,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers__array
     ) {
       if (v == null) continue;
-    _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(decoded);
+    
     }
     instance.#_36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers = _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers;
     
@@ -44986,7 +45850,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -44996,12 +45860,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
+    
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -45030,7 +45899,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -45040,12 +45909,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
+    
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -45072,10 +45946,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
+    
     }
     instance.#_3yAv8jymNfNuJUDuBzJ1NQhdbAee_following = _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following;
     
@@ -45102,10 +45985,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
+    
     }
     instance.#_BBCTgfphhsFzpVfKTykGSpBNwoA_followers = _BBCTgfphhsFzpVfKTykGSpBNwoA_followers;
     
@@ -45132,10 +46024,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
+    
     }
     instance.#_3bgkPwJanyTCoVFM9ovRcus8tKkU_liked = _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked;
     
@@ -45162,10 +46063,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
+    
     }
     instance.#_4N1vBJzXDf8NbBumeECQMFvKetja_featured = _4N1vBJzXDf8NbBumeECQMFvKetja_featured;
     
@@ -45192,10 +46102,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
+    
     }
     instance.#_2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags = _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags;
     
@@ -45222,10 +46141,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
+    
     }
     instance.#_3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams = _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams;
     const _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints: (Endpoints)[] = [];
@@ -45240,10 +46168,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints__array
     ) {
       if (v == null) continue;
-    _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(await Endpoints.fromJsonLd(
+    
+      const decoded =
+    await Endpoints.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
+    
     }
     instance.#_sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints = _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints;
     const _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable: (boolean)[] = [];
@@ -45258,7 +46195,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable__array
     ) {
       if (v == null) continue;
-    _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(decoded);
+    
     }
     instance.#_gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable = _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable;
     const _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended: (boolean)[] = [];
@@ -45273,7 +46219,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended__array
     ) {
       if (v == null) continue;
-    _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(decoded);
+    
     }
     instance.#_2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended = _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended;
     const _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial: (boolean)[] = [];
@@ -45288,7 +46243,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial__array
     ) {
       if (v == null) continue;
-    _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(decoded);
+    
     }
     instance.#_79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial = _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial;
     const _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable: (boolean)[] = [];
@@ -45303,7 +46267,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable__array
     ) {
       if (v == null) continue;
-    _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(decoded);
+    
     }
     instance.#_2diCorzqPGQQqftp6e4SrCEwEnyk_indexable = _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable;
     
@@ -45332,7 +46305,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -45354,12 +46327,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
+    
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -45388,7 +46366,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -45410,12 +46388,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
+    
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -45442,10 +46425,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(await DidService.fromJsonLd(
+      
+      const decoded =
+    await DidService.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
+    
     }
     instance.#_4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service = _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service;
     const _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage: (string)[] = [];
@@ -45460,7 +46452,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage__array
     ) {
       if (v == null) continue;
-    _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(decoded);
+    
     }
     instance.#_QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage = _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage;
     const _2xEU4QtkC53RAun67T81Egqt9vmL_isCat: (boolean)[] = [];
@@ -45475,7 +46476,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2xEU4QtkC53RAun67T81Egqt9vmL_isCat__array
     ) {
       if (v == null) continue;
-    _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(decoded);
+    
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
@@ -46055,6 +47065,12 @@ export class Link {
 
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
+    }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== \\"object\\") return true;
+      if (!(\\"_shouldCacheJsonLd\\" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
     }
     
     /**
@@ -47281,7 +48297,9 @@ get names(): ((string | LanguageString))[] {
         : _pVjLsybKQdmkjuU7MHjiVmNnuj7_href__array
     ) {
       if (v == null) continue;
-    _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(v[\\"@id\\"].startsWith(\\"at://\\")
+    
+      const decoded =
+    v[\\"@id\\"].startsWith(\\"at://\\")
         ? new URL(\\"at://\\" +
           encodeURIComponent(
             v[\\"@id\\"].includes(\\"/\\", 5)
@@ -47296,7 +48314,14 @@ get names(): ((string | LanguageString))[] {
         )
         : URL.canParse(v[\\"@id\\"]) && (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))
           ? new URL(v[\\"@id\\"])
-          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))))
+          : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])))
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
+    
     }
     instance.#_pVjLsybKQdmkjuU7MHjiVmNnuj7_href = _pVjLsybKQdmkjuU7MHjiVmNnuj7_href;
     const _2a1c5GkfkQsnyyLybF8UXBQfFuHZ_rel: (string)[] = [];
@@ -47311,7 +48336,16 @@ get names(): ((string | LanguageString))[] {
         : _2a1c5GkfkQsnyyLybF8UXBQfFuHZ_rel__array
     ) {
       if (v == null) continue;
-    _2a1c5GkfkQsnyyLybF8UXBQfFuHZ_rel.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2a1c5GkfkQsnyyLybF8UXBQfFuHZ_rel.push(decoded);
+    
     }
     instance.#_2a1c5GkfkQsnyyLybF8UXBQfFuHZ_rel = _2a1c5GkfkQsnyyLybF8UXBQfFuHZ_rel;
     const _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType: (string)[] = [];
@@ -47326,7 +48360,16 @@ get names(): ((string | LanguageString))[] {
         : _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType__array
     ) {
       if (v == null) continue;
-    _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType.push(decoded);
+    
     }
     instance.#_3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType = _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType;
     const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
@@ -47343,18 +48386,23 @@ get names(): ((string | LanguageString))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
+    
     }
     instance.#_4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name = _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name;
     const _f57HKWCp1YRBbTJE8PF12RbDJGf_hreflang: (Intl.Locale)[] = [];
@@ -47369,7 +48417,16 @@ get names(): ((string | LanguageString))[] {
         : _f57HKWCp1YRBbTJE8PF12RbDJGf_hreflang__array
     ) {
       if (v == null) continue;
-    _f57HKWCp1YRBbTJE8PF12RbDJGf_hreflang.push(new Intl.Locale(v[\\"@value\\"]))
+    
+      const decoded =
+    new Intl.Locale(v[\\"@value\\"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _f57HKWCp1YRBbTJE8PF12RbDJGf_hreflang.push(decoded);
+    
     }
     instance.#_f57HKWCp1YRBbTJE8PF12RbDJGf_hreflang = _f57HKWCp1YRBbTJE8PF12RbDJGf_hreflang;
     const _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height: (number)[] = [];
@@ -47384,7 +48441,16 @@ get names(): ((string | LanguageString))[] {
         : _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height__array
     ) {
       if (v == null) continue;
-    _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height.push(decoded);
+    
     }
     instance.#_2cGKFeFJMmiNpGZFEF75mCwFQsKb_height = _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height;
     const _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width: (number)[] = [];
@@ -47399,7 +48465,16 @@ get names(): ((string | LanguageString))[] {
         : _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width__array
     ) {
       if (v == null) continue;
-    _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width.push(decoded);
+    
     }
     instance.#_2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width = _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width;
     
@@ -47428,7 +48503,7 @@ get names(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Link\\",\\"https://www.w3.org/ns/activitystreams#Hashtag\\",\\"https://www.w3.org/ns/activitystreams#Mention\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Link.fromJsonLd(
       v,
@@ -47440,12 +48515,17 @@ get names(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(decoded);
+    
     }
     instance.#_gCVTegXxWWCw6wWRxa1QF65zusg_preview = _gCVTegXxWWCw6wWRxa1QF65zusg_preview;
     
@@ -51435,7 +52515,16 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
         : _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl__array
     ) {
       if (v == null) continue;
-    _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl.push(new URL(v[\\"@value\\"]))
+    
+      const decoded =
+    new URL(v[\\"@value\\"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl.push(decoded);
+    
     }
     instance.#_K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl = _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl;
     
@@ -52134,7 +53223,7 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -52146,12 +53235,17 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
+    
     }
     instance.#_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items = _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items;
     
@@ -52929,7 +54023,7 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& [\\"https://www.w3.org/ns/activitystreams#Object\\",\\"http://joinmastodon.org/ns#Emoji\\",\\"http://litepub.social/ns#ChatMessage\\",\\"https://www.w3.org/ns/activitystreams#Activity\\",\\"http://litepub.social/ns#EmojiReact\\",\\"https://www.w3.org/ns/activitystreams#Accept\\",\\"https://www.w3.org/ns/activitystreams#TentativeAccept\\",\\"https://www.w3.org/ns/activitystreams#Add\\",\\"https://www.w3.org/ns/activitystreams#Announce\\",\\"https://www.w3.org/ns/activitystreams#Create\\",\\"https://www.w3.org/ns/activitystreams#Delete\\",\\"https://www.w3.org/ns/activitystreams#Dislike\\",\\"https://www.w3.org/ns/activitystreams#Flag\\",\\"https://www.w3.org/ns/activitystreams#Follow\\",\\"https://www.w3.org/ns/activitystreams#Ignore\\",\\"https://www.w3.org/ns/activitystreams#Block\\",\\"https://www.w3.org/ns/activitystreams#IntransitiveActivity\\",\\"https://www.w3.org/ns/activitystreams#Arrive\\",\\"https://www.w3.org/ns/activitystreams#Question\\",\\"https://www.w3.org/ns/activitystreams#Travel\\",\\"https://www.w3.org/ns/activitystreams#Join\\",\\"https://www.w3.org/ns/activitystreams#Leave\\",\\"https://www.w3.org/ns/activitystreams#Like\\",\\"https://www.w3.org/ns/activitystreams#Listen\\",\\"https://www.w3.org/ns/activitystreams#Move\\",\\"https://www.w3.org/ns/activitystreams#Offer\\",\\"https://www.w3.org/ns/activitystreams#Invite\\",\\"https://www.w3.org/ns/activitystreams#Read\\",\\"https://www.w3.org/ns/activitystreams#Reject\\",\\"https://www.w3.org/ns/activitystreams#TentativeReject\\",\\"https://www.w3.org/ns/activitystreams#Remove\\",\\"https://www.w3.org/ns/activitystreams#Undo\\",\\"https://www.w3.org/ns/activitystreams#Update\\",\\"https://www.w3.org/ns/activitystreams#View\\",\\"https://www.w3.org/ns/activitystreams#Application\\",\\"https://www.w3.org/ns/activitystreams#Article\\",\\"https://www.w3.org/ns/activitystreams#Collection\\",\\"https://www.w3.org/ns/activitystreams#CollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollectionPage\\",\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\",\\"https://www.w3.org/ns/activitystreams#Document\\",\\"https://www.w3.org/ns/activitystreams#Audio\\",\\"https://www.w3.org/ns/activitystreams#Image\\",\\"https://www.w3.org/ns/activitystreams#Page\\",\\"https://www.w3.org/ns/activitystreams#Video\\",\\"https://www.w3.org/ns/activitystreams#Event\\",\\"https://www.w3.org/ns/activitystreams#Group\\",\\"https://www.w3.org/ns/activitystreams#Note\\",\\"https://www.w3.org/ns/activitystreams#Organization\\",\\"https://www.w3.org/ns/activitystreams#Person\\",\\"https://www.w3.org/ns/activitystreams#Place\\",\\"https://www.w3.org/ns/activitystreams#Profile\\",\\"https://www.w3.org/ns/activitystreams#Relationship\\",\\"https://www.w3.org/ns/activitystreams#Service\\",\\"https://www.w3.org/ns/activitystreams#Tombstone\\"].some(
             t => v[\\"@type\\"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -52941,12 +54035,17 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
+    
     }
     instance.#_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items = _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items;
     const _2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex: (number)[] = [];
@@ -52961,7 +54060,16 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         : _2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex__array
     ) {
       if (v == null) continue;
-    _2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex.push(decoded);
+    
     }
     instance.#_2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex = _2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex;
     
@@ -58539,18 +59647,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
+    
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -58577,10 +59690,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(await CryptographicKey.fromJsonLd(
+      
+      const decoded =
+    await CryptographicKey.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
+    
     }
     instance.#_axq166E2eZADq34V4MYUc8KMZdC_publicKey = _axq166E2eZADq34V4MYUc8KMZdC_publicKey;
     
@@ -58607,10 +59729,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(await Multikey.fromJsonLd(
+      
+      const decoded =
+    await Multikey.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
+    
     }
     instance.#_4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod = _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod;
     const _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers: (boolean)[] = [];
@@ -58625,7 +59756,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers__array
     ) {
       if (v == null) continue;
-    _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(decoded);
+    
     }
     instance.#_36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers = _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers;
     
@@ -58654,7 +59794,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -58664,12 +59804,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
+    
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -58698,7 +59843,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -58708,12 +59853,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
+    
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -58740,10 +59890,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
+    
     }
     instance.#_3yAv8jymNfNuJUDuBzJ1NQhdbAee_following = _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following;
     
@@ -58770,10 +59929,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
+    
     }
     instance.#_BBCTgfphhsFzpVfKTykGSpBNwoA_followers = _BBCTgfphhsFzpVfKTykGSpBNwoA_followers;
     
@@ -58800,10 +59968,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
+    
     }
     instance.#_3bgkPwJanyTCoVFM9ovRcus8tKkU_liked = _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked;
     
@@ -58830,10 +60007,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
+    
     }
     instance.#_4N1vBJzXDf8NbBumeECQMFvKetja_featured = _4N1vBJzXDf8NbBumeECQMFvKetja_featured;
     
@@ -58860,10 +60046,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
+    
     }
     instance.#_2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags = _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags;
     
@@ -58890,10 +60085,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
+    
     }
     instance.#_3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams = _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams;
     const _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints: (Endpoints)[] = [];
@@ -58908,10 +60112,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints__array
     ) {
       if (v == null) continue;
-    _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(await Endpoints.fromJsonLd(
+    
+      const decoded =
+    await Endpoints.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
+    
     }
     instance.#_sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints = _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints;
     const _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable: (boolean)[] = [];
@@ -58926,7 +60139,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable__array
     ) {
       if (v == null) continue;
-    _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(decoded);
+    
     }
     instance.#_gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable = _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable;
     const _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended: (boolean)[] = [];
@@ -58941,7 +60163,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended__array
     ) {
       if (v == null) continue;
-    _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(decoded);
+    
     }
     instance.#_2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended = _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended;
     const _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial: (boolean)[] = [];
@@ -58956,7 +60187,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial__array
     ) {
       if (v == null) continue;
-    _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(decoded);
+    
     }
     instance.#_79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial = _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial;
     const _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable: (boolean)[] = [];
@@ -58971,7 +60211,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable__array
     ) {
       if (v == null) continue;
-    _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(decoded);
+    
     }
     instance.#_2diCorzqPGQQqftp6e4SrCEwEnyk_indexable = _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable;
     
@@ -59000,7 +60249,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -59022,12 +60271,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
+    
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -59056,7 +60310,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -59078,12 +60332,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
+    
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -59110,10 +60369,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(await DidService.fromJsonLd(
+      
+      const decoded =
+    await DidService.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
+    
     }
     instance.#_4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service = _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service;
     const _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage: (string)[] = [];
@@ -59128,7 +60396,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage__array
     ) {
       if (v == null) continue;
-    _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(decoded);
+    
     }
     instance.#_QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage = _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage;
     const _2xEU4QtkC53RAun67T81Egqt9vmL_isCat: (boolean)[] = [];
@@ -59143,7 +60420,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2xEU4QtkC53RAun67T81Egqt9vmL_isCat__array
     ) {
       if (v == null) continue;
-    _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(decoded);
+    
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
@@ -65494,18 +66780,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
+    
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -65532,10 +66823,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(await CryptographicKey.fromJsonLd(
+      
+      const decoded =
+    await CryptographicKey.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
+    
     }
     instance.#_axq166E2eZADq34V4MYUc8KMZdC_publicKey = _axq166E2eZADq34V4MYUc8KMZdC_publicKey;
     
@@ -65562,10 +66862,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(await Multikey.fromJsonLd(
+      
+      const decoded =
+    await Multikey.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
+    
     }
     instance.#_4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod = _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod;
     const _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers: (boolean)[] = [];
@@ -65580,7 +66889,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers__array
     ) {
       if (v == null) continue;
-    _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(decoded);
+    
     }
     instance.#_36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers = _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers;
     
@@ -65609,7 +66927,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -65619,12 +66937,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
+    
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -65653,7 +66976,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -65663,12 +66986,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
+    
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -65695,10 +67023,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
+    
     }
     instance.#_3yAv8jymNfNuJUDuBzJ1NQhdbAee_following = _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following;
     
@@ -65725,10 +67062,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
+    
     }
     instance.#_BBCTgfphhsFzpVfKTykGSpBNwoA_followers = _BBCTgfphhsFzpVfKTykGSpBNwoA_followers;
     
@@ -65755,10 +67101,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
+    
     }
     instance.#_3bgkPwJanyTCoVFM9ovRcus8tKkU_liked = _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked;
     
@@ -65785,10 +67140,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
+    
     }
     instance.#_4N1vBJzXDf8NbBumeECQMFvKetja_featured = _4N1vBJzXDf8NbBumeECQMFvKetja_featured;
     
@@ -65815,10 +67179,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
+    
     }
     instance.#_2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags = _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags;
     
@@ -65845,10 +67218,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
+    
     }
     instance.#_3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams = _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams;
     const _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints: (Endpoints)[] = [];
@@ -65863,10 +67245,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints__array
     ) {
       if (v == null) continue;
-    _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(await Endpoints.fromJsonLd(
+    
+      const decoded =
+    await Endpoints.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
+    
     }
     instance.#_sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints = _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints;
     const _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable: (boolean)[] = [];
@@ -65881,7 +67272,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable__array
     ) {
       if (v == null) continue;
-    _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(decoded);
+    
     }
     instance.#_gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable = _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable;
     const _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended: (boolean)[] = [];
@@ -65896,7 +67296,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended__array
     ) {
       if (v == null) continue;
-    _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(decoded);
+    
     }
     instance.#_2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended = _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended;
     const _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial: (boolean)[] = [];
@@ -65911,7 +67320,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial__array
     ) {
       if (v == null) continue;
-    _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(decoded);
+    
     }
     instance.#_79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial = _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial;
     const _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable: (boolean)[] = [];
@@ -65926,7 +67344,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable__array
     ) {
       if (v == null) continue;
-    _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(decoded);
+    
     }
     instance.#_2diCorzqPGQQqftp6e4SrCEwEnyk_indexable = _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable;
     
@@ -65955,7 +67382,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -65977,12 +67404,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
+    
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -66011,7 +67443,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -66033,12 +67465,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
+    
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -66065,10 +67502,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(await DidService.fromJsonLd(
+      
+      const decoded =
+    await DidService.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
+    
     }
     instance.#_4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service = _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service;
     const _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage: (string)[] = [];
@@ -66083,7 +67529,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage__array
     ) {
       if (v == null) continue;
-    _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(decoded);
+    
     }
     instance.#_QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage = _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage;
     const _2xEU4QtkC53RAun67T81Egqt9vmL_isCat: (boolean)[] = [];
@@ -66098,7 +67553,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2xEU4QtkC53RAun67T81Egqt9vmL_isCat__array
     ) {
       if (v == null) continue;
-    _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(decoded);
+    
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
@@ -67384,7 +68848,16 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
         : _3UCsHnBHvDAXJnBuzw3zw1VVs3Ne_accuracy__array
     ) {
       if (v == null) continue;
-    _3UCsHnBHvDAXJnBuzw3zw1VVs3Ne_accuracy.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3UCsHnBHvDAXJnBuzw3zw1VVs3Ne_accuracy.push(decoded);
+    
     }
     instance.#_3UCsHnBHvDAXJnBuzw3zw1VVs3Ne_accuracy = _3UCsHnBHvDAXJnBuzw3zw1VVs3Ne_accuracy;
     const _3Q6KDcFQUJRRaBux1BL2yp5QWiBi_altitude: (number)[] = [];
@@ -67399,7 +68872,16 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
         : _3Q6KDcFQUJRRaBux1BL2yp5QWiBi_altitude__array
     ) {
       if (v == null) continue;
-    _3Q6KDcFQUJRRaBux1BL2yp5QWiBi_altitude.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3Q6KDcFQUJRRaBux1BL2yp5QWiBi_altitude.push(decoded);
+    
     }
     instance.#_3Q6KDcFQUJRRaBux1BL2yp5QWiBi_altitude = _3Q6KDcFQUJRRaBux1BL2yp5QWiBi_altitude;
     const _3g85RoKRnaNjP7DFyLSvsWDg7HGM_latitude: (number)[] = [];
@@ -67414,7 +68896,16 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
         : _3g85RoKRnaNjP7DFyLSvsWDg7HGM_latitude__array
     ) {
       if (v == null) continue;
-    _3g85RoKRnaNjP7DFyLSvsWDg7HGM_latitude.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3g85RoKRnaNjP7DFyLSvsWDg7HGM_latitude.push(decoded);
+    
     }
     instance.#_3g85RoKRnaNjP7DFyLSvsWDg7HGM_latitude = _3g85RoKRnaNjP7DFyLSvsWDg7HGM_latitude;
     const _B2GEYdS9yBAF3ho1pm1rcRg7cSf_longitude: (number)[] = [];
@@ -67429,7 +68920,16 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
         : _B2GEYdS9yBAF3ho1pm1rcRg7cSf_longitude__array
     ) {
       if (v == null) continue;
-    _B2GEYdS9yBAF3ho1pm1rcRg7cSf_longitude.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _B2GEYdS9yBAF3ho1pm1rcRg7cSf_longitude.push(decoded);
+    
     }
     instance.#_B2GEYdS9yBAF3ho1pm1rcRg7cSf_longitude = _B2GEYdS9yBAF3ho1pm1rcRg7cSf_longitude;
     const _3ga86BKHUtRkGx5PHBjRiUXXzwnw_radius: (number)[] = [];
@@ -67444,7 +68944,16 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
         : _3ga86BKHUtRkGx5PHBjRiUXXzwnw_radius__array
     ) {
       if (v == null) continue;
-    _3ga86BKHUtRkGx5PHBjRiUXXzwnw_radius.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3ga86BKHUtRkGx5PHBjRiUXXzwnw_radius.push(decoded);
+    
     }
     instance.#_3ga86BKHUtRkGx5PHBjRiUXXzwnw_radius = _3ga86BKHUtRkGx5PHBjRiUXXzwnw_radius;
     const _oKrwxU4V8wiKhMW1QEYQibcJh8c_units: ((\\"cm\\" | \\"feet\\" | \\"inches\\" | \\"km\\" | \\"m\\" | \\"miles\\" | URL))[] = [];
@@ -67461,7 +68970,7 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
       && (v[\\"@value\\"] == \\"cm\\" || v[\\"@value\\"] == \\"feet\\" || v[\\"@value\\"] == \\"inches\\" || v[\\"@value\\"] == \\"km\\" || v[\\"@value\\"] == \\"m\\" || v[\\"@value\\"] == \\"miles\\") ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@id\\" in v
         && typeof v[\\"@id\\"] === \\"string\\"
         && v[\\"@id\\"] !== \\"\\" ? v[\\"@id\\"].startsWith(\\"at://\\")
@@ -67481,12 +68990,17 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
           ? new URL(v[\\"@id\\"])
           : new URL(v[\\"@id\\"], (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"]))) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
+    
     }
     instance.#_oKrwxU4V8wiKhMW1QEYQibcJh8c_units = _oKrwxU4V8wiKhMW1QEYQibcJh8c_units;
     
@@ -68261,10 +69775,19 @@ proofs?: (DataIntegrityProof | URL)[];describes?: Object | URL | null;}
         );
         continue;
       }
-      _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
+    
     }
     instance.#_3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes = _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes;
     
@@ -69398,10 +70921,19 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         );
         continue;
       }
-      _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
+    
     }
     instance.#_2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf = _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf;
     
@@ -69428,10 +70960,19 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         );
         continue;
       }
-      _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
+    
     }
     instance.#_2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf = _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf;
     const _3KronwL8DiiKBRcJFKQPiEHm8xb6_closed: ((Temporal.Instant | boolean))[] = [];
@@ -69448,7 +70989,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
         && \\"@value\\" in v && typeof v[\\"@value\\"] === \\"string\\"
         && v[\\"@type\\"] === \\"http://www.w3.org/2001/XMLSchema#dateTime\\"
         // Check if the value is a valid RFC 3339 date-time string
@@ -69460,12 +71001,17 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       ) : typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"boolean\\" ? v[\\"@value\\"] : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3KronwL8DiiKBRcJFKQPiEHm8xb6_closed.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3KronwL8DiiKBRcJFKQPiEHm8xb6_closed.push(decoded);
+    
     }
     instance.#_3KronwL8DiiKBRcJFKQPiEHm8xb6_closed = _3KronwL8DiiKBRcJFKQPiEHm8xb6_closed;
     const _3H4RdST7dxfmghccvE3rKD3KgcxG_votersCount: (number)[] = [];
@@ -69480,7 +71026,16 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         : _3H4RdST7dxfmghccvE3rKD3KgcxG_votersCount__array
     ) {
       if (v == null) continue;
-    _3H4RdST7dxfmghccvE3rKD3KgcxG_votersCount.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3H4RdST7dxfmghccvE3rKD3KgcxG_votersCount.push(decoded);
+    
     }
     instance.#_3H4RdST7dxfmghccvE3rKD3KgcxG_votersCount = _3H4RdST7dxfmghccvE3rKD3KgcxG_votersCount;
     const _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl: (URL)[] = [];
@@ -69503,7 +71058,16 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         : _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl__array
     ) {
       if (v == null) continue;
-    _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl.push(new URL(v[\\"@value\\"]))
+    
+      const decoded =
+    new URL(v[\\"@value\\"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl.push(decoded);
+    
     }
     instance.#_K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl = _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl;
     
@@ -71815,10 +73379,19 @@ relationships?: (Object | URL)[];}
         );
         continue;
       }
-      _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
+    
     }
     instance.#_2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject = _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject;
     
@@ -71845,10 +73418,19 @@ relationships?: (Object | URL)[];}
         );
         continue;
       }
-      _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
+    
     }
     instance.#_2MH19yxjn1wnHsNfa5n4JBhJzxyc_object = _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object;
     
@@ -71875,10 +73457,19 @@ relationships?: (Object | URL)[];}
         );
         continue;
       }
-      _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
+    
     }
     instance.#_4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship = _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship;
     
@@ -77826,18 +79417,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
+    
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -77864,10 +79460,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(await CryptographicKey.fromJsonLd(
+      
+      const decoded =
+    await CryptographicKey.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
+    
     }
     instance.#_axq166E2eZADq34V4MYUc8KMZdC_publicKey = _axq166E2eZADq34V4MYUc8KMZdC_publicKey;
     
@@ -77894,10 +79499,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(await Multikey.fromJsonLd(
+      
+      const decoded =
+    await Multikey.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
+    
     }
     instance.#_4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod = _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod;
     const _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers: (boolean)[] = [];
@@ -77912,7 +79526,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers__array
     ) {
       if (v == null) continue;
-    _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(decoded);
+    
     }
     instance.#_36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers = _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers;
     
@@ -77941,7 +79564,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -77951,12 +79574,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
+    
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -77985,7 +79613,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#OrderedCollection\\") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -77995,12 +79623,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
+    
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -78027,10 +79660,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
+    
     }
     instance.#_3yAv8jymNfNuJUDuBzJ1NQhdbAee_following = _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following;
     
@@ -78057,10 +79699,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
+    
     }
     instance.#_BBCTgfphhsFzpVfKTykGSpBNwoA_followers = _BBCTgfphhsFzpVfKTykGSpBNwoA_followers;
     
@@ -78087,10 +79738,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
+    
     }
     instance.#_3bgkPwJanyTCoVFM9ovRcus8tKkU_liked = _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked;
     
@@ -78117,10 +79777,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
+    
     }
     instance.#_4N1vBJzXDf8NbBumeECQMFvKetja_featured = _4N1vBJzXDf8NbBumeECQMFvKetja_featured;
     
@@ -78147,10 +79816,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
+    
     }
     instance.#_2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags = _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags;
     
@@ -78177,10 +79855,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
+    
     }
     instance.#_3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams = _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams;
     const _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints: (Endpoints)[] = [];
@@ -78195,10 +79882,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints__array
     ) {
       if (v == null) continue;
-    _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(await Endpoints.fromJsonLd(
+    
+      const decoded =
+    await Endpoints.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
+    
     }
     instance.#_sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints = _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints;
     const _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable: (boolean)[] = [];
@@ -78213,7 +79909,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable__array
     ) {
       if (v == null) continue;
-    _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(decoded);
+    
     }
     instance.#_gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable = _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable;
     const _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended: (boolean)[] = [];
@@ -78228,7 +79933,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended__array
     ) {
       if (v == null) continue;
-    _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(decoded);
+    
     }
     instance.#_2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended = _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended;
     const _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial: (boolean)[] = [];
@@ -78243,7 +79957,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial__array
     ) {
       if (v == null) continue;
-    _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(decoded);
+    
     }
     instance.#_79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial = _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial;
     const _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable: (boolean)[] = [];
@@ -78258,7 +79981,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable__array
     ) {
       if (v == null) continue;
-    _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(decoded);
+    
     }
     instance.#_2diCorzqPGQQqftp6e4SrCEwEnyk_indexable = _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable;
     
@@ -78287,7 +80019,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -78309,12 +80041,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
+    
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -78343,7 +80080,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === \\"object\\" && \\"@type\\" in v
+    typeof v === \\"object\\" && \\"@type\\" in v
       && Array.isArray(v[\\"@type\\"])&& v[\\"@type\\"].includes(\\"https://www.w3.org/ns/activitystreams#Application\\") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
@@ -78365,12 +80102,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
+    
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -78397,10 +80139,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(await DidService.fromJsonLd(
+      
+      const decoded =
+    await DidService.fromJsonLd(
       v,
       { ...options, baseUrl: (values[\\"@id\\"] == null ? options.baseUrl : new URL(values[\\"@id\\"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
+    
     }
     instance.#_4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service = _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service;
     const _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage: (string)[] = [];
@@ -78415,7 +80166,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage__array
     ) {
       if (v == null) continue;
-    _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(decoded);
+    
     }
     instance.#_QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage = _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage;
     const _2xEU4QtkC53RAun67T81Egqt9vmL_isCat: (boolean)[] = [];
@@ -78430,7 +80190,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2xEU4QtkC53RAun67T81Egqt9vmL_isCat__array
     ) {
       if (v == null) continue;
-    _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(decoded);
+    
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
@@ -79003,6 +80772,12 @@ export class Source {
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
     }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== \\"object\\") return true;
+      if (!(\\"_shouldCacheJsonLd\\" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
+    }
     
     /**
      * The type URI of {@link Source}: \`https://www.w3.org/ns/activitystreams#Source\`.
@@ -79475,18 +81250,23 @@ get contents(): ((string | LanguageString))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === \\"object\\" && \\"@value\\" in v
+    typeof v === \\"object\\" && \\"@value\\" in v
         && typeof v[\\"@value\\"] === \\"string\\" && !(\\"@language\\" in v) ? v[\\"@value\\"] : typeof v === \\"object\\" && \\"@language\\" in v && \\"@value\\" in v
         && typeof v[\\"@language\\"] === \\"string\\"
         && typeof v[\\"@value\\"] === \\"string\\"
         && isValidLanguageTag(v[\\"@language\\"]) ? new LanguageString(v[\\"@value\\"], v[\\"@language\\"]) : undefined
       ;
+    
       if (typeof decoded === \\"undefined\\") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
+    
     }
     instance.#_4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content = _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content;
     const _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType: (string)[] = [];
@@ -79501,7 +81281,16 @@ get contents(): ((string | LanguageString))[] {
         : _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType__array
     ) {
       if (v == null) continue;
-    _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType.push(v[\\"@value\\"])
+    
+      const decoded =
+    v[\\"@value\\"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType.push(decoded);
+    
     }
     instance.#_3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType = _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType;
     
@@ -80679,11 +82468,20 @@ proofs?: (DataIntegrityProof | URL)[];deleted?: Temporal.Instant | null;}
         : _8g8g4LiVMhFTXskuDEqx4ascxUr_deleted__array
     ) {
       if (v == null) continue;
-    _8g8g4LiVMhFTXskuDEqx4ascxUr_deleted.push(Temporal.Instant.from(
+    
+      const decoded =
+    Temporal.Instant.from(
         v[\\"@value\\"].substring(19).match(/[Z+-]/)
           ? v[\\"@value\\"]
           : v[\\"@value\\"] + \\"Z\\"
-      ))
+      )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _8g8g4LiVMhFTXskuDEqx4ascxUr_deleted.push(decoded);
+    
     }
     instance.#_8g8g4LiVMhFTXskuDEqx4ascxUr_deleted = _8g8g4LiVMhFTXskuDEqx4ascxUr_deleted;
     

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
@@ -23,6 +23,16 @@ import {
     isTemporalInstant,
 } from "@fedify/vocab-runtime/temporal";
 
+function isValidLanguageTag(language: string): boolean {
+  try {
+    new Intl.Locale(language);
+    return true;
+  } catch (error) {
+    if (error instanceof RangeError) return false;
+    throw error;
+  }
+}
+
 
 /** Describes an object of any kind. The Object type serves as the base type for
  * most of the other kinds of objects defined in the Activity Vocabulary,
@@ -9538,7 +9548,8 @@ get urls(): ((URL | Link))[] {
       typeof v === "object" && "@value" in v
         && typeof v["@value"] === "string" && !("@language" in v) ? v["@value"] : typeof v === "object" && "@language" in v && "@value" in v
         && typeof v["@language"] === "string"
-        && typeof v["@value"] === "string" ? new LanguageString(v["@value"], v["@language"]) : undefined
+        && typeof v["@value"] === "string"
+        && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
       if (typeof decoded === "undefined") continue;
       _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
@@ -9605,7 +9616,8 @@ get urls(): ((URL | Link))[] {
       typeof v === "object" && "@value" in v
         && typeof v["@value"] === "string" && !("@language" in v) ? v["@value"] : typeof v === "object" && "@language" in v && "@value" in v
         && typeof v["@language"] === "string"
-        && typeof v["@value"] === "string" ? new LanguageString(v["@value"], v["@language"]) : undefined
+        && typeof v["@value"] === "string"
+        && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
       if (typeof decoded === "undefined") continue;
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
@@ -10038,7 +10050,8 @@ get urls(): ((URL | Link))[] {
       typeof v === "object" && "@value" in v
         && typeof v["@value"] === "string" && !("@language" in v) ? v["@value"] : typeof v === "object" && "@language" in v && "@value" in v
         && typeof v["@language"] === "string"
-        && typeof v["@value"] === "string" ? new LanguageString(v["@value"], v["@language"]) : undefined
+        && typeof v["@value"] === "string"
+        && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
       if (typeof decoded === "undefined") continue;
       _4LqirZspQbFWWQEbFcXAxm7tTDN1_summary.push(decoded);
@@ -16123,7 +16136,8 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
       typeof v === "object" && "@value" in v
         && typeof v["@value"] === "string" && !("@language" in v) ? v["@value"] : typeof v === "object" && "@language" in v && "@value" in v
         && typeof v["@language"] === "string"
-        && typeof v["@value"] === "string" ? new LanguageString(v["@value"], v["@language"]) : undefined
+        && typeof v["@value"] === "string"
+        && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
       if (typeof decoded === "undefined") continue;
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
@@ -16147,7 +16161,8 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
       typeof v === "object" && "@value" in v
         && typeof v["@value"] === "string" && !("@language" in v) ? v["@value"] : typeof v === "object" && "@language" in v && "@value" in v
         && typeof v["@language"] === "string"
-        && typeof v["@value"] === "string" ? new LanguageString(v["@value"], v["@language"]) : undefined
+        && typeof v["@value"] === "string"
+        && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
       if (typeof decoded === "undefined") continue;
       _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value.push(decoded);
@@ -26305,7 +26320,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@value" in v
         && typeof v["@value"] === "string" && !("@language" in v) ? v["@value"] : typeof v === "object" && "@language" in v && "@value" in v
         && typeof v["@language"] === "string"
-        && typeof v["@value"] === "string" ? new LanguageString(v["@value"], v["@language"]) : undefined
+        && typeof v["@value"] === "string"
+        && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
       if (typeof decoded === "undefined") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
@@ -44540,7 +44556,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@value" in v
         && typeof v["@value"] === "string" && !("@language" in v) ? v["@value"] : typeof v === "object" && "@language" in v && "@value" in v
         && typeof v["@language"] === "string"
-        && typeof v["@value"] === "string" ? new LanguageString(v["@value"], v["@language"]) : undefined
+        && typeof v["@value"] === "string"
+        && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
       if (typeof decoded === "undefined") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
@@ -46981,7 +46998,8 @@ get names(): ((string | LanguageString))[] {
       typeof v === "object" && "@value" in v
         && typeof v["@value"] === "string" && !("@language" in v) ? v["@value"] : typeof v === "object" && "@language" in v && "@value" in v
         && typeof v["@language"] === "string"
-        && typeof v["@value"] === "string" ? new LanguageString(v["@value"], v["@language"]) : undefined
+        && typeof v["@value"] === "string"
+        && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
       if (typeof decoded === "undefined") continue;
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
@@ -58080,7 +58098,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@value" in v
         && typeof v["@value"] === "string" && !("@language" in v) ? v["@value"] : typeof v === "object" && "@language" in v && "@value" in v
         && typeof v["@language"] === "string"
-        && typeof v["@value"] === "string" ? new LanguageString(v["@value"], v["@language"]) : undefined
+        && typeof v["@value"] === "string"
+        && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
       if (typeof decoded === "undefined") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
@@ -65007,7 +65026,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@value" in v
         && typeof v["@value"] === "string" && !("@language" in v) ? v["@value"] : typeof v === "object" && "@language" in v && "@value" in v
         && typeof v["@language"] === "string"
-        && typeof v["@value"] === "string" ? new LanguageString(v["@value"], v["@language"]) : undefined
+        && typeof v["@value"] === "string"
+        && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
       if (typeof decoded === "undefined") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
@@ -77269,7 +77289,8 @@ get preferredUsernames(): ((string | LanguageString))[] {
       typeof v === "object" && "@value" in v
         && typeof v["@value"] === "string" && !("@language" in v) ? v["@value"] : typeof v === "object" && "@language" in v && "@value" in v
         && typeof v["@language"] === "string"
-        && typeof v["@value"] === "string" ? new LanguageString(v["@value"], v["@language"]) : undefined
+        && typeof v["@value"] === "string"
+        && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
       if (typeof decoded === "undefined") continue;
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
@@ -78887,7 +78908,8 @@ get contents(): ((string | LanguageString))[] {
       typeof v === "object" && "@value" in v
         && typeof v["@value"] === "string" && !("@language" in v) ? v["@value"] : typeof v === "object" && "@language" in v && "@value" in v
         && typeof v["@language"] === "string"
-        && typeof v["@value"] === "string" ? new LanguageString(v["@value"], v["@language"]) : undefined
+        && typeof v["@value"] === "string"
+        && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
       if (typeof decoded === "undefined") continue;
       _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
@@ -90,6 +90,12 @@ export class Object {
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
     }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== "object") return true;
+      if (!("_shouldCacheJsonLd" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
+    }
     
     /**
      * The type URI of {@link Object}: \`https://www.w3.org/ns/activitystreams#Object\`.
@@ -9438,7 +9444,7 @@ get urls(): ((URL | Link))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -9454,12 +9460,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _49BipA5dq9eoH8LX8xdsVumveTca_attachment.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _49BipA5dq9eoH8LX8xdsVumveTca_attachment.push(decoded);
+    
     }
     instance.#_49BipA5dq9eoH8LX8xdsVumveTca_attachment = _49BipA5dq9eoH8LX8xdsVumveTca_attachment;
     
@@ -9488,7 +9499,7 @@ get urls(): ((URL | Link))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
@@ -9510,12 +9521,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo.push(decoded);
+    
     }
     instance.#_42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo = _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo;
     
@@ -9542,10 +9558,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience.push(decoded);
+    
     }
     instance.#_3ocC3VVi88cEd5sPWL8djkZsvTN6_audience = _3ocC3VVi88cEd5sPWL8djkZsvTN6_audience;
     const _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content: ((string | LanguageString))[] = [];
@@ -9562,18 +9587,23 @@ get urls(): ((URL | Link))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === "object" && "@value" in v
+    typeof v === "object" && "@value" in v
         && typeof v["@value"] === "string" && !("@language" in v) ? v["@value"] : typeof v === "object" && "@language" in v && "@value" in v
         && typeof v["@language"] === "string"
         && typeof v["@value"] === "string"
         && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
+    
     }
     instance.#_4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content = _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content;
     
@@ -9602,7 +9632,7 @@ get urls(): ((URL | Link))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -9614,12 +9644,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3mhZzGXSpQ431mBSz2kvych22v4e_context.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3mhZzGXSpQ431mBSz2kvych22v4e_context.push(decoded);
+    
     }
     instance.#_3mhZzGXSpQ431mBSz2kvych22v4e_context = _3mhZzGXSpQ431mBSz2kvych22v4e_context;
     const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
@@ -9636,18 +9671,23 @@ get urls(): ((URL | Link))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === "object" && "@value" in v
+    typeof v === "object" && "@value" in v
         && typeof v["@value"] === "string" && !("@language" in v) ? v["@value"] : typeof v === "object" && "@language" in v && "@value" in v
         && typeof v["@language"] === "string"
         && typeof v["@value"] === "string"
         && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
+    
     }
     instance.#_4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name = _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name;
     const _219RwDanjScTv5tYCjwGZVCM7KZ9_endTime: (Temporal.Instant)[] = [];
@@ -9662,11 +9702,20 @@ get urls(): ((URL | Link))[] {
         : _219RwDanjScTv5tYCjwGZVCM7KZ9_endTime__array
     ) {
       if (v == null) continue;
-    _219RwDanjScTv5tYCjwGZVCM7KZ9_endTime.push(Temporal.Instant.from(
+    
+      const decoded =
+    Temporal.Instant.from(
         v["@value"].substring(19).match(/[Z+-]/)
           ? v["@value"]
           : v["@value"] + "Z"
-      ))
+      )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _219RwDanjScTv5tYCjwGZVCM7KZ9_endTime.push(decoded);
+    
     }
     instance.#_219RwDanjScTv5tYCjwGZVCM7KZ9_endTime = _219RwDanjScTv5tYCjwGZVCM7KZ9_endTime;
     
@@ -9695,7 +9744,7 @@ get urls(): ((URL | Link))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -9707,12 +9756,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _86xFhmgBapoMvYqjbjRuDPayTrS_generator.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _86xFhmgBapoMvYqjbjRuDPayTrS_generator.push(decoded);
+    
     }
     instance.#_86xFhmgBapoMvYqjbjRuDPayTrS_generator = _86xFhmgBapoMvYqjbjRuDPayTrS_generator;
     
@@ -9739,10 +9793,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(await Image.fromJsonLd(
+      
+      const decoded =
+    await Image.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon.push(decoded);
+    
     }
     instance.#_33CjRLy5ujtsUrwRSCrsggvGdKuR_icon = _33CjRLy5ujtsUrwRSCrsggvGdKuR_icon;
     
@@ -9769,10 +9832,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(await Image.fromJsonLd(
+      
+      const decoded =
+    await Image.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3dXrUdkARxwyJLtJcYi1AJ92H41U_image.push(decoded);
+    
     }
     instance.#_3dXrUdkARxwyJLtJcYi1AJ92H41U_image = _3dXrUdkARxwyJLtJcYi1AJ92H41U_image;
     
@@ -9801,7 +9873,7 @@ get urls(): ((URL | Link))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -9813,12 +9885,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo.push(decoded);
+    
     }
     instance.#_3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo = _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo;
     
@@ -9847,7 +9924,7 @@ get urls(): ((URL | Link))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -9859,12 +9936,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _31k5MUZJsnsPNg8dQQJieWaXTFnR_location.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _31k5MUZJsnsPNg8dQQJieWaXTFnR_location.push(decoded);
+    
     }
     instance.#_31k5MUZJsnsPNg8dQQJieWaXTFnR_location = _31k5MUZJsnsPNg8dQQJieWaXTFnR_location;
     
@@ -9893,7 +9975,7 @@ get urls(): ((URL | Link))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
@@ -9905,12 +9987,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(decoded);
+    
     }
     instance.#_gCVTegXxWWCw6wWRxa1QF65zusg_preview = _gCVTegXxWWCw6wWRxa1QF65zusg_preview;
     const _5e258TDXtuhaFRPZiGoDfEpjdMr_published: (Temporal.Instant)[] = [];
@@ -9925,11 +10012,20 @@ get urls(): ((URL | Link))[] {
         : _5e258TDXtuhaFRPZiGoDfEpjdMr_published__array
     ) {
       if (v == null) continue;
-    _5e258TDXtuhaFRPZiGoDfEpjdMr_published.push(Temporal.Instant.from(
+    
+      const decoded =
+    Temporal.Instant.from(
         v["@value"].substring(19).match(/[Z+-]/)
           ? v["@value"]
           : v["@value"] + "Z"
-      ))
+      )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _5e258TDXtuhaFRPZiGoDfEpjdMr_published.push(decoded);
+    
     }
     instance.#_5e258TDXtuhaFRPZiGoDfEpjdMr_published = _5e258TDXtuhaFRPZiGoDfEpjdMr_published;
     
@@ -9956,10 +10052,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _7UpwM3JWcXhADcscukEehBorf6k_replies.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _7UpwM3JWcXhADcscukEehBorf6k_replies.push(decoded);
+    
     }
     instance.#_7UpwM3JWcXhADcscukEehBorf6k_replies = _7UpwM3JWcXhADcscukEehBorf6k_replies;
     
@@ -9986,10 +10091,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3kAfck9PcEYt2L7xug5y99YPbANs_shares.push(decoded);
+    
     }
     instance.#_3kAfck9PcEYt2L7xug5y99YPbANs_shares = _3kAfck9PcEYt2L7xug5y99YPbANs_shares;
     
@@ -10016,10 +10130,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes.push(decoded);
+    
     }
     instance.#_S3ceDnpMdzoTRCccB9FkJWrEzYW_likes = _S3ceDnpMdzoTRCccB9FkJWrEzYW_likes;
     
@@ -10046,10 +10169,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions.push(decoded);
+    
     }
     instance.#_kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions = _kMatyyNAuxoTD8GQMBfA5ogThMR_emojiReactions;
     const _2w3Jmue4up8iVDUA51WZqomEF438_startTime: (Temporal.Instant)[] = [];
@@ -10064,11 +10196,20 @@ get urls(): ((URL | Link))[] {
         : _2w3Jmue4up8iVDUA51WZqomEF438_startTime__array
     ) {
       if (v == null) continue;
-    _2w3Jmue4up8iVDUA51WZqomEF438_startTime.push(Temporal.Instant.from(
+    
+      const decoded =
+    Temporal.Instant.from(
         v["@value"].substring(19).match(/[Z+-]/)
           ? v["@value"]
           : v["@value"] + "Z"
-      ))
+      )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2w3Jmue4up8iVDUA51WZqomEF438_startTime.push(decoded);
+    
     }
     instance.#_2w3Jmue4up8iVDUA51WZqomEF438_startTime = _2w3Jmue4up8iVDUA51WZqomEF438_startTime;
     const _4LqirZspQbFWWQEbFcXAxm7tTDN1_summary: ((string | LanguageString))[] = [];
@@ -10085,18 +10226,23 @@ get urls(): ((URL | Link))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === "object" && "@value" in v
+    typeof v === "object" && "@value" in v
         && typeof v["@value"] === "string" && !("@language" in v) ? v["@value"] : typeof v === "object" && "@language" in v && "@value" in v
         && typeof v["@language"] === "string"
         && typeof v["@value"] === "string"
         && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _4LqirZspQbFWWQEbFcXAxm7tTDN1_summary.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4LqirZspQbFWWQEbFcXAxm7tTDN1_summary.push(decoded);
+    
     }
     instance.#_4LqirZspQbFWWQEbFcXAxm7tTDN1_summary = _4LqirZspQbFWWQEbFcXAxm7tTDN1_summary;
     
@@ -10125,7 +10271,7 @@ get urls(): ((URL | Link))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -10137,12 +10283,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _5chuqj6s95p5gg2sk1HntGfarRf_tag.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _5chuqj6s95p5gg2sk1HntGfarRf_tag.push(decoded);
+    
     }
     instance.#_5chuqj6s95p5gg2sk1HntGfarRf_tag = _5chuqj6s95p5gg2sk1HntGfarRf_tag;
     const _385aB7ySixcf5Un6z3VsWmThgCzQ_updated: (Temporal.Instant)[] = [];
@@ -10157,11 +10308,20 @@ get urls(): ((URL | Link))[] {
         : _385aB7ySixcf5Un6z3VsWmThgCzQ_updated__array
     ) {
       if (v == null) continue;
-    _385aB7ySixcf5Un6z3VsWmThgCzQ_updated.push(Temporal.Instant.from(
+    
+      const decoded =
+    Temporal.Instant.from(
         v["@value"].substring(19).match(/[Z+-]/)
           ? v["@value"]
           : v["@value"] + "Z"
-      ))
+      )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _385aB7ySixcf5Un6z3VsWmThgCzQ_updated.push(decoded);
+    
     }
     instance.#_385aB7ySixcf5Un6z3VsWmThgCzQ_updated = _385aB7ySixcf5Un6z3VsWmThgCzQ_updated;
     const _2oPEH9MQ3aj8JVwyYuWkqoVwV865_url: ((URL | Link))[] = [];
@@ -10178,7 +10338,7 @@ get urls(): ((URL | Link))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === "object" && "@id" in v
+    typeof v === "object" && "@id" in v
         && typeof v["@id"] === "string"
         && v["@id"] !== "" ? v["@id"].startsWith("at://")
         ? new URL("at://" +
@@ -10202,12 +10362,17 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2oPEH9MQ3aj8JVwyYuWkqoVwV865_url.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2oPEH9MQ3aj8JVwyYuWkqoVwV865_url.push(decoded);
+    
     }
     instance.#_2oPEH9MQ3aj8JVwyYuWkqoVwV865_url = _2oPEH9MQ3aj8JVwyYuWkqoVwV865_url;
     
@@ -10234,10 +10399,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to.push(decoded);
+    
     }
     instance.#_3hFbw7DTpHhq3cvVhkY8njhcsXbd_to = _3hFbw7DTpHhq3cvVhkY8njhcsXbd_to;
     
@@ -10264,10 +10438,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto.push(decoded);
+    
     }
     instance.#_aLZupjwL8XB7tzdLgCMXdjZ6qej_bto = _aLZupjwL8XB7tzdLgCMXdjZ6qej_bto;
     
@@ -10294,10 +10477,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc.push(decoded);
+    
     }
     instance.#_42a1SvBs24QSLzKcfjCyNTjW5a1g_cc = _42a1SvBs24QSLzKcfjCyNTjW5a1g_cc;
     
@@ -10324,10 +10516,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc.push(decoded);
+    
     }
     instance.#_3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc = _3qvegKUB8YLgTXRpEf8E6JZSkz2H_bcc;
     const _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType: (string)[] = [];
@@ -10342,7 +10543,16 @@ get urls(): ((URL | Link))[] {
         : _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType__array
     ) {
       if (v == null) continue;
-    _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType.push(decoded);
+    
     }
     instance.#_3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType = _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType;
     const _3bNvLMBN1bCJETiTihM3wvi1B2JX_duration: (Temporal.Duration)[] = [];
@@ -10357,7 +10567,16 @@ get urls(): ((URL | Link))[] {
         : _3bNvLMBN1bCJETiTihM3wvi1B2JX_duration__array
     ) {
       if (v == null) continue;
-    _3bNvLMBN1bCJETiTihM3wvi1B2JX_duration.push(Temporal.Duration.from(v["@value"]))
+    
+      const decoded =
+    Temporal.Duration.from(v["@value"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3bNvLMBN1bCJETiTihM3wvi1B2JX_duration.push(decoded);
+    
     }
     instance.#_3bNvLMBN1bCJETiTihM3wvi1B2JX_duration = _3bNvLMBN1bCJETiTihM3wvi1B2JX_duration;
     const _u8gdcDTtChQ4tbSQMXc4cYWyum7_sensitive: (boolean)[] = [];
@@ -10372,7 +10591,16 @@ get urls(): ((URL | Link))[] {
         : _u8gdcDTtChQ4tbSQMXc4cYWyum7_sensitive__array
     ) {
       if (v == null) continue;
-    _u8gdcDTtChQ4tbSQMXc4cYWyum7_sensitive.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _u8gdcDTtChQ4tbSQMXc4cYWyum7_sensitive.push(decoded);
+    
     }
     instance.#_u8gdcDTtChQ4tbSQMXc4cYWyum7_sensitive = _u8gdcDTtChQ4tbSQMXc4cYWyum7_sensitive;
     const _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source: (Source)[] = [];
@@ -10387,10 +10615,19 @@ get urls(): ((URL | Link))[] {
         : _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source__array
     ) {
       if (v == null) continue;
-    _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(await Source.fromJsonLd(
+    
+      const decoded =
+    await Source.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source.push(decoded);
+    
     }
     instance.#_2ZwCFoS787v8y8bXKjMoE6MAbrEB_source = _2ZwCFoS787v8y8bXKjMoE6MAbrEB_source;
     
@@ -10417,10 +10654,19 @@ get urls(): ((URL | Link))[] {
         );
         continue;
       }
-      _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(await DataIntegrityProof.fromJsonLd(
+      
+      const decoded =
+    await DataIntegrityProof.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof.push(decoded);
+    
     }
     instance.#_42rPnotok1ivQ2RNCKNbeFJgx8b8_proof = _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof;
     
@@ -11988,7 +12234,16 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
         : _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl__array
     ) {
       if (v == null) continue;
-    _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl.push(new URL(v["@value"]))
+    
+      const decoded =
+    new URL(v["@value"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl.push(decoded);
+    
     }
     instance.#_K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl = _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl;
     
@@ -15020,7 +15275,7 @@ instruments?: (Object | URL)[];}
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
@@ -15042,12 +15297,17 @@ instruments?: (Object | URL)[];}
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor.push(decoded);
+    
     }
     instance.#_2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor = _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor;
     
@@ -15074,10 +15334,19 @@ instruments?: (Object | URL)[];}
         );
         continue;
       }
-      _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
+    
     }
     instance.#_2MH19yxjn1wnHsNfa5n4JBhJzxyc_object = _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object;
     
@@ -15104,10 +15373,19 @@ instruments?: (Object | URL)[];}
         );
         continue;
       }
-      _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target.push(decoded);
+    
     }
     instance.#_3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target = _3JQCmF2Ww56Ag9EWRYoSZRDNCYtF_target;
     
@@ -15134,10 +15412,19 @@ instruments?: (Object | URL)[];}
         );
         continue;
       }
-      _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result.push(decoded);
+    
     }
     instance.#_u4QGFbRFcYmPEKGbPv1hpBR9r5G_result = _u4QGFbRFcYmPEKGbPv1hpBR9r5G_result;
     
@@ -15164,10 +15451,19 @@ instruments?: (Object | URL)[];}
         );
         continue;
       }
-      _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _25zu2s3VxVujgEKqrDycjE284XQR_origin.push(decoded);
+    
     }
     instance.#_25zu2s3VxVujgEKqrDycjE284XQR_origin = _25zu2s3VxVujgEKqrDycjE284XQR_origin;
     
@@ -15194,10 +15490,19 @@ instruments?: (Object | URL)[];}
         );
         continue;
       }
-      _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument.push(decoded);
+    
     }
     instance.#_3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument = _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument;
     
@@ -15793,6 +16098,12 @@ export class PropertyValue {
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
     }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== "object") return true;
+      if (!("_shouldCacheJsonLd" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
+    }
     
     /**
      * The type URI of {@link PropertyValue}: \`http://schema.org#PropertyValue\`.
@@ -16222,18 +16533,23 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
       if (v == null) continue;
     
       const decoded =
-      typeof v === "object" && "@value" in v
+    typeof v === "object" && "@value" in v
         && typeof v["@value"] === "string" && !("@language" in v) ? v["@value"] : typeof v === "object" && "@language" in v && "@value" in v
         && typeof v["@language"] === "string"
         && typeof v["@value"] === "string"
         && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
+    
     }
     instance.#_4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name = _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name;
     const _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value: ((string | LanguageString))[] = [];
@@ -16250,18 +16566,23 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
       if (v == null) continue;
     
       const decoded =
-      typeof v === "object" && "@value" in v
+    typeof v === "object" && "@value" in v
         && typeof v["@value"] === "string" && !("@language" in v) ? v["@value"] : typeof v === "object" && "@language" in v && "@value" in v
         && typeof v["@language"] === "string"
         && typeof v["@value"] === "string"
         && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value.push(decoded);
+    
     }
     instance.#_2cSy2magg4iZ7zLaG8U7DiJMoCkx_value = _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value;
     
@@ -16420,6 +16741,12 @@ export class DidService {
 
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
+    }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== "object") return true;
+      if (!("_shouldCacheJsonLd" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
     }
     
     /**
@@ -16790,7 +17117,9 @@ get endpoints(): (URL)[] {
         : _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint__array
     ) {
       if (v == null) continue;
-    _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(v["@id"].startsWith("at://")
+    
+      const decoded =
+    v["@id"].startsWith("at://")
         ? new URL("at://" +
           encodeURIComponent(
             v["@id"].includes("/", 5)
@@ -16805,7 +17134,14 @@ get endpoints(): (URL)[] {
         )
         : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))))
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])))
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint.push(decoded);
+    
     }
     instance.#_2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint = _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint;
     
@@ -17234,6 +17570,12 @@ export class DataIntegrityProof {
 
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
+    }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== "object") return true;
+      if (!("_shouldCacheJsonLd" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
     }
     
     /**
@@ -17975,7 +18317,16 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
         : _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite__array
     ) {
       if (v == null) continue;
-    _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite.push(decoded);
+    
     }
     instance.#_3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite = _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite;
     
@@ -18002,10 +18353,19 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
         );
         continue;
       }
-      _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(await Multikey.fromJsonLd(
+      
+      const decoded =
+    await Multikey.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod.push(decoded);
+    
     }
     instance.#_2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod = _2mHVKxqA7zncjveJrDEo3pWpMZqg_verificationMethod;
     const _2AeEnPcAvVrPEuKbpmn9ZKNmWHKb_proofPurpose: ("assertionMethod" | "authentication" | "capabilityInvocation" | "capabilityDelegation" | "keyAgreement")[] = [];
@@ -18020,7 +18380,16 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
         : _2AeEnPcAvVrPEuKbpmn9ZKNmWHKb_proofPurpose__array
     ) {
       if (v == null) continue;
-    _2AeEnPcAvVrPEuKbpmn9ZKNmWHKb_proofPurpose.push(v["@id"].substring(26))
+    
+      const decoded =
+    v["@id"].substring(26)
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2AeEnPcAvVrPEuKbpmn9ZKNmWHKb_proofPurpose.push(decoded);
+    
     }
     instance.#_2AeEnPcAvVrPEuKbpmn9ZKNmWHKb_proofPurpose = _2AeEnPcAvVrPEuKbpmn9ZKNmWHKb_proofPurpose;
     const _3CjFK5vfKpX4HQuNh2b18TykoVLq_proofValue: (Uint8Array)[] = [];
@@ -18035,7 +18404,16 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
         : _3CjFK5vfKpX4HQuNh2b18TykoVLq_proofValue__array
     ) {
       if (v == null) continue;
-    _3CjFK5vfKpX4HQuNh2b18TykoVLq_proofValue.push(decodeMultibase(v["@value"]))
+    
+      const decoded =
+    decodeMultibase(v["@value"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3CjFK5vfKpX4HQuNh2b18TykoVLq_proofValue.push(decoded);
+    
     }
     instance.#_3CjFK5vfKpX4HQuNh2b18TykoVLq_proofValue = _3CjFK5vfKpX4HQuNh2b18TykoVLq_proofValue;
     const _3qzP3ukEZoUziK5FEiA1RhU4aqac: (Temporal.Instant)[] = [];
@@ -18050,11 +18428,20 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
         : _3qzP3ukEZoUziK5FEiA1RhU4aqac__array
     ) {
       if (v == null) continue;
-    _3qzP3ukEZoUziK5FEiA1RhU4aqac.push(Temporal.Instant.from(
+    
+      const decoded =
+    Temporal.Instant.from(
         v["@value"].substring(19).match(/[Z+-]/)
           ? v["@value"]
           : v["@value"] + "Z"
-      ))
+      )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3qzP3ukEZoUziK5FEiA1RhU4aqac.push(decoded);
+    
     }
     instance.#_3qzP3ukEZoUziK5FEiA1RhU4aqac = _3qzP3ukEZoUziK5FEiA1RhU4aqac;
     
@@ -18269,6 +18656,12 @@ export class CryptographicKey {
 
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
+    }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== "object") return true;
+      if (!("_shouldCacheJsonLd" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
     }
     
     /**
@@ -18954,7 +19347,7 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
@@ -18976,12 +19369,17 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner.push(decoded);
+    
     }
     instance.#_5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner = _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner;
     const _2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem: (CryptoKey)[] = [];
@@ -18996,7 +19394,16 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
         : _2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem__array
     ) {
       if (v == null) continue;
-    _2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem.push(await importPem(v["@value"]))
+    
+      const decoded =
+    await importPem(v["@value"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem.push(decoded);
+    
     }
     instance.#_2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem = _2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem;
     
@@ -19155,6 +19562,12 @@ export class Multikey {
 
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
+    }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== "object") return true;
+      if (!("_shouldCacheJsonLd" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
     }
     
     /**
@@ -19847,7 +20260,7 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
@@ -19869,12 +20282,17 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller.push(decoded);
+    
     }
     instance.#_2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller = _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller;
     const _4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase: (CryptoKey)[] = [];
@@ -19889,7 +20307,16 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
         : _4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase__array
     ) {
       if (v == null) continue;
-    _4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase.push(await importMultibaseKey(v["@value"]))
+    
+      const decoded =
+    await importMultibaseKey(v["@value"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase.push(decoded);
+    
     }
     instance.#_4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase = _4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase;
     
@@ -26508,18 +26935,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === "object" && "@value" in v
+    typeof v === "object" && "@value" in v
         && typeof v["@value"] === "string" && !("@language" in v) ? v["@value"] : typeof v === "object" && "@language" in v && "@value" in v
         && typeof v["@language"] === "string"
         && typeof v["@value"] === "string"
         && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
+    
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -26546,10 +26978,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(await CryptographicKey.fromJsonLd(
+      
+      const decoded =
+    await CryptographicKey.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
+    
     }
     instance.#_axq166E2eZADq34V4MYUc8KMZdC_publicKey = _axq166E2eZADq34V4MYUc8KMZdC_publicKey;
     
@@ -26576,10 +27017,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(await Multikey.fromJsonLd(
+      
+      const decoded =
+    await Multikey.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
+    
     }
     instance.#_4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod = _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod;
     const _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers: (boolean)[] = [];
@@ -26594,7 +27044,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers__array
     ) {
       if (v == null) continue;
-    _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(decoded);
+    
     }
     instance.#_36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers = _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers;
     
@@ -26623,7 +27082,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
@@ -26633,12 +27092,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
+    
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -26667,7 +27131,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
@@ -26677,12 +27141,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
+    
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -26709,10 +27178,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
+    
     }
     instance.#_3yAv8jymNfNuJUDuBzJ1NQhdbAee_following = _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following;
     
@@ -26739,10 +27217,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
+    
     }
     instance.#_BBCTgfphhsFzpVfKTykGSpBNwoA_followers = _BBCTgfphhsFzpVfKTykGSpBNwoA_followers;
     
@@ -26769,10 +27256,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
+    
     }
     instance.#_3bgkPwJanyTCoVFM9ovRcus8tKkU_liked = _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked;
     
@@ -26799,10 +27295,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
+    
     }
     instance.#_4N1vBJzXDf8NbBumeECQMFvKetja_featured = _4N1vBJzXDf8NbBumeECQMFvKetja_featured;
     
@@ -26829,10 +27334,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
+    
     }
     instance.#_2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags = _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags;
     
@@ -26859,10 +27373,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
+    
     }
     instance.#_3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams = _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams;
     const _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints: (Endpoints)[] = [];
@@ -26877,10 +27400,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints__array
     ) {
       if (v == null) continue;
-    _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(await Endpoints.fromJsonLd(
+    
+      const decoded =
+    await Endpoints.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
+    
     }
     instance.#_sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints = _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints;
     const _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable: (boolean)[] = [];
@@ -26895,7 +27427,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable__array
     ) {
       if (v == null) continue;
-    _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(decoded);
+    
     }
     instance.#_gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable = _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable;
     const _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended: (boolean)[] = [];
@@ -26910,7 +27451,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended__array
     ) {
       if (v == null) continue;
-    _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(decoded);
+    
     }
     instance.#_2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended = _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended;
     const _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial: (boolean)[] = [];
@@ -26925,7 +27475,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial__array
     ) {
       if (v == null) continue;
-    _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(decoded);
+    
     }
     instance.#_79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial = _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial;
     const _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable: (boolean)[] = [];
@@ -26940,7 +27499,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable__array
     ) {
       if (v == null) continue;
-    _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(decoded);
+    
     }
     instance.#_2diCorzqPGQQqftp6e4SrCEwEnyk_indexable = _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable;
     
@@ -26969,7 +27537,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
@@ -26991,12 +27559,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
+    
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -27025,7 +27598,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
@@ -27047,12 +27620,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
+    
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -27079,10 +27657,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(await DidService.fromJsonLd(
+      
+      const decoded =
+    await DidService.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
+    
     }
     instance.#_4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service = _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service;
     const _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage: (string)[] = [];
@@ -27097,7 +27684,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage__array
     ) {
       if (v == null) continue;
-    _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(decoded);
+    
     }
     instance.#_QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage = _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage;
     const _2xEU4QtkC53RAun67T81Egqt9vmL_isCat: (boolean)[] = [];
@@ -27112,7 +27708,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2xEU4QtkC53RAun67T81Egqt9vmL_isCat__array
     ) {
       if (v == null) continue;
-    _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(decoded);
+    
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
@@ -28739,7 +29344,16 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
         : _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl__array
     ) {
       if (v == null) continue;
-    _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl.push(new URL(v["@value"]))
+    
+      const decoded =
+    new URL(v["@value"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl.push(decoded);
+    
     }
     instance.#_K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl = _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl;
     
@@ -29285,7 +29899,16 @@ proofs?: (DataIntegrityProof | URL)[];width?: number | null;height?: number | nu
         : _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width__array
     ) {
       if (v == null) continue;
-    _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width.push(decoded);
+    
     }
     instance.#_2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width = _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width;
     const _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height: (number)[] = [];
@@ -29300,7 +29923,16 @@ proofs?: (DataIntegrityProof | URL)[];width?: number | null;height?: number | nu
         : _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height__array
     ) {
       if (v == null) continue;
-    _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height.push(decoded);
+    
     }
     instance.#_2cGKFeFJMmiNpGZFEF75mCwFQsKb_height = _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height;
     
@@ -34201,7 +34833,16 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         : _XDbmNDuWHmrhqH712zqtecdbv1V_totalItems__array
     ) {
       if (v == null) continue;
-    _XDbmNDuWHmrhqH712zqtecdbv1V_totalItems.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _XDbmNDuWHmrhqH712zqtecdbv1V_totalItems.push(decoded);
+    
     }
     instance.#_XDbmNDuWHmrhqH712zqtecdbv1V_totalItems = _XDbmNDuWHmrhqH712zqtecdbv1V_totalItems;
     
@@ -34228,10 +34869,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(await CollectionPage.fromJsonLd(
+      
+      const decoded =
+    await CollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3UyUdxnyn6cDn53QKrh4MBiearma_current.push(decoded);
+    
     }
     instance.#_3UyUdxnyn6cDn53QKrh4MBiearma_current = _3UyUdxnyn6cDn53QKrh4MBiearma_current;
     
@@ -34258,10 +34908,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(await CollectionPage.fromJsonLd(
+      
+      const decoded =
+    await CollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _J52RqweMe6hhv7RnLJMC8BExTE5_first.push(decoded);
+    
     }
     instance.#_J52RqweMe6hhv7RnLJMC8BExTE5_first = _J52RqweMe6hhv7RnLJMC8BExTE5_first;
     
@@ -34288,10 +34947,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(await CollectionPage.fromJsonLd(
+      
+      const decoded =
+    await CollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last.push(decoded);
+    
     }
     instance.#_gyJJnyEFnuNVi1HFZKfAn3Hfn26_last = _gyJJnyEFnuNVi1HFZKfAn3Hfn26_last;
     
@@ -34320,7 +34988,7 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -34332,12 +35000,17 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
+    
     }
     instance.#_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items = _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items;
     
@@ -34364,10 +35037,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf.push(decoded);
+    
     }
     instance.#_4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf = _4TB9Qd9ddtcZEpMfzbHhzafE6jaJ_likesOf;
     
@@ -34394,10 +35076,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf.push(decoded);
+    
     }
     instance.#_3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf = _3manzgeKiPsugpztKGiaUUwJ3ito_sharesOf;
     
@@ -34424,10 +35115,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf.push(decoded);
+    
     }
     instance.#_3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf = _3T3oGm3twpcQUcrnMisXQtmDZ32X_repliesOf;
     
@@ -34454,10 +35154,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf.push(decoded);
+    
     }
     instance.#_2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf = _2bvRkAFZjMfVD8jiUWZJr5YokSeN_inboxOf;
     
@@ -34484,10 +35193,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf.push(decoded);
+    
     }
     instance.#_4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf = _4AHzVZDxHjK6uEWa9UiKHGK34yYm_outboxOf;
     
@@ -34514,10 +35232,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf.push(decoded);
+    
     }
     instance.#_41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf = _41aoZ5M6yRUHy3Zx8q6iuZQxtopb_followersOf;
     
@@ -34544,10 +35271,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf.push(decoded);
+    
     }
     instance.#_2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf = _2nXT2Ah42UjEEQF5oJQ39CbKB1xj_followingOf;
     
@@ -34574,10 +35310,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf.push(decoded);
+    
     }
     instance.#_2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf = _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf;
     
@@ -36053,10 +36798,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf.push(decoded);
+    
     }
     instance.#_2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf = _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf;
     
@@ -36083,10 +36837,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(await CollectionPage.fromJsonLd(
+      
+      const decoded =
+    await CollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next.push(decoded);
+    
     }
     instance.#_3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next = _3BT4kQLcXhHx7TAWaNDKh8nFn9eY_next;
     
@@ -36113,10 +36876,19 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         );
         continue;
       }
-      _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(await CollectionPage.fromJsonLd(
+      
+      const decoded =
+    await CollectionPage.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev.push(decoded);
+    
     }
     instance.#_3b8yG8tDNzQFFEnWhCc13G8eHooA_prev = _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev;
     
@@ -37293,6 +38065,12 @@ export class Endpoints {
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
     }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== "object") return true;
+      if (!("_shouldCacheJsonLd" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
+    }
     
     /**
      * The type URI of {@link Endpoints}: \`https://www.w3.org/ns/activitystreams#Endpoints\`.
@@ -38011,7 +38789,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         : _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl__array
     ) {
       if (v == null) continue;
-    _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(v["@id"].startsWith("at://")
+    
+      const decoded =
+    v["@id"].startsWith("at://")
         ? new URL("at://" +
           encodeURIComponent(
             v["@id"].includes("/", 5)
@@ -38026,7 +38806,14 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))))
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])))
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl.push(decoded);
+    
     }
     instance.#_2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl = _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl;
     const _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint: (URL)[] = [];
@@ -38041,7 +38828,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         : _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint__array
     ) {
       if (v == null) continue;
-    _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(v["@id"].startsWith("at://")
+    
+      const decoded =
+    v["@id"].startsWith("at://")
         ? new URL("at://" +
           encodeURIComponent(
             v["@id"].includes("/", 5)
@@ -38056,7 +38845,14 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))))
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])))
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint.push(decoded);
+    
     }
     instance.#_25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint = _25S6UmgzDead8hxL5sQFezZTAusd_oauthAuthorizationEndpoint;
     const _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint: (URL)[] = [];
@@ -38071,7 +38867,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         : _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint__array
     ) {
       if (v == null) continue;
-    _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(v["@id"].startsWith("at://")
+    
+      const decoded =
+    v["@id"].startsWith("at://")
         ? new URL("at://" +
           encodeURIComponent(
             v["@id"].includes("/", 5)
@@ -38086,7 +38884,14 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))))
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])))
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint.push(decoded);
+    
     }
     instance.#_iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint = _iAMxqrSba7yBCRB1FZ5kEVdKEZ3_oauthTokenEndpoint;
     const _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey: (URL)[] = [];
@@ -38101,7 +38906,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         : _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey__array
     ) {
       if (v == null) continue;
-    _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(v["@id"].startsWith("at://")
+    
+      const decoded =
+    v["@id"].startsWith("at://")
         ? new URL("at://" +
           encodeURIComponent(
             v["@id"].includes("/", 5)
@@ -38116,7 +38923,14 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))))
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])))
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey.push(decoded);
+    
     }
     instance.#_8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey = _8Bx9qN8oU7Bpt2xi6khaxWp1gMr_provideClientKey;
     const _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey: (URL)[] = [];
@@ -38131,7 +38945,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         : _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey__array
     ) {
       if (v == null) continue;
-    _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(v["@id"].startsWith("at://")
+    
+      const decoded =
+    v["@id"].startsWith("at://")
         ? new URL("at://" +
           encodeURIComponent(
             v["@id"].includes("/", 5)
@@ -38146,7 +38962,14 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))))
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])))
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey.push(decoded);
+    
     }
     instance.#_3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey = _3dU7PMVQZJpsCpo2F4RQXxBXdPmS_signClientKey;
     const _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox: (URL)[] = [];
@@ -38161,7 +38984,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         : _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox__array
     ) {
       if (v == null) continue;
-    _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(v["@id"].startsWith("at://")
+    
+      const decoded =
+    v["@id"].startsWith("at://")
         ? new URL("at://" +
           encodeURIComponent(
             v["@id"].includes("/", 5)
@@ -38176,7 +39001,14 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
         )
         : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))))
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])))
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox.push(decoded);
+    
     }
     instance.#_3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox = _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox;
     
@@ -44873,18 +45705,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === "object" && "@value" in v
+    typeof v === "object" && "@value" in v
         && typeof v["@value"] === "string" && !("@language" in v) ? v["@value"] : typeof v === "object" && "@language" in v && "@value" in v
         && typeof v["@language"] === "string"
         && typeof v["@value"] === "string"
         && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
+    
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -44911,10 +45748,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(await CryptographicKey.fromJsonLd(
+      
+      const decoded =
+    await CryptographicKey.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
+    
     }
     instance.#_axq166E2eZADq34V4MYUc8KMZdC_publicKey = _axq166E2eZADq34V4MYUc8KMZdC_publicKey;
     
@@ -44941,10 +45787,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(await Multikey.fromJsonLd(
+      
+      const decoded =
+    await Multikey.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
+    
     }
     instance.#_4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod = _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod;
     const _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers: (boolean)[] = [];
@@ -44959,7 +45814,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers__array
     ) {
       if (v == null) continue;
-    _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(decoded);
+    
     }
     instance.#_36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers = _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers;
     
@@ -44988,7 +45852,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
@@ -44998,12 +45862,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
+    
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -45032,7 +45901,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
@@ -45042,12 +45911,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
+    
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -45074,10 +45948,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
+    
     }
     instance.#_3yAv8jymNfNuJUDuBzJ1NQhdbAee_following = _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following;
     
@@ -45104,10 +45987,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
+    
     }
     instance.#_BBCTgfphhsFzpVfKTykGSpBNwoA_followers = _BBCTgfphhsFzpVfKTykGSpBNwoA_followers;
     
@@ -45134,10 +46026,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
+    
     }
     instance.#_3bgkPwJanyTCoVFM9ovRcus8tKkU_liked = _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked;
     
@@ -45164,10 +46065,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
+    
     }
     instance.#_4N1vBJzXDf8NbBumeECQMFvKetja_featured = _4N1vBJzXDf8NbBumeECQMFvKetja_featured;
     
@@ -45194,10 +46104,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
+    
     }
     instance.#_2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags = _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags;
     
@@ -45224,10 +46143,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
+    
     }
     instance.#_3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams = _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams;
     const _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints: (Endpoints)[] = [];
@@ -45242,10 +46170,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints__array
     ) {
       if (v == null) continue;
-    _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(await Endpoints.fromJsonLd(
+    
+      const decoded =
+    await Endpoints.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
+    
     }
     instance.#_sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints = _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints;
     const _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable: (boolean)[] = [];
@@ -45260,7 +46197,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable__array
     ) {
       if (v == null) continue;
-    _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(decoded);
+    
     }
     instance.#_gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable = _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable;
     const _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended: (boolean)[] = [];
@@ -45275,7 +46221,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended__array
     ) {
       if (v == null) continue;
-    _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(decoded);
+    
     }
     instance.#_2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended = _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended;
     const _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial: (boolean)[] = [];
@@ -45290,7 +46245,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial__array
     ) {
       if (v == null) continue;
-    _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(decoded);
+    
     }
     instance.#_79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial = _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial;
     const _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable: (boolean)[] = [];
@@ -45305,7 +46269,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable__array
     ) {
       if (v == null) continue;
-    _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(decoded);
+    
     }
     instance.#_2diCorzqPGQQqftp6e4SrCEwEnyk_indexable = _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable;
     
@@ -45334,7 +46307,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
@@ -45356,12 +46329,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
+    
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -45390,7 +46368,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
@@ -45412,12 +46390,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
+    
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -45444,10 +46427,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(await DidService.fromJsonLd(
+      
+      const decoded =
+    await DidService.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
+    
     }
     instance.#_4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service = _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service;
     const _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage: (string)[] = [];
@@ -45462,7 +46454,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage__array
     ) {
       if (v == null) continue;
-    _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(decoded);
+    
     }
     instance.#_QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage = _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage;
     const _2xEU4QtkC53RAun67T81Egqt9vmL_isCat: (boolean)[] = [];
@@ -45477,7 +46478,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2xEU4QtkC53RAun67T81Egqt9vmL_isCat__array
     ) {
       if (v == null) continue;
-    _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(decoded);
+    
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
@@ -46057,6 +47067,12 @@ export class Link {
 
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
+    }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== "object") return true;
+      if (!("_shouldCacheJsonLd" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
     }
     
     /**
@@ -47283,7 +48299,9 @@ get names(): ((string | LanguageString))[] {
         : _pVjLsybKQdmkjuU7MHjiVmNnuj7_href__array
     ) {
       if (v == null) continue;
-    _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(v["@id"].startsWith("at://")
+    
+      const decoded =
+    v["@id"].startsWith("at://")
         ? new URL("at://" +
           encodeURIComponent(
             v["@id"].includes("/", 5)
@@ -47298,7 +48316,14 @@ get names(): ((string | LanguageString))[] {
         )
         : URL.canParse(v["@id"]) && (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))
           ? new URL(v["@id"])
-          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))))
+          : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"])))
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _pVjLsybKQdmkjuU7MHjiVmNnuj7_href.push(decoded);
+    
     }
     instance.#_pVjLsybKQdmkjuU7MHjiVmNnuj7_href = _pVjLsybKQdmkjuU7MHjiVmNnuj7_href;
     const _2a1c5GkfkQsnyyLybF8UXBQfFuHZ_rel: (string)[] = [];
@@ -47313,7 +48338,16 @@ get names(): ((string | LanguageString))[] {
         : _2a1c5GkfkQsnyyLybF8UXBQfFuHZ_rel__array
     ) {
       if (v == null) continue;
-    _2a1c5GkfkQsnyyLybF8UXBQfFuHZ_rel.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2a1c5GkfkQsnyyLybF8UXBQfFuHZ_rel.push(decoded);
+    
     }
     instance.#_2a1c5GkfkQsnyyLybF8UXBQfFuHZ_rel = _2a1c5GkfkQsnyyLybF8UXBQfFuHZ_rel;
     const _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType: (string)[] = [];
@@ -47328,7 +48362,16 @@ get names(): ((string | LanguageString))[] {
         : _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType__array
     ) {
       if (v == null) continue;
-    _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType.push(decoded);
+    
     }
     instance.#_3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType = _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType;
     const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
@@ -47345,18 +48388,23 @@ get names(): ((string | LanguageString))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === "object" && "@value" in v
+    typeof v === "object" && "@value" in v
         && typeof v["@value"] === "string" && !("@language" in v) ? v["@value"] : typeof v === "object" && "@language" in v && "@value" in v
         && typeof v["@language"] === "string"
         && typeof v["@value"] === "string"
         && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
+    
     }
     instance.#_4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name = _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name;
     const _f57HKWCp1YRBbTJE8PF12RbDJGf_hreflang: (Intl.Locale)[] = [];
@@ -47371,7 +48419,16 @@ get names(): ((string | LanguageString))[] {
         : _f57HKWCp1YRBbTJE8PF12RbDJGf_hreflang__array
     ) {
       if (v == null) continue;
-    _f57HKWCp1YRBbTJE8PF12RbDJGf_hreflang.push(new Intl.Locale(v["@value"]))
+    
+      const decoded =
+    new Intl.Locale(v["@value"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _f57HKWCp1YRBbTJE8PF12RbDJGf_hreflang.push(decoded);
+    
     }
     instance.#_f57HKWCp1YRBbTJE8PF12RbDJGf_hreflang = _f57HKWCp1YRBbTJE8PF12RbDJGf_hreflang;
     const _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height: (number)[] = [];
@@ -47386,7 +48443,16 @@ get names(): ((string | LanguageString))[] {
         : _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height__array
     ) {
       if (v == null) continue;
-    _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height.push(decoded);
+    
     }
     instance.#_2cGKFeFJMmiNpGZFEF75mCwFQsKb_height = _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height;
     const _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width: (number)[] = [];
@@ -47401,7 +48467,16 @@ get names(): ((string | LanguageString))[] {
         : _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width__array
     ) {
       if (v == null) continue;
-    _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width.push(decoded);
+    
     }
     instance.#_2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width = _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width;
     
@@ -47430,7 +48505,7 @@ get names(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Link","https://www.w3.org/ns/activitystreams#Hashtag","https://www.w3.org/ns/activitystreams#Mention"].some(
             t => v["@type"].includes(t)) ? await Link.fromJsonLd(
       v,
@@ -47442,12 +48517,17 @@ get names(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(decoded);
+    
     }
     instance.#_gCVTegXxWWCw6wWRxa1QF65zusg_preview = _gCVTegXxWWCw6wWRxa1QF65zusg_preview;
     
@@ -51437,7 +52517,16 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
         : _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl__array
     ) {
       if (v == null) continue;
-    _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl.push(new URL(v["@value"]))
+    
+      const decoded =
+    new URL(v["@value"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl.push(decoded);
+    
     }
     instance.#_K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl = _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl;
     
@@ -52136,7 +53225,7 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -52148,12 +53237,17 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
+    
     }
     instance.#_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items = _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items;
     
@@ -52931,7 +54025,7 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& ["https://www.w3.org/ns/activitystreams#Object","http://joinmastodon.org/ns#Emoji","http://litepub.social/ns#ChatMessage","https://www.w3.org/ns/activitystreams#Activity","http://litepub.social/ns#EmojiReact","https://www.w3.org/ns/activitystreams#Accept","https://www.w3.org/ns/activitystreams#TentativeAccept","https://www.w3.org/ns/activitystreams#Add","https://www.w3.org/ns/activitystreams#Announce","https://www.w3.org/ns/activitystreams#Create","https://www.w3.org/ns/activitystreams#Delete","https://www.w3.org/ns/activitystreams#Dislike","https://www.w3.org/ns/activitystreams#Flag","https://www.w3.org/ns/activitystreams#Follow","https://www.w3.org/ns/activitystreams#Ignore","https://www.w3.org/ns/activitystreams#Block","https://www.w3.org/ns/activitystreams#IntransitiveActivity","https://www.w3.org/ns/activitystreams#Arrive","https://www.w3.org/ns/activitystreams#Question","https://www.w3.org/ns/activitystreams#Travel","https://www.w3.org/ns/activitystreams#Join","https://www.w3.org/ns/activitystreams#Leave","https://www.w3.org/ns/activitystreams#Like","https://www.w3.org/ns/activitystreams#Listen","https://www.w3.org/ns/activitystreams#Move","https://www.w3.org/ns/activitystreams#Offer","https://www.w3.org/ns/activitystreams#Invite","https://www.w3.org/ns/activitystreams#Read","https://www.w3.org/ns/activitystreams#Reject","https://www.w3.org/ns/activitystreams#TentativeReject","https://www.w3.org/ns/activitystreams#Remove","https://www.w3.org/ns/activitystreams#Undo","https://www.w3.org/ns/activitystreams#Update","https://www.w3.org/ns/activitystreams#View","https://www.w3.org/ns/activitystreams#Application","https://www.w3.org/ns/activitystreams#Article","https://www.w3.org/ns/activitystreams#Collection","https://www.w3.org/ns/activitystreams#CollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollectionPage","https://www.w3.org/ns/activitystreams#OrderedCollection","https://www.w3.org/ns/activitystreams#Document","https://www.w3.org/ns/activitystreams#Audio","https://www.w3.org/ns/activitystreams#Image","https://www.w3.org/ns/activitystreams#Page","https://www.w3.org/ns/activitystreams#Video","https://www.w3.org/ns/activitystreams#Event","https://www.w3.org/ns/activitystreams#Group","https://www.w3.org/ns/activitystreams#Note","https://www.w3.org/ns/activitystreams#Organization","https://www.w3.org/ns/activitystreams#Person","https://www.w3.org/ns/activitystreams#Place","https://www.w3.org/ns/activitystreams#Profile","https://www.w3.org/ns/activitystreams#Relationship","https://www.w3.org/ns/activitystreams#Service","https://www.w3.org/ns/activitystreams#Tombstone"].some(
             t => v["@type"].includes(t)) ? await Object.fromJsonLd(
       v,
@@ -52943,12 +54037,17 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
+    
     }
     instance.#_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items = _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items;
     const _2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex: (number)[] = [];
@@ -52963,7 +54062,16 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
         : _2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex__array
     ) {
       if (v == null) continue;
-    _2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex.push(decoded);
+    
     }
     instance.#_2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex = _2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex;
     
@@ -58541,18 +59649,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === "object" && "@value" in v
+    typeof v === "object" && "@value" in v
         && typeof v["@value"] === "string" && !("@language" in v) ? v["@value"] : typeof v === "object" && "@language" in v && "@value" in v
         && typeof v["@language"] === "string"
         && typeof v["@value"] === "string"
         && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
+    
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -58579,10 +59692,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(await CryptographicKey.fromJsonLd(
+      
+      const decoded =
+    await CryptographicKey.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
+    
     }
     instance.#_axq166E2eZADq34V4MYUc8KMZdC_publicKey = _axq166E2eZADq34V4MYUc8KMZdC_publicKey;
     
@@ -58609,10 +59731,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(await Multikey.fromJsonLd(
+      
+      const decoded =
+    await Multikey.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
+    
     }
     instance.#_4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod = _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod;
     const _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers: (boolean)[] = [];
@@ -58627,7 +59758,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers__array
     ) {
       if (v == null) continue;
-    _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(decoded);
+    
     }
     instance.#_36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers = _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers;
     
@@ -58656,7 +59796,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
@@ -58666,12 +59806,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
+    
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -58700,7 +59845,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
@@ -58710,12 +59855,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
+    
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -58742,10 +59892,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
+    
     }
     instance.#_3yAv8jymNfNuJUDuBzJ1NQhdbAee_following = _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following;
     
@@ -58772,10 +59931,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
+    
     }
     instance.#_BBCTgfphhsFzpVfKTykGSpBNwoA_followers = _BBCTgfphhsFzpVfKTykGSpBNwoA_followers;
     
@@ -58802,10 +59970,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
+    
     }
     instance.#_3bgkPwJanyTCoVFM9ovRcus8tKkU_liked = _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked;
     
@@ -58832,10 +60009,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
+    
     }
     instance.#_4N1vBJzXDf8NbBumeECQMFvKetja_featured = _4N1vBJzXDf8NbBumeECQMFvKetja_featured;
     
@@ -58862,10 +60048,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
+    
     }
     instance.#_2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags = _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags;
     
@@ -58892,10 +60087,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
+    
     }
     instance.#_3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams = _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams;
     const _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints: (Endpoints)[] = [];
@@ -58910,10 +60114,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints__array
     ) {
       if (v == null) continue;
-    _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(await Endpoints.fromJsonLd(
+    
+      const decoded =
+    await Endpoints.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
+    
     }
     instance.#_sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints = _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints;
     const _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable: (boolean)[] = [];
@@ -58928,7 +60141,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable__array
     ) {
       if (v == null) continue;
-    _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(decoded);
+    
     }
     instance.#_gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable = _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable;
     const _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended: (boolean)[] = [];
@@ -58943,7 +60165,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended__array
     ) {
       if (v == null) continue;
-    _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(decoded);
+    
     }
     instance.#_2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended = _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended;
     const _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial: (boolean)[] = [];
@@ -58958,7 +60189,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial__array
     ) {
       if (v == null) continue;
-    _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(decoded);
+    
     }
     instance.#_79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial = _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial;
     const _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable: (boolean)[] = [];
@@ -58973,7 +60213,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable__array
     ) {
       if (v == null) continue;
-    _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(decoded);
+    
     }
     instance.#_2diCorzqPGQQqftp6e4SrCEwEnyk_indexable = _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable;
     
@@ -59002,7 +60251,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
@@ -59024,12 +60273,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
+    
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -59058,7 +60312,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
@@ -59080,12 +60334,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
+    
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -59112,10 +60371,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(await DidService.fromJsonLd(
+      
+      const decoded =
+    await DidService.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
+    
     }
     instance.#_4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service = _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service;
     const _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage: (string)[] = [];
@@ -59130,7 +60398,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage__array
     ) {
       if (v == null) continue;
-    _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(decoded);
+    
     }
     instance.#_QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage = _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage;
     const _2xEU4QtkC53RAun67T81Egqt9vmL_isCat: (boolean)[] = [];
@@ -59145,7 +60422,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2xEU4QtkC53RAun67T81Egqt9vmL_isCat__array
     ) {
       if (v == null) continue;
-    _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(decoded);
+    
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
@@ -65496,18 +66782,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === "object" && "@value" in v
+    typeof v === "object" && "@value" in v
         && typeof v["@value"] === "string" && !("@language" in v) ? v["@value"] : typeof v === "object" && "@language" in v && "@value" in v
         && typeof v["@language"] === "string"
         && typeof v["@value"] === "string"
         && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
+    
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -65534,10 +66825,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(await CryptographicKey.fromJsonLd(
+      
+      const decoded =
+    await CryptographicKey.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
+    
     }
     instance.#_axq166E2eZADq34V4MYUc8KMZdC_publicKey = _axq166E2eZADq34V4MYUc8KMZdC_publicKey;
     
@@ -65564,10 +66864,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(await Multikey.fromJsonLd(
+      
+      const decoded =
+    await Multikey.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
+    
     }
     instance.#_4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod = _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod;
     const _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers: (boolean)[] = [];
@@ -65582,7 +66891,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers__array
     ) {
       if (v == null) continue;
-    _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(decoded);
+    
     }
     instance.#_36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers = _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers;
     
@@ -65611,7 +66929,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
@@ -65621,12 +66939,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
+    
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -65655,7 +66978,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
@@ -65665,12 +66988,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
+    
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -65697,10 +67025,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
+    
     }
     instance.#_3yAv8jymNfNuJUDuBzJ1NQhdbAee_following = _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following;
     
@@ -65727,10 +67064,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
+    
     }
     instance.#_BBCTgfphhsFzpVfKTykGSpBNwoA_followers = _BBCTgfphhsFzpVfKTykGSpBNwoA_followers;
     
@@ -65757,10 +67103,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
+    
     }
     instance.#_3bgkPwJanyTCoVFM9ovRcus8tKkU_liked = _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked;
     
@@ -65787,10 +67142,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
+    
     }
     instance.#_4N1vBJzXDf8NbBumeECQMFvKetja_featured = _4N1vBJzXDf8NbBumeECQMFvKetja_featured;
     
@@ -65817,10 +67181,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
+    
     }
     instance.#_2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags = _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags;
     
@@ -65847,10 +67220,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
+    
     }
     instance.#_3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams = _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams;
     const _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints: (Endpoints)[] = [];
@@ -65865,10 +67247,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints__array
     ) {
       if (v == null) continue;
-    _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(await Endpoints.fromJsonLd(
+    
+      const decoded =
+    await Endpoints.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
+    
     }
     instance.#_sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints = _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints;
     const _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable: (boolean)[] = [];
@@ -65883,7 +67274,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable__array
     ) {
       if (v == null) continue;
-    _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(decoded);
+    
     }
     instance.#_gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable = _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable;
     const _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended: (boolean)[] = [];
@@ -65898,7 +67298,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended__array
     ) {
       if (v == null) continue;
-    _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(decoded);
+    
     }
     instance.#_2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended = _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended;
     const _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial: (boolean)[] = [];
@@ -65913,7 +67322,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial__array
     ) {
       if (v == null) continue;
-    _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(decoded);
+    
     }
     instance.#_79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial = _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial;
     const _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable: (boolean)[] = [];
@@ -65928,7 +67346,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable__array
     ) {
       if (v == null) continue;
-    _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(decoded);
+    
     }
     instance.#_2diCorzqPGQQqftp6e4SrCEwEnyk_indexable = _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable;
     
@@ -65957,7 +67384,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
@@ -65979,12 +67406,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
+    
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -66013,7 +67445,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
@@ -66035,12 +67467,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
+    
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -66067,10 +67504,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(await DidService.fromJsonLd(
+      
+      const decoded =
+    await DidService.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
+    
     }
     instance.#_4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service = _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service;
     const _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage: (string)[] = [];
@@ -66085,7 +67531,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage__array
     ) {
       if (v == null) continue;
-    _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(decoded);
+    
     }
     instance.#_QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage = _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage;
     const _2xEU4QtkC53RAun67T81Egqt9vmL_isCat: (boolean)[] = [];
@@ -66100,7 +67555,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2xEU4QtkC53RAun67T81Egqt9vmL_isCat__array
     ) {
       if (v == null) continue;
-    _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(decoded);
+    
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
@@ -67386,7 +68850,16 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
         : _3UCsHnBHvDAXJnBuzw3zw1VVs3Ne_accuracy__array
     ) {
       if (v == null) continue;
-    _3UCsHnBHvDAXJnBuzw3zw1VVs3Ne_accuracy.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3UCsHnBHvDAXJnBuzw3zw1VVs3Ne_accuracy.push(decoded);
+    
     }
     instance.#_3UCsHnBHvDAXJnBuzw3zw1VVs3Ne_accuracy = _3UCsHnBHvDAXJnBuzw3zw1VVs3Ne_accuracy;
     const _3Q6KDcFQUJRRaBux1BL2yp5QWiBi_altitude: (number)[] = [];
@@ -67401,7 +68874,16 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
         : _3Q6KDcFQUJRRaBux1BL2yp5QWiBi_altitude__array
     ) {
       if (v == null) continue;
-    _3Q6KDcFQUJRRaBux1BL2yp5QWiBi_altitude.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3Q6KDcFQUJRRaBux1BL2yp5QWiBi_altitude.push(decoded);
+    
     }
     instance.#_3Q6KDcFQUJRRaBux1BL2yp5QWiBi_altitude = _3Q6KDcFQUJRRaBux1BL2yp5QWiBi_altitude;
     const _3g85RoKRnaNjP7DFyLSvsWDg7HGM_latitude: (number)[] = [];
@@ -67416,7 +68898,16 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
         : _3g85RoKRnaNjP7DFyLSvsWDg7HGM_latitude__array
     ) {
       if (v == null) continue;
-    _3g85RoKRnaNjP7DFyLSvsWDg7HGM_latitude.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3g85RoKRnaNjP7DFyLSvsWDg7HGM_latitude.push(decoded);
+    
     }
     instance.#_3g85RoKRnaNjP7DFyLSvsWDg7HGM_latitude = _3g85RoKRnaNjP7DFyLSvsWDg7HGM_latitude;
     const _B2GEYdS9yBAF3ho1pm1rcRg7cSf_longitude: (number)[] = [];
@@ -67431,7 +68922,16 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
         : _B2GEYdS9yBAF3ho1pm1rcRg7cSf_longitude__array
     ) {
       if (v == null) continue;
-    _B2GEYdS9yBAF3ho1pm1rcRg7cSf_longitude.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _B2GEYdS9yBAF3ho1pm1rcRg7cSf_longitude.push(decoded);
+    
     }
     instance.#_B2GEYdS9yBAF3ho1pm1rcRg7cSf_longitude = _B2GEYdS9yBAF3ho1pm1rcRg7cSf_longitude;
     const _3ga86BKHUtRkGx5PHBjRiUXXzwnw_radius: (number)[] = [];
@@ -67446,7 +68946,16 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
         : _3ga86BKHUtRkGx5PHBjRiUXXzwnw_radius__array
     ) {
       if (v == null) continue;
-    _3ga86BKHUtRkGx5PHBjRiUXXzwnw_radius.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3ga86BKHUtRkGx5PHBjRiUXXzwnw_radius.push(decoded);
+    
     }
     instance.#_3ga86BKHUtRkGx5PHBjRiUXXzwnw_radius = _3ga86BKHUtRkGx5PHBjRiUXXzwnw_radius;
     const _oKrwxU4V8wiKhMW1QEYQibcJh8c_units: (("cm" | "feet" | "inches" | "km" | "m" | "miles" | URL))[] = [];
@@ -67463,7 +68972,7 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
       if (v == null) continue;
     
       const decoded =
-      typeof v === "object" && "@value" in v
+    typeof v === "object" && "@value" in v
       && (v["@value"] == "cm" || v["@value"] == "feet" || v["@value"] == "inches" || v["@value"] == "km" || v["@value"] == "m" || v["@value"] == "miles") ? v["@value"] : typeof v === "object" && "@id" in v
         && typeof v["@id"] === "string"
         && v["@id"] !== "" ? v["@id"].startsWith("at://")
@@ -67483,12 +68992,17 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
           ? new URL(v["@id"])
           : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
+    
     }
     instance.#_oKrwxU4V8wiKhMW1QEYQibcJh8c_units = _oKrwxU4V8wiKhMW1QEYQibcJh8c_units;
     
@@ -68263,10 +69777,19 @@ proofs?: (DataIntegrityProof | URL)[];describes?: Object | URL | null;}
         );
         continue;
       }
-      _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes.push(decoded);
+    
     }
     instance.#_3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes = _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes;
     
@@ -69400,10 +70923,19 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         );
         continue;
       }
-      _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf.push(decoded);
+    
     }
     instance.#_2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf = _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf;
     
@@ -69430,10 +70962,19 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         );
         continue;
       }
-      _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf.push(decoded);
+    
     }
     instance.#_2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf = _2mV6isMTPRKbWdLCjcpiEysq5dAY_anyOf;
     const _3KronwL8DiiKBRcJFKQPiEHm8xb6_closed: ((Temporal.Instant | boolean))[] = [];
@@ -69450,7 +70991,7 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       if (v == null) continue;
     
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
         && "@value" in v && typeof v["@value"] === "string"
         && v["@type"] === "http://www.w3.org/2001/XMLSchema#dateTime"
         // Check if the value is a valid RFC 3339 date-time string
@@ -69462,12 +71003,17 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       ) : typeof v === "object" && "@value" in v
         && typeof v["@value"] === "boolean" ? v["@value"] : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3KronwL8DiiKBRcJFKQPiEHm8xb6_closed.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3KronwL8DiiKBRcJFKQPiEHm8xb6_closed.push(decoded);
+    
     }
     instance.#_3KronwL8DiiKBRcJFKQPiEHm8xb6_closed = _3KronwL8DiiKBRcJFKQPiEHm8xb6_closed;
     const _3H4RdST7dxfmghccvE3rKD3KgcxG_votersCount: (number)[] = [];
@@ -69482,7 +71028,16 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         : _3H4RdST7dxfmghccvE3rKD3KgcxG_votersCount__array
     ) {
       if (v == null) continue;
-    _3H4RdST7dxfmghccvE3rKD3KgcxG_votersCount.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3H4RdST7dxfmghccvE3rKD3KgcxG_votersCount.push(decoded);
+    
     }
     instance.#_3H4RdST7dxfmghccvE3rKD3KgcxG_votersCount = _3H4RdST7dxfmghccvE3rKD3KgcxG_votersCount;
     const _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl: (URL)[] = [];
@@ -69505,7 +71060,16 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
         : _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl__array
     ) {
       if (v == null) continue;
-    _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl.push(new URL(v["@value"]))
+    
+      const decoded =
+    new URL(v["@value"])
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl.push(decoded);
+    
     }
     instance.#_K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl = _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl;
     
@@ -71817,10 +73381,19 @@ relationships?: (Object | URL)[];}
         );
         continue;
       }
-      _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject.push(decoded);
+    
     }
     instance.#_2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject = _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject;
     
@@ -71847,10 +73420,19 @@ relationships?: (Object | URL)[];}
         );
         continue;
       }
-      _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object.push(decoded);
+    
     }
     instance.#_2MH19yxjn1wnHsNfa5n4JBhJzxyc_object = _2MH19yxjn1wnHsNfa5n4JBhJzxyc_object;
     
@@ -71877,10 +73459,19 @@ relationships?: (Object | URL)[];}
         );
         continue;
       }
-      _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(await Object.fromJsonLd(
+      
+      const decoded =
+    await Object.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship.push(decoded);
+    
     }
     instance.#_4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship = _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship;
     
@@ -77828,18 +79419,23 @@ get preferredUsernames(): ((string | LanguageString))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === "object" && "@value" in v
+    typeof v === "object" && "@value" in v
         && typeof v["@value"] === "string" && !("@language" in v) ? v["@value"] : typeof v === "object" && "@language" in v && "@value" in v
         && typeof v["@language"] === "string"
         && typeof v["@value"] === "string"
         && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
+    
     }
     instance.#_3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername = _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername;
     
@@ -77866,10 +79462,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(await CryptographicKey.fromJsonLd(
+      
+      const decoded =
+    await CryptographicKey.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _axq166E2eZADq34V4MYUc8KMZdC_publicKey.push(decoded);
+    
     }
     instance.#_axq166E2eZADq34V4MYUc8KMZdC_publicKey = _axq166E2eZADq34V4MYUc8KMZdC_publicKey;
     
@@ -77896,10 +79501,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(await Multikey.fromJsonLd(
+      
+      const decoded =
+    await Multikey.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod.push(decoded);
+    
     }
     instance.#_4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod = _4EHQFWZSz1k1d4LmPrQiMba2GbP3_assertionMethod;
     const _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers: (boolean)[] = [];
@@ -77914,7 +79528,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers__array
     ) {
       if (v == null) continue;
-    _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers.push(decoded);
+    
     }
     instance.#_36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers = _36QNc9MxfkKf6h8sEUQSHnV9NZA_manuallyApprovesFollowers;
     
@@ -77943,7 +79566,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
@@ -77953,12 +79576,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
+    
     }
     instance.#_3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox = _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox;
     
@@ -77987,7 +79615,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#OrderedCollection") ? await OrderedCollection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
@@ -77997,12 +79625,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
+    
     }
     instance.#_41QwhqJouoLg3h8dRPKat21brynC_outbox = _41QwhqJouoLg3h8dRPKat21brynC_outbox;
     
@@ -78029,10 +79662,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following.push(decoded);
+    
     }
     instance.#_3yAv8jymNfNuJUDuBzJ1NQhdbAee_following = _3yAv8jymNfNuJUDuBzJ1NQhdbAee_following;
     
@@ -78059,10 +79701,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _BBCTgfphhsFzpVfKTykGSpBNwoA_followers.push(decoded);
+    
     }
     instance.#_BBCTgfphhsFzpVfKTykGSpBNwoA_followers = _BBCTgfphhsFzpVfKTykGSpBNwoA_followers;
     
@@ -78089,10 +79740,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked.push(decoded);
+    
     }
     instance.#_3bgkPwJanyTCoVFM9ovRcus8tKkU_liked = _3bgkPwJanyTCoVFM9ovRcus8tKkU_liked;
     
@@ -78119,10 +79779,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4N1vBJzXDf8NbBumeECQMFvKetja_featured.push(decoded);
+    
     }
     instance.#_4N1vBJzXDf8NbBumeECQMFvKetja_featured = _4N1vBJzXDf8NbBumeECQMFvKetja_featured;
     
@@ -78149,10 +79818,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags.push(decoded);
+    
     }
     instance.#_2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags = _2MxnRRLq9iPzx5CFq2NPrXdUDCac_featuredTags;
     
@@ -78179,10 +79857,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(await Collection.fromJsonLd(
+      
+      const decoded =
+    await Collection.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams.push(decoded);
+    
     }
     instance.#_3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams = _3sG2Hdwn9qzKGu9mpYkqakAMUkH9_streams;
     const _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints: (Endpoints)[] = [];
@@ -78197,10 +79884,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints__array
     ) {
       if (v == null) continue;
-    _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(await Endpoints.fromJsonLd(
+    
+      const decoded =
+    await Endpoints.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints.push(decoded);
+    
     }
     instance.#_sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints = _sEoQwUbfk4hEfugzNQ2ZiDcLMkG_endpoints;
     const _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable: (boolean)[] = [];
@@ -78215,7 +79911,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable__array
     ) {
       if (v == null) continue;
-    _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable.push(decoded);
+    
     }
     instance.#_gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable = _gAJzg1QDc4rcefFsUzGSYmyXvNH_discoverable;
     const _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended: (boolean)[] = [];
@@ -78230,7 +79935,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended__array
     ) {
       if (v == null) continue;
-    _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended.push(decoded);
+    
     }
     instance.#_2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended = _2kGKkJtoFWg8c18PaVSqj9NKP4t7_suspended;
     const _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial: (boolean)[] = [];
@@ -78245,7 +79959,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial__array
     ) {
       if (v == null) continue;
-    _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial.push(decoded);
+    
     }
     instance.#_79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial = _79S8K4f5J9MWUgCxziRyUe6PTHZ_memorial;
     const _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable: (boolean)[] = [];
@@ -78260,7 +79983,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable__array
     ) {
       if (v == null) continue;
-    _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable.push(decoded);
+    
     }
     instance.#_2diCorzqPGQQqftp6e4SrCEwEnyk_indexable = _2diCorzqPGQQqftp6e4SrCEwEnyk_indexable;
     
@@ -78289,7 +80021,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
@@ -78311,12 +80043,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
+    
     }
     instance.#_2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo = _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo;
     
@@ -78345,7 +80082,7 @@ get preferredUsernames(): ((string | LanguageString))[] {
       }
       
       const decoded =
-      typeof v === "object" && "@type" in v
+    typeof v === "object" && "@type" in v
       && Array.isArray(v["@type"])&& v["@type"].includes("https://www.w3.org/ns/activitystreams#Application") ? await Application.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
@@ -78367,12 +80104,17 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
+    
     }
     instance.#_3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs = _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs;
     
@@ -78399,10 +80141,19 @@ get preferredUsernames(): ((string | LanguageString))[] {
         );
         continue;
       }
-      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(await DidService.fromJsonLd(
+      
+      const decoded =
+    await DidService.fromJsonLd(
       v,
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
-    ))
+    )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service.push(decoded);
+    
     }
     instance.#_4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service = _4Q6NrKH6bazBGtxwG8vyG77ir7Tg_service;
     const _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage: (string)[] = [];
@@ -78417,7 +80168,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage__array
     ) {
       if (v == null) continue;
-    _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage.push(decoded);
+    
     }
     instance.#_QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage = _QuxorEK1txp7jGjq8BRQfTPvUwp__misskey_followedMessage;
     const _2xEU4QtkC53RAun67T81Egqt9vmL_isCat: (boolean)[] = [];
@@ -78432,7 +80192,16 @@ get preferredUsernames(): ((string | LanguageString))[] {
         : _2xEU4QtkC53RAun67T81Egqt9vmL_isCat__array
     ) {
       if (v == null) continue;
-    _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _2xEU4QtkC53RAun67T81Egqt9vmL_isCat.push(decoded);
+    
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
@@ -79005,6 +80774,12 @@ export class Source {
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
     }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== "object") return true;
+      if (!("_shouldCacheJsonLd" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
+    }
     
     /**
      * The type URI of {@link Source}: \`https://www.w3.org/ns/activitystreams#Source\`.
@@ -79477,18 +81252,23 @@ get contents(): ((string | LanguageString))[] {
       if (v == null) continue;
     
       const decoded =
-      typeof v === "object" && "@value" in v
+    typeof v === "object" && "@value" in v
         && typeof v["@value"] === "string" && !("@language" in v) ? v["@value"] : typeof v === "object" && "@language" in v && "@value" in v
         && typeof v["@language"] === "string"
         && typeof v["@value"] === "string"
         && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
+    
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
       
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
+    
     }
     instance.#_4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content = _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content;
     const _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType: (string)[] = [];
@@ -79503,7 +81283,16 @@ get contents(): ((string | LanguageString))[] {
         : _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType__array
     ) {
       if (v == null) continue;
-    _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType.push(v["@value"])
+    
+      const decoded =
+    v["@value"]
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType.push(decoded);
+    
     }
     instance.#_3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType = _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType;
     
@@ -80681,11 +82470,20 @@ proofs?: (DataIntegrityProof | URL)[];deleted?: Temporal.Instant | null;}
         : _8g8g4LiVMhFTXskuDEqx4ascxUr_deleted__array
     ) {
       if (v == null) continue;
-    _8g8g4LiVMhFTXskuDEqx4ascxUr_deleted.push(Temporal.Instant.from(
+    
+      const decoded =
+    Temporal.Instant.from(
         v["@value"].substring(19).match(/[Z+-]/)
           ? v["@value"]
           : v["@value"] + "Z"
-      ))
+      )
+      ;
+    
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      _8g8g4LiVMhFTXskuDEqx4ascxUr_deleted.push(decoded);
+    
     }
     instance.#_8g8g4LiVMhFTXskuDEqx4ascxUr_deleted = _8g8g4LiVMhFTXskuDEqx4ascxUr_deleted;
     

--- a/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
+++ b/packages/vocab-tools/src/__snapshots__/class.test.ts.snap
@@ -52,6 +52,7 @@ export class Object {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -80,6 +81,14 @@ export class Object {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -9402,6 +9411,8 @@ get urls(): ((URL | Link))[] {
       options,
     );
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _49BipA5dq9eoH8LX8xdsVumveTca_attachment: (Object | Link | PropertyValue | URL)[] = [];
       const _trust_49BipA5dq9eoH8LX8xdsVumveTca_attachment: Set<number> = new Set();
     
@@ -9443,7 +9454,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _49BipA5dq9eoH8LX8xdsVumveTca_attachment.push(decoded);
       
     }
@@ -9496,7 +9510,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _42CGqJ94zgQ3ZBbfHwD8Hrr2L5Py_attributedTo.push(decoded);
       
     }
@@ -9551,7 +9568,10 @@ get urls(): ((URL | Link))[] {
         && typeof v["@value"] === "string"
         && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
       
     }
@@ -9594,7 +9614,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3mhZzGXSpQ431mBSz2kvych22v4e_context.push(decoded);
       
     }
@@ -9619,7 +9642,10 @@ get urls(): ((URL | Link))[] {
         && typeof v["@value"] === "string"
         && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
       
     }
@@ -9681,7 +9707,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _86xFhmgBapoMvYqjbjRuDPayTrS_generator.push(decoded);
       
     }
@@ -9784,7 +9813,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3fpbDrvZgf3Kq1a5V9aByFn8kx3s_inReplyTo.push(decoded);
       
     }
@@ -9827,7 +9859,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _31k5MUZJsnsPNg8dQQJieWaXTFnR_location.push(decoded);
       
     }
@@ -9870,7 +9905,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(decoded);
       
     }
@@ -10053,7 +10091,10 @@ get urls(): ((URL | Link))[] {
         && typeof v["@value"] === "string"
         && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _4LqirZspQbFWWQEbFcXAxm7tTDN1_summary.push(decoded);
       
     }
@@ -10096,7 +10137,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _5chuqj6s95p5gg2sk1HntGfarRf_tag.push(decoded);
       
     }
@@ -10158,7 +10202,10 @@ get urls(): ((URL | Link))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2oPEH9MQ3aj8JVwyYuWkqoVwV865_url.push(decoded);
       
     }
@@ -10377,7 +10424,11 @@ get urls(): ((URL | Link))[] {
     }
     instance.#_42rPnotok1ivQ2RNCKNbeFJgx8b8_proof = _42rPnotok1ivQ2RNCKNbeFJgx8b8_proof;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -11473,7 +11524,13 @@ proofs?: (DataIntegrityProof | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -11909,7 +11966,9 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
     if (!(instance instanceof ChatMessage)) {
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
-    const _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl: (URL)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl: (URL)[] = [];
 
     let _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl__array = values["https://www.w3.org/ns/activitystreams#quoteUrl"];
     
@@ -11933,7 +11992,11 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
     }
     instance.#_K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl = _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -14930,6 +14993,8 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor: (Application | Group | Organization | Person | Service | URL)[] = [];
       const _trust_2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor: Set<number> = new Set();
     
@@ -14977,7 +15042,10 @@ instruments?: (Object | URL)[];}
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2DjTTboo3CNHU2a2JQqUSE2dbv9D_actor.push(decoded);
       
     }
@@ -15133,7 +15201,11 @@ instruments?: (Object | URL)[];}
     }
     instance.#_3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument = _3c5t2x7DYRo2shwTxpkd4kYSS5WQ_instrument;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -15622,7 +15694,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -15677,6 +15755,7 @@ export class PropertyValue {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -15705,6 +15784,14 @@ export class PropertyValue {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -16119,7 +16206,9 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
       { id: "@id" in values ? new URL(values["@id"] as string) : undefined },
       options,
     );
-    const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name: ((string | LanguageString))[] = [];
 
     let _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name__array = values["https://www.w3.org/ns/activitystreams#name"];
     
@@ -16139,7 +16228,10 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         && typeof v["@value"] === "string"
         && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
       
     }
@@ -16164,13 +16256,20 @@ name?: string | LanguageString | null;value?: string | LanguageString | null;}
         && typeof v["@value"] === "string"
         && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value.push(decoded);
       
     }
     instance.#_2cSy2magg4iZ7zLaG8U7DiJMoCkx_value = _2cSy2magg4iZ7zLaG8U7DiJMoCkx_value;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -16284,6 +16383,7 @@ export class DidService {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -16312,6 +16412,14 @@ export class DidService {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -16668,7 +16776,9 @@ get endpoints(): (URL)[] {
       { id: "@id" in values ? new URL(values["@id"] as string) : undefined },
       options,
     );
-    const _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint: (URL)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint: (URL)[] = [];
 
     let _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint__array = values["https://www.w3.org/ns/did#serviceEndpoint"];
     
@@ -16699,7 +16809,11 @@ get endpoints(): (URL)[] {
     }
     instance.#_2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint = _2KM4fetG6FTJ1cphj76rzJ8Dyv7p_serviceEndpoint;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -17020,7 +17134,13 @@ endpoints?: (URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -17077,6 +17197,7 @@ export class DataIntegrityProof {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -17105,6 +17226,14 @@ export class DataIntegrityProof {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -17832,7 +17961,9 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
       { id: "@id" in values ? new URL(values["@id"] as string) : undefined },
       options,
     );
-    const _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite: ("eddsa-jcs-2022")[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite: ("eddsa-jcs-2022")[] = [];
 
     let _3RurJsa7tnptyqMFR5hDGcP9pMs5_cryptosuite__array = values["https://w3id.org/security#cryptosuite"];
     
@@ -17927,7 +18058,11 @@ cryptosuite?: "eddsa-jcs-2022" | null;verificationMethod?: Multikey | URL | null
     }
     instance.#_3qzP3ukEZoUziK5FEiA1RhU4aqac = _3qzP3ukEZoUziK5FEiA1RhU4aqac;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -18097,6 +18232,7 @@ export class CryptographicKey {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -18125,6 +18261,14 @@ export class CryptographicKey {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -18783,6 +18927,8 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       options,
     );
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner: (Application | Group | Organization | Person | Service | URL)[] = [];
       const _trust_5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner: Set<number> = new Set();
     
@@ -18830,7 +18976,10 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _5UJq9NDh3ZHgswFwwdVxQvJxdx2_owner.push(decoded);
       
     }
@@ -18851,7 +19000,11 @@ owner?: Application | Group | Organization | Person | Service | URL | null;publi
     }
     instance.#_2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem = _2fE2QMDdg6KFGqa4NEC3TmjApSAD_publicKeyPem;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -18965,6 +19118,7 @@ export class Multikey {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -18993,6 +19147,14 @@ export class Multikey {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -19658,6 +19820,8 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       options,
     );
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller: (Application | Group | Organization | Person | Service | URL)[] = [];
       const _trust_2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller: Set<number> = new Set();
     
@@ -19705,7 +19869,10 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2yr3eUBTP6cNcyaxKzAXWjFsnGzN_controller.push(decoded);
       
     }
@@ -19726,7 +19893,11 @@ controller?: Application | Group | Organization | Person | Service | URL | null;
     }
     instance.#_4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase = _4XLHbsR2gLVWU3NpEqKt9wANzn4F_publicKeyMultibase;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -20120,7 +20291,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -20456,7 +20633,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -20791,7 +20974,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -26303,7 +26492,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
     if (!(instance instanceof Application)) {
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
-    const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
 
     let _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername__array = values["https://www.w3.org/ns/activitystreams#preferredUsername"];
     
@@ -26323,7 +26514,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
         && typeof v["@value"] === "string"
         && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
     }
@@ -26439,7 +26633,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
     }
@@ -26480,7 +26677,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
     }
@@ -26791,7 +26991,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
     }
@@ -26844,7 +27047,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
     }
@@ -26910,7 +27116,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -27729,7 +27939,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -28064,7 +28280,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -28495,7 +28717,9 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
     if (!(instance instanceof Article)) {
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
-    const _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl: (URL)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl: (URL)[] = [];
 
     let _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl__array = values["https://www.w3.org/ns/activitystreams#quoteUrl"];
     
@@ -28519,7 +28743,11 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
     }
     instance.#_K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl = _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -29043,7 +29271,9 @@ proofs?: (DataIntegrityProof | URL)[];width?: number | null;height?: number | nu
     if (!(instance instanceof Document)) {
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
-    const _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width: (number)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width: (number)[] = [];
 
     let _2e9AP7WdHBJYAgXG6GEyq7nSkNMe_width__array = values["https://www.w3.org/ns/activitystreams#width"];
     
@@ -29074,7 +29304,11 @@ proofs?: (DataIntegrityProof | URL)[];width?: number | null;height?: number | nu
     }
     instance.#_2cGKFeFJMmiNpGZFEF75mCwFQsKb_height = _2cGKFeFJMmiNpGZFEF75mCwFQsKb_height;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -29451,7 +29685,13 @@ proofs?: (DataIntegrityProof | URL)[];width?: number | null;height?: number | nu
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -29789,7 +30029,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -30125,7 +30371,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -33935,7 +34187,9 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
     if (!(instance instanceof Collection)) {
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
-    const _XDbmNDuWHmrhqH712zqtecdbv1V_totalItems: (number)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _XDbmNDuWHmrhqH712zqtecdbv1V_totalItems: (number)[] = [];
 
     let _XDbmNDuWHmrhqH712zqtecdbv1V_totalItems__array = values["https://www.w3.org/ns/activitystreams#totalItems"];
     
@@ -34078,7 +34332,10 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
       
     }
@@ -34324,7 +34581,11 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
     }
     instance.#_2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf = _2bsySzmT3qEZcrnoe3tZ5xBjXSju_likedOf;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -35767,6 +36028,8 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf: (Collection | URL)[] = [];
       const _trust_2kWgBhQKjEauxx8C6qF3ZQamK4Le_partOf: Set<number> = new Set();
     
@@ -35857,7 +36120,11 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
     }
     instance.#_3b8yG8tDNzQFFEnWhCc13G8eHooA_prev = _3b8yG8tDNzQFFEnWhCc13G8eHooA_prev;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -36249,7 +36516,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -36583,7 +36856,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -36915,7 +37194,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -36970,6 +37255,7 @@ export class Endpoints {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -36998,6 +37284,14 @@ export class Endpoints {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -37703,7 +37997,9 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
       { id: "@id" in values ? new URL(values["@id"] as string) : undefined },
       options,
     );
-    const _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl: (URL)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl: (URL)[] = [];
 
     let _2JCYDbSxEHCCLdBYed33cCETfGyR_proxyUrl__array = values["https://www.w3.org/ns/activitystreams#proxyUrl"];
     
@@ -37884,7 +38180,11 @@ proxyUrl?: URL | null;oauthAuthorizationEndpoint?: URL | null;oauthTokenEndpoint
     }
     instance.#_3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox = _3JprUSDLVqqX4dwHRi37qGZZCRCc_sharedInbox;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -38356,7 +38656,13 @@ proofs?: (DataIntegrityProof | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -38691,7 +38997,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -39027,7 +39339,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -44539,7 +44857,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
     if (!(instance instanceof Group)) {
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
-    const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
 
     let _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername__array = values["https://www.w3.org/ns/activitystreams#preferredUsername"];
     
@@ -44559,7 +44879,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
         && typeof v["@value"] === "string"
         && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
     }
@@ -44675,7 +44998,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
     }
@@ -44716,7 +45042,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
     }
@@ -45027,7 +45356,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
     }
@@ -45080,7 +45412,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
     }
@@ -45146,7 +45481,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -45681,6 +46020,7 @@ export class Link {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -45709,6 +46049,14 @@ export class Link {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -46921,7 +47269,9 @@ get names(): ((string | LanguageString))[] {
       { id: "@id" in values ? new URL(values["@id"] as string) : undefined },
       options,
     );
-    const _pVjLsybKQdmkjuU7MHjiVmNnuj7_href: (URL)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _pVjLsybKQdmkjuU7MHjiVmNnuj7_href: (URL)[] = [];
 
     let _pVjLsybKQdmkjuU7MHjiVmNnuj7_href__array = values["https://www.w3.org/ns/activitystreams#href"];
     
@@ -47001,7 +47351,10 @@ get names(): ((string | LanguageString))[] {
         && typeof v["@value"] === "string"
         && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _4ZHbBuK7PrsvGgrjM8wgc6KMWjav_name.push(decoded);
       
     }
@@ -47089,13 +47442,20 @@ get names(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _gCVTegXxWWCw6wWRxa1QF65zusg_preview.push(decoded);
       
     }
     instance.#_gCVTegXxWWCw6wWRxa1QF65zusg_preview = _gCVTegXxWWCw6wWRxa1QF65zusg_preview;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -47585,7 +47945,13 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -47922,7 +48288,13 @@ proofs?: (DataIntegrityProof | URL)[];width?: number | null;height?: number | nu
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -48261,7 +48633,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -48595,7 +48973,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -48929,7 +49313,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -49263,7 +49653,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -49597,7 +49993,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -49929,7 +50331,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -50227,7 +50635,13 @@ names?: ((string | LanguageString))[];language?: Intl.Locale | null;height?: num
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -50562,7 +50976,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -50995,7 +51415,9 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
     if (!(instance instanceof Note)) {
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
-    const _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl: (URL)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl: (URL)[] = [];
 
     let _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl__array = values["https://www.w3.org/ns/activitystreams#quoteUrl"];
     
@@ -51019,7 +51441,11 @@ proofs?: (DataIntegrityProof | URL)[];quoteUrl?: URL | null;}
     }
     instance.#_K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl = _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -51683,6 +52109,8 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items: (Object | Link | URL)[] = [];
       const _trust_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items: Set<number> = new Set();
     
@@ -51720,13 +52148,20 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
       
     }
     instance.#_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items = _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -52469,6 +52904,8 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items: (Object | Link | URL)[] = [];
       const _trust_2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items: Set<number> = new Set();
     
@@ -52506,7 +52943,10 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2JPCKWTcfBmTCcW8Tv3TpRaLVaqg_items.push(decoded);
       
     }
@@ -52527,7 +52967,11 @@ proofs?: (DataIntegrityProof | URL)[];totalItems?: number | null;current?: Colle
     }
     instance.#_2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex = _2W4yinFwqmpneu2h4m1mZ3pcLADd_startIndex;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -58081,7 +58525,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
     if (!(instance instanceof Organization)) {
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
-    const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
 
     let _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername__array = values["https://www.w3.org/ns/activitystreams#preferredUsername"];
     
@@ -58101,7 +58547,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
         && typeof v["@value"] === "string"
         && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
     }
@@ -58217,7 +58666,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
     }
@@ -58258,7 +58710,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
     }
@@ -58569,7 +59024,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
     }
@@ -58622,7 +59080,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
     }
@@ -58688,7 +59149,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -59497,7 +59962,13 @@ proofs?: (DataIntegrityProof | URL)[];width?: number | null;height?: number | nu
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -65009,7 +65480,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
     if (!(instance instanceof Person)) {
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
-    const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
 
     let _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername__array = values["https://www.w3.org/ns/activitystreams#preferredUsername"];
     
@@ -65029,7 +65502,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
         && typeof v["@value"] === "string"
         && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
     }
@@ -65145,7 +65621,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
     }
@@ -65186,7 +65665,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
     }
@@ -65497,7 +65979,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
     }
@@ -65550,7 +66035,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
     }
@@ -65616,7 +66104,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -66880,7 +67372,9 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
     if (!(instance instanceof Place)) {
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
-    const _3UCsHnBHvDAXJnBuzw3zw1VVs3Ne_accuracy: (number)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _3UCsHnBHvDAXJnBuzw3zw1VVs3Ne_accuracy: (number)[] = [];
 
     let _3UCsHnBHvDAXJnBuzw3zw1VVs3Ne_accuracy__array = values["https://www.w3.org/ns/activitystreams#accuracy"];
     
@@ -66989,13 +67483,20 @@ proofs?: (DataIntegrityProof | URL)[];accuracy?: number | null;altitude?: number
           ? new URL(v["@id"])
           : new URL(v["@id"], (values["@id"] == null ? options.baseUrl : new URL(values["@id"]))) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _oKrwxU4V8wiKhMW1QEYQibcJh8c_units.push(decoded);
       
     }
     instance.#_oKrwxU4V8wiKhMW1QEYQibcJh8c_units = _oKrwxU4V8wiKhMW1QEYQibcJh8c_units;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -67737,6 +68238,8 @@ proofs?: (DataIntegrityProof | URL)[];describes?: Object | URL | null;}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes: (Object | URL)[] = [];
       const _trust_3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes: Set<number> = new Set();
     
@@ -67767,7 +68270,11 @@ proofs?: (DataIntegrityProof | URL)[];describes?: Object | URL | null;}
     }
     instance.#_3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes = _3CLQ1PLSXrhSQbTGGHuxNyaEFKM1_describes;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -68868,6 +69375,8 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf: (Object | URL)[] = [];
       const _trust_2N5scKaVEcdYHFmfKYYacAwUhUgQ_oneOf: Set<number> = new Set();
     
@@ -68953,7 +69462,10 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
       ) : typeof v === "object" && "@value" in v
         && typeof v["@value"] === "boolean" ? v["@value"] : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3KronwL8DiiKBRcJFKQPiEHm8xb6_closed.push(decoded);
       
     }
@@ -68997,7 +69509,11 @@ instruments?: (Object | URL)[];exclusiveOptions?: (Object | URL)[];inclusiveOpti
     }
     instance.#_K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl = _K1zrMQkQjmciFAmGdGLfaDbG925_quoteUrl;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -69434,7 +69950,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -69772,7 +70294,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -71264,6 +71792,8 @@ relationships?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
       const _2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject: (Object | URL)[] = [];
       const _trust_2Zqdmi46ZnDQsECS6mzwhrv3rUKq_subject: Set<number> = new Set();
     
@@ -71354,7 +71884,11 @@ relationships?: (Object | URL)[];}
     }
     instance.#_4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship = _4Lzz89F9qipAQSGkWyX9DGWiUojG_relationship;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -71760,7 +72294,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -77272,7 +77812,9 @@ get preferredUsernames(): ((string | LanguageString))[] {
     if (!(instance instanceof Service)) {
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
-    const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername: ((string | LanguageString))[] = [];
 
     let _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername__array = values["https://www.w3.org/ns/activitystreams#preferredUsername"];
     
@@ -77292,7 +77834,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
         && typeof v["@value"] === "string"
         && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3isuDgRAKSntq9XdbjiNxjwyPZAf_preferredUsername.push(decoded);
       
     }
@@ -77408,7 +77953,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3ghX3VfZXXbLvhCRH7QJqpzLrXjB_inbox.push(decoded);
       
     }
@@ -77449,7 +77997,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _41QwhqJouoLg3h8dRPKat21brynC_outbox.push(decoded);
       
     }
@@ -77760,7 +78311,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _2ZNWDhuNdSXBwEmrB5kwffdKGzok_movedTo.push(decoded);
       
     }
@@ -77813,7 +78367,10 @@ get preferredUsernames(): ((string | LanguageString))[] {
       { ...options, baseUrl: (values["@id"] == null ? options.baseUrl : new URL(values["@id"])) }
     ) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _3NV7TGNhuABbryNjNi4wib4DgNpY_alsoKnownAs.push(decoded);
       
     }
@@ -77879,7 +78436,11 @@ get preferredUsernames(): ((string | LanguageString))[] {
     }
     instance.#_2xEU4QtkC53RAun67T81Egqt9vmL_isCat = _2xEU4QtkC53RAun67T81Egqt9vmL_isCat;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -78406,6 +78967,7 @@ export class Source {
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -78434,6 +78996,14 @@ export class Source {
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     
     /**
@@ -78891,7 +79461,9 @@ get contents(): ((string | LanguageString))[] {
       { id: "@id" in values ? new URL(values["@id"] as string) : undefined },
       options,
     );
-    const _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content: ((string | LanguageString))[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content: ((string | LanguageString))[] = [];
 
     let _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content__array = values["https://www.w3.org/ns/activitystreams#content"];
     
@@ -78911,7 +79483,10 @@ get contents(): ((string | LanguageString))[] {
         && typeof v["@value"] === "string"
         && isValidLanguageTag(v["@language"]) ? new LanguageString(v["@value"], v["@language"]) : undefined
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       _4HuuRSdSrXq8Jj2J9gcdYfoCzeuz_content.push(decoded);
       
     }
@@ -78932,7 +79507,11 @@ get contents(): ((string | LanguageString))[] {
     }
     instance.#_3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType = _3BLrzmscsjHCw8TF5BHRW9WkPnX8_mediaType;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -79327,7 +79906,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -79661,7 +80246,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -80076,7 +80667,9 @@ proofs?: (DataIntegrityProof | URL)[];deleted?: Temporal.Instant | null;}
     if (!(instance instanceof Tombstone)) {
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
-    const _8g8g4LiVMhFTXskuDEqx4ascxUr_deleted: (Temporal.Instant)[] = [];
+    
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  const _8g8g4LiVMhFTXskuDEqx4ascxUr_deleted: (Temporal.Instant)[] = [];
 
     let _8g8g4LiVMhFTXskuDEqx4ascxUr_deleted__array = values["https://www.w3.org/ns/activitystreams#deleted"];
     
@@ -80096,7 +80689,11 @@ proofs?: (DataIntegrityProof | URL)[];deleted?: Temporal.Instant | null;}
     }
     instance.#_8g8g4LiVMhFTXskuDEqx4ascxUr_deleted = _8g8g4LiVMhFTXskuDEqx4ascxUr_deleted;
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -80452,7 +81049,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -80791,7 +81394,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -81128,7 +81737,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -81465,7 +82080,13 @@ proofs?: (DataIntegrityProof | URL)[];width?: number | null;height?: number | nu
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {
@@ -81798,7 +82419,13 @@ instruments?: (Object | URL)[];}
       throw new TypeError("Unexpected type: " + instance.constructor.name);
     }
     
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {

--- a/packages/vocab-tools/src/class.ts
+++ b/packages/vocab-tools/src/class.ts
@@ -138,6 +138,17 @@ export async function* generateClasses(
     isTemporalDuration,
     isTemporalInstant,
 } from "@fedify/vocab-runtime/temporal";\n`;
+  yield `
+function isValidLanguageTag(language: string): boolean {
+  try {
+    new Intl.Locale(language);
+    return true;
+  } catch (error) {
+    if (error instanceof RangeError) return false;
+    throw error;
+  }
+}
+`;
   yield "\n\n";
   const sorted = sortTopologically(types);
   for (const typeUri of sorted) {

--- a/packages/vocab-tools/src/class.ts
+++ b/packages/vocab-tools/src/class.ts
@@ -95,6 +95,12 @@ async function* generateClass(
     protected set _shouldCacheJsonLd(value: boolean) {
       this.#shouldCacheJsonLd = value;
     }
+
+    protected static _shouldCacheDecodedJsonLd(value: unknown): boolean {
+      if (value == null || typeof value !== "object") return true;
+      if (!("_shouldCacheJsonLd" in value)) return true;
+      return (value as { _shouldCacheJsonLd: boolean })._shouldCacheJsonLd;
+    }
     `;
   }
   yield `

--- a/packages/vocab-tools/src/class.ts
+++ b/packages/vocab-tools/src/class.ts
@@ -57,6 +57,7 @@ async function* generateClass(
       values?: Record<string, unknown>;
     };
     #cachedJsonLd?: unknown;
+    #shouldCacheJsonLd = true;
     readonly id: URL | null;
 
     protected get _documentLoader(): DocumentLoader | undefined {
@@ -85,6 +86,14 @@ async function* generateClass(
 
     protected set _cachedJsonLd(value: unknown | undefined) {
       this.#cachedJsonLd = value;
+    }
+
+    protected get _shouldCacheJsonLd(): boolean {
+      return this.#shouldCacheJsonLd;
+    }
+
+    protected set _shouldCacheJsonLd(value: boolean) {
+      this.#shouldCacheJsonLd = value;
     }
     `;
   }

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -438,20 +438,18 @@ export async function* generateDecoder(
       }
       `;
     }
-    if (property.range.length == 1) {
-      yield `${variable}.push(${
-        getDecoder(
-          property.range[0],
-          types,
-          "v",
-          "options",
-          `(values["@id"] == null ? options.baseUrl : new URL(values["@id"]))`,
-        )
-      })`;
-    } else {
-      yield `
+    yield `
       const decoded =
-      `;
+    `;
+    if (property.range.length == 1) {
+      yield getDecoder(
+        property.range[0],
+        types,
+        "v",
+        "options",
+        `(values["@id"] == null ? options.baseUrl : new URL(values["@id"]))`,
+      );
+    } else {
       const decoders = getDecoders(
         property.range,
         types,
@@ -460,15 +458,24 @@ export async function* generateDecoder(
         `(values["@id"] == null ? options.baseUrl : new URL(values["@id"]))`,
       );
       for (const code of decoders) yield code;
-      yield `
+    }
+    yield `
       ;
+    `;
+    if (property.range.length > 1) {
+      yield `
       if (typeof decoded === "undefined") {
         shouldCacheJsonLd = false;
         continue;
       }
-      ${variable}.push(decoded);
       `;
     }
+    yield `
+      if (!this._shouldCacheDecodedJsonLd(decoded)) {
+        shouldCacheJsonLd = false;
+      }
+      ${variable}.push(decoded);
+    `;
     yield `
     }
     instance.${await getFieldName(property.uri)} = ${variable};

--- a/packages/vocab-tools/src/codec.ts
+++ b/packages/vocab-tools/src/codec.ts
@@ -396,6 +396,9 @@ export async function* generateDecoder(
     }
     `;
   }
+  yield `
+    let shouldCacheJsonLd = instance._shouldCacheJsonLd;
+  `;
   for (const property of type.properties) {
     const variable = await getFieldName(property.uri, "");
     yield await generateField(property, types, "const ");
@@ -459,7 +462,10 @@ export async function* generateDecoder(
       for (const code of decoders) yield code;
       yield `
       ;
-      if (typeof decoded === "undefined") continue;
+      if (typeof decoded === "undefined") {
+        shouldCacheJsonLd = false;
+        continue;
+      }
       ${variable}.push(decoded);
       `;
     }
@@ -469,7 +475,11 @@ export async function* generateDecoder(
     `;
   }
   yield `
-    if (!("_fromSubclass" in options) || !options._fromSubclass) {
+    instance._shouldCacheJsonLd = shouldCacheJsonLd;
+    if (
+      shouldCacheJsonLd &&
+      (!("_fromSubclass" in options) || !options._fromSubclass)
+    ) {
       try {
         instance._cachedJsonLd = structuredClone(json);
       } catch {

--- a/packages/vocab-tools/src/type.ts
+++ b/packages/vocab-tools/src/type.ts
@@ -176,7 +176,8 @@ const scalarTypes: Record<string, ScalarType> = {
     dataCheck(v) {
       return `typeof ${v} === "object" && "@language" in ${v} && "@value" in ${v}
         && typeof ${v}["@language"] === "string"
-        && typeof ${v}["@value"] === "string"`;
+        && typeof ${v}["@value"] === "string"
+        && isValidLanguageTag(${v}["@language"])`;
     },
     decoder(v) {
       return `new LanguageString(${v}["@value"], ${v}["@language"])`;

--- a/packages/vocab/src/vocab.test.ts
+++ b/packages/vocab/src/vocab.test.ts
@@ -31,6 +31,7 @@ import {
   OrderedCollectionPage,
   Person,
   Place,
+  PropertyValue,
   Question,
   Source,
 } from "./vocab.ts";
@@ -280,6 +281,26 @@ test("Note.fromJsonLd() ignores malformed language tags", async () => {
   deepStrictEqual(note.contents, [new LanguageString("Hi", "en")]);
   const jsonLd = await note.toJsonLd() as Record<string, unknown>;
   deepStrictEqual(jsonLd.contentMap, { en: "Hi" });
+});
+
+test("Note.fromJsonLd() ignores malformed language tags in nested objects", async () => {
+  const note = await Note.fromJsonLd({
+    "@type": ["https://www.w3.org/ns/activitystreams#Note"],
+    "https://www.w3.org/ns/activitystreams#attachment": [{
+      "@type": ["http://schema.org#PropertyValue"],
+      "https://www.w3.org/ns/activitystreams#name": [
+        { "@value": "Malformed", "@language": "invalid_tag" },
+        { "@value": "Valid", "@language": "en" },
+      ],
+    }],
+  });
+
+  deepStrictEqual(await Array.fromAsync(note.getAttachments()), [
+    new PropertyValue({ name: new LanguageString("Valid", "en") }),
+  ]);
+  const jsonLd = await note.toJsonLd() as Record<string, unknown>;
+  const attachment = jsonLd.attachment as Record<string, unknown>;
+  deepStrictEqual(attachment.nameMap, { en: "Valid" });
 });
 
 test("Note.toJsonLd()", async () => {

--- a/packages/vocab/src/vocab.test.ts
+++ b/packages/vocab/src/vocab.test.ts
@@ -267,6 +267,19 @@ test("Object.toJsonLd()", async () => {
   });
 });
 
+test("Note.fromJsonLd() ignores malformed language tags", async () => {
+  const note = await Note.fromJsonLd({
+    "@context": "https://www.w3.org/ns/activitystreams",
+    type: "Note",
+    contentMap: {
+      invalid_tag: "Hello",
+      en: "Hi",
+    },
+  });
+
+  deepStrictEqual(note.contents, [new LanguageString("Hi", "en")]);
+});
+
 test("Note.toJsonLd()", async () => {
   const note = new Note({
     tags: [

--- a/packages/vocab/src/vocab.test.ts
+++ b/packages/vocab/src/vocab.test.ts
@@ -278,6 +278,8 @@ test("Note.fromJsonLd() ignores malformed language tags", async () => {
   });
 
   deepStrictEqual(note.contents, [new LanguageString("Hi", "en")]);
+  const jsonLd = await note.toJsonLd() as Record<string, unknown>;
+  deepStrictEqual(jsonLd.contentMap, { en: "Hi" });
 });
 
 test("Note.toJsonLd()", async () => {


### PR DESCRIPTION
Why this patch handles the error in the parser
----------------------------------------------

Remote JSON-LD can contain a language map key that `Intl.Locale` does not accept. Before this patch, the generated vocabulary parser still passed that key into `new LanguageString(...)`, so a malformed remote field could surface as a `RangeError` while parsing an inbox activity.

The fix keeps `LanguageString` itself strict. Constructing one directly with an invalid tag should still fail, because that is useful feedback for local code. The generated parser has a different job: it is reading remote input and already skips scalar values that do not match any supported decoded shape. This patch makes invalid language tags follow that same path.


How the parser now avoids the crash
-----------------------------------

The `rdf:langString` data check in *packages/vocab-tools/src/type.ts* now requires the `@language` value to be accepted by `Intl.Locale` before emitting a `LanguageString` constructor call. *packages/vocab-tools/src/class.ts* emits the helper used by generated vocabulary classes.

That helper catches only `RangeError`, which is the error shape used for a bad locale identifier. Other errors still propagate. That keeps the fallback narrow: malformed remote language tags are treated as bad input, but unrelated programming or runtime errors are not hidden.

The regression test in *packages/vocab/src/vocab.test.ts* uses a `Note` with a mixed `contentMap`: one malformed language key and one valid `en` key. The valid entry still parses, and the malformed entry is ignored.


Verification
------------

I ran the targeted regression test first and confirmed that it failed with the old `RangeError`. After the fix, these checks passed:

 -  `deno task -f @fedify/vocab test --filter "Note.fromJsonLd() ignores malformed language tags"`
 -  `mise run test:update_snapshots`
 -  `git diff --check`
 -  `mise run check`
 -  `mise run test-each vocab-tools vocab`
