### PR TITLE
Fix collection dispatchers 404 after `build()`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,19 @@ Version 2.0.22
 
 To be released.
 
+### @fedify/fedify
+
+ -  Fixed custom collection dispatchers registered through
+    `FederationBuilder.setCollectionDispatcher()` and
+    `setOrderedCollectionDispatcher()` returning 404 Not Found after
+    `build()`.  `build()` now copies the collection callbacks and item types
+    onto the built federation, so the registered routes dispatch their
+    collections instead of being treated as unknown routes.
+    [[#849], [#851] by ChanHaeng Lee]
+
+[#849]: https://github.com/fedify-dev/fedify/issues/849
+[#851]: https://github.com/fedify-dev/fedify/pull/851
+
 ### @fedify/vocab
 
  -  Fixed Activity Vocabulary parsing so malformed language tags in remote

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ To be released.
 
  -  Fixed custom collection dispatchers registered through
     `FederationBuilder.setCollectionDispatcher()` and
-    `setOrderedCollectionDispatcher()` returning 404 Not Found after
+    `setOrderedCollectionDispatcher()` returning `404 Not Found` after
     `build()`.  `build()` now copies the collection callbacks and item types
     onto the built federation, so the registered routes dispatch their
     collections instead of being treated as unknown routes.

--- a/packages/cli/src/startup.test.ts
+++ b/packages/cli/src/startup.test.ts
@@ -10,7 +10,14 @@ const packageDir = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 async function runCommand(
   command: string,
   args: string[],
-): Promise<{ code: number | null; stdout: string; stderr: string }> {
+): Promise<
+  {
+    code: number | null;
+    signal: NodeJS.Signals | null;
+    stdout: string;
+    stderr: string;
+  }
+> {
   return await new Promise((resolvePromise, reject) => {
     const child = spawn(command, args, {
       cwd: packageDir,
@@ -26,8 +33,8 @@ async function runCommand(
       stderr += chunk;
     });
     child.on("error", reject);
-    child.on("close", (code) => {
-      resolvePromise({ code, stdout, stderr });
+    child.on("close", (code, signal) => {
+      resolvePromise({ code, signal, stdout, stderr });
     });
   });
 }
@@ -38,11 +45,15 @@ function getNodeCommand(): string {
     : process.execPath;
 }
 
-test("CLI starts successfully with --help", async () => {
+test("CLI starts successfully with --help", { timeout: 60_000 }, async () => {
   const result = await runCommand(getNodeCommand(), [
     resolve(packageDir, "dist/mod.js"),
     "--help",
   ]);
-  strictEqual(result.code, 0, result.stderr);
+  strictEqual(
+    result.code,
+    0,
+    `exited with signal ${result.signal}; stderr: ${result.stderr}`,
+  );
   match(result.stdout, /fedify/);
 });

--- a/packages/fedify/src/federation/builder.test.ts
+++ b/packages/fedify/src/federation/builder.test.ts
@@ -286,4 +286,37 @@ test("FederationBuilder", async (t) => {
       );
     },
   );
+
+  await t.step(
+    "propagates custom collection dispatchers to the built federation",
+    async () => {
+      const kv = new MemoryKvStore();
+      const builder = createFederationBuilder<void>();
+      builder.setCollectionDispatcher(
+        "test",
+        Note,
+        "/c/{id}",
+        () => ({ items: [] }),
+      );
+
+      const impl = (await builder.build({
+        kv,
+        origin: "https://example.com",
+      })) as FederationImpl<void>;
+
+      // The dispatcher callback and item type must reach the built
+      // federation, not just the route.
+      assertExists(impl.collectionCallbacks["test"]);
+      assertEquals(impl.collectionTypeIds["test"], Note);
+
+      // End-to-end: the registered route must dispatch instead of 404ing.
+      const response = await impl.fetch(
+        new Request("https://example.com/c/x", {
+          headers: { accept: "application/activity+json" },
+        }),
+        { contextData: undefined },
+      );
+      assertEquals(response.status, 200);
+    },
+  );
 });

--- a/packages/fedify/src/federation/builder.ts
+++ b/packages/fedify/src/federation/builder.ts
@@ -163,6 +163,8 @@ export class FederationBuilderImpl<TContextData>
     f.webFingerLinksDispatcher = this.webFingerLinksDispatcher;
     f.objectCallbacks = { ...this.objectCallbacks };
     f.objectTypeIds = { ...this.objectTypeIds };
+    f.collectionCallbacks = { ...this.collectionCallbacks };
+    f.collectionTypeIds = { ...this.collectionTypeIds };
     f.inboxPath = this.inboxPath;
     f.inboxCallbacks = this.inboxCallbacks == null
       ? undefined


### PR DESCRIPTION
Summary
-------

Fixes custom collection dispatchers registered through `FederationBuilder` returning 404 after `build()` (#849).  Also includes a small test-only mitigation for a flaky CLI startup test that fails under `mise run test` (#908).


Related issue
-------------

 -  fixes https://github.com/fedify-dev/fedify/issues/849
 -  relates to https://github.com/fedify-dev/fedify/issues/908 (test-only mitigation; the broader fix is tracked there)


Changes
-------

 -  `FederationBuilderImpl.build()` now copies `collectionCallbacks` and `collectionTypeIds` onto the built federation, alongside the object callbacks and type IDs it already copied.
 -  Added a regression test in *builder.test.ts* that builds a federation with a custom collection dispatcher and asserts both that the callbacks/item types reach the built federation and that the registered route dispatches with 200 instead of 404.
 -  Gave the *startup.test.ts* "CLI starts successfully with --help" test an explicit 60s timeout and made its subprocess `close` handler capture the termination signal for clearer failure messages.


Benefits
--------

 -  Custom collection dispatchers (`setCollectionDispatcher()` / `setOrderedCollectionDispatcher()`) configured via the builder now work end-to-end after `build()`, instead of silently 404ing.
 -  The CLI startup test no longer fails intermittently under the parallel `mise run test` matrix, where Bun's default 5000ms per-test timeout would kill the slow-to-start subprocess and surface a confusing `null !== 0` error.  Capturing the signal also makes any future failure diagnosable.

Additional notes
----------------

 -  Targets `2.0-maintenance` as the oldest branch containing the bug.
 -  The *startup.test.ts* change is a local mitigation only.  The agreed broader fix — adding an explicit `--timeout` to the `test:bun` scripts of `cli`, `debugger`, and `vocab-tools` — is tracked in #908 and intentionally not bundled here.
 -  AI disclosure: Assisted-by: Claude Code:claude-opus-4.8