### PR TITLE
Cover example runner timeout parsing

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,15 +8,6 @@ Version 2.4.0
 
 To be released.
 
-### Documentation and examples
-
- -  Added focused coverage for the example test runner's documented
-    `--timeout` option so contributor checks catch regressions in its CLI
-    parsing.  [[#887], [#910] by Matteo Stella]
-
-[#887]: https://github.com/fedify-dev/fedify/issues/887
-[#910]: https://github.com/fedify-dev/fedify/pull/910
-
 
 Version 2.3.1
 -------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,15 @@ Version 2.4.0
 
 To be released.
 
+### Documentation and examples
+
+ -  Added focused coverage for the example test runner's documented
+    `--timeout` option so contributor checks catch regressions in its CLI
+    parsing.  [[#887], [#910] by Matteo Stella]
+
+[#887]: https://github.com/fedify-dev/fedify/issues/887
+[#910]: https://github.com/fedify-dev/fedify/pull/910
+
 
 Version 2.3.1
 -------------

--- a/deno.json
+++ b/deno.json
@@ -121,6 +121,7 @@
   },
   "test": {
     "include": [
+      "./examples/test-examples",
       "./packages"
     ],
     "exclude": [

--- a/examples/test-examples/mod.test.ts
+++ b/examples/test-examples/mod.test.ts
@@ -37,6 +37,8 @@ describe("parseCliArgs", () => {
     const options = parseCliArgs([
       "--timeout",
       "--debug",
+      "--timeout",
+      "-d",
       "--timeout=",
       "--timeout=-1",
       "express",
@@ -44,6 +46,20 @@ describe("parseCliArgs", () => {
 
     strictEqual(options.defaultTimeoutMs, 10_000);
     strictEqual(options.debugMode, true);
+    deepStrictEqual([...options.filterNames], ["express"]);
+  });
+
+  it("consumes invalid timeout values without treating them as filters", () => {
+    const options = parseCliArgs([
+      "--timeout",
+      "abc",
+      "--timeout",
+      "-1",
+      "express",
+    ]);
+
+    strictEqual(options.defaultTimeoutMs, 10_000);
+    strictEqual(options.debugMode, false);
     deepStrictEqual([...options.filterNames], ["express"]);
   });
 });

--- a/examples/test-examples/mod.test.ts
+++ b/examples/test-examples/mod.test.ts
@@ -1,0 +1,35 @@
+import { deepStrictEqual, strictEqual } from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { parseCliArgs } from "./mod.ts";
+
+describe("parseCliArgs", () => {
+  it("uses the documented default timeout", () => {
+    const options = parseCliArgs([]);
+
+    strictEqual(options.defaultTimeoutMs, 10_000);
+    strictEqual(options.debugMode, false);
+    deepStrictEqual([...options.filterNames], []);
+  });
+
+  it("honors --timeout with a separate value", () => {
+    const options = parseCliArgs(["--timeout", "2500", "hono-sample"]);
+
+    strictEqual(options.defaultTimeoutMs, 2500);
+    strictEqual(options.debugMode, false);
+    deepStrictEqual([...options.filterNames], ["hono-sample"]);
+  });
+
+  it("honors --timeout=value and debug aliases", () => {
+    const options = parseCliArgs([
+      "--timeout=1500",
+      "-d",
+      "express",
+      "koa",
+    ]);
+
+    strictEqual(options.defaultTimeoutMs, 1500);
+    strictEqual(options.debugMode, true);
+    deepStrictEqual([...options.filterNames], ["express", "koa"]);
+  });
+});

--- a/examples/test-examples/mod.test.ts
+++ b/examples/test-examples/mod.test.ts
@@ -32,4 +32,18 @@ describe("parseCliArgs", () => {
     strictEqual(options.debugMode, true);
     deepStrictEqual([...options.filterNames], ["express", "koa"]);
   });
+
+  it("ignores invalid timeout values without skipping flags", () => {
+    const options = parseCliArgs([
+      "--timeout",
+      "--debug",
+      "--timeout=",
+      "--timeout=-1",
+      "express",
+    ]);
+
+    strictEqual(options.defaultTimeoutMs, 10_000);
+    strictEqual(options.debugMode, true);
+    deepStrictEqual([...options.filterNames], ["express"]);
+  });
 });

--- a/examples/test-examples/mod.ts
+++ b/examples/test-examples/mod.ts
@@ -128,6 +128,13 @@ interface CliOptions {
   filterNames: Set<string>;
 }
 
+function parseTimeoutMs(value: string | undefined): number | undefined {
+  if (value == null || value.trim() === "") return undefined;
+  const timeoutMs = Number(value);
+  if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) return undefined;
+  return timeoutMs;
+}
+
 export function parseCliArgs(args: readonly string[]): CliOptions {
   let defaultTimeoutMs = 10_000;
   let debugMode = false;
@@ -135,10 +142,14 @@ export function parseCliArgs(args: readonly string[]): CliOptions {
 
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
-    if (arg === "--timeout" && i + 1 < args.length) {
-      defaultTimeoutMs = Number(args[++i]);
+    if (arg === "--timeout") {
+      const timeoutMs = parseTimeoutMs(args[i + 1]);
+      if (timeoutMs == null) continue;
+      defaultTimeoutMs = timeoutMs;
+      i++;
     } else if (arg.startsWith("--timeout=")) {
-      defaultTimeoutMs = Number(arg.slice("--timeout=".length));
+      const timeoutMs = parseTimeoutMs(arg.slice("--timeout=".length));
+      if (timeoutMs != null) defaultTimeoutMs = timeoutMs;
     } else if (arg === "--debug" || arg === "-d") {
       debugMode = true;
     } else if (!arg.startsWith("--")) {

--- a/examples/test-examples/mod.ts
+++ b/examples/test-examples/mod.ts
@@ -135,6 +135,10 @@ function parseTimeoutMs(value: string | undefined): number | undefined {
   return timeoutMs;
 }
 
+function isCliFlag(value: string): boolean {
+  return value === "-d" || value.startsWith("--");
+}
+
 export function parseCliArgs(args: readonly string[]): CliOptions {
   let defaultTimeoutMs = 10_000;
   let debugMode = false;
@@ -143,10 +147,14 @@ export function parseCliArgs(args: readonly string[]): CliOptions {
   for (let i = 0; i < args.length; i++) {
     const arg = args[i];
     if (arg === "--timeout") {
-      const timeoutMs = parseTimeoutMs(args[i + 1]);
-      if (timeoutMs == null) continue;
-      defaultTimeoutMs = timeoutMs;
-      i++;
+      const rawValue = args[i + 1];
+      const timeoutMs = parseTimeoutMs(rawValue);
+      if (timeoutMs != null) {
+        defaultTimeoutMs = timeoutMs;
+        i++;
+      } else if (rawValue != null && !isCliFlag(rawValue)) {
+        i++;
+      }
     } else if (arg.startsWith("--timeout=")) {
       const timeoutMs = parseTimeoutMs(arg.slice("--timeout=".length));
       if (timeoutMs != null) defaultTimeoutMs = timeoutMs;

--- a/examples/test-examples/mod.ts
+++ b/examples/test-examples/mod.ts
@@ -33,34 +33,31 @@ const REPO_ROOT = fromFileUrl(new URL("../../", import.meta.url));
 
 // ─── Logging ──────────────────────────────────────────────────────────────────
 //
-// We configure logtape before everything else so that log calls in helpers
-// work even if they execute at module-initialization time.
-//
 // All test-runner logs live under the ["fedify", "examples"] category.
 // Library-internal fedify logs are intentionally excluded so they don't flood
 // the output.  Pass --debug to lower the level from "info" to "debug".
 
-const debugMode = Deno.args.includes("--debug") || Deno.args.includes("-d");
-
-await configure({
-  sinks: { console: getConsoleSink() },
-  filters: {},
-  loggers: [
-    {
-      category: ["fedify", "examples"],
-      lowestLevel: debugMode ? "debug" : "info",
-      sinks: ["console"],
-      filters: [],
-    },
-    {
-      // Suppress logtape's own meta-logs unless something is wrong.
-      category: ["logtape", "meta"],
-      lowestLevel: "warning",
-      sinks: ["console"],
-      filters: [],
-    },
-  ],
-});
+async function configureLogging(debugMode: boolean): Promise<void> {
+  await configure({
+    sinks: { console: getConsoleSink() },
+    filters: {},
+    loggers: [
+      {
+        category: ["fedify", "examples"],
+        lowestLevel: debugMode ? "debug" : "info",
+        sinks: ["console"],
+        filters: [],
+      },
+      {
+        // Suppress logtape's own meta-logs unless something is wrong.
+        category: ["logtape", "meta"],
+        lowestLevel: "warning",
+        sinks: ["console"],
+        filters: [],
+      },
+    ],
+  });
+}
 
 const logger = getLogger(["fedify", "examples", "test-runner"]);
 
@@ -108,7 +105,7 @@ interface MultiHandleExample {
   name: string;
   dir: string;
   /** Command prefix—the handle is appended as the final argument. */
-  cmdPrefix?: string[];
+  cmd: string[];
   /** Handles to try, in order.  Pass if any succeeds. */
   handles: string[];
   description: string;
@@ -124,6 +121,33 @@ type TestResult =
   | { name: string; status: "pass"; output: string }
   | { name: string; status: "fail"; error: string; output: string }
   | { name: string; status: "skip"; reason: string };
+
+interface CliOptions {
+  defaultTimeoutMs: number;
+  debugMode: boolean;
+  filterNames: Set<string>;
+}
+
+export function parseCliArgs(args: readonly string[]): CliOptions {
+  let defaultTimeoutMs = 10_000;
+  let debugMode = false;
+  const filterNames = new Set<string>();
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === "--timeout" && i + 1 < args.length) {
+      defaultTimeoutMs = Number(args[++i]);
+    } else if (arg.startsWith("--timeout=")) {
+      defaultTimeoutMs = Number(arg.slice("--timeout=".length));
+    } else if (arg === "--debug" || arg === "-d") {
+      debugMode = true;
+    } else if (!arg.startsWith("--")) {
+      filterNames.add(arg);
+    }
+  }
+
+  return { defaultTimeoutMs, debugMode, filterNames };
+}
 
 // ─── Example Registry ─────────────────────────────────────────────────────────
 //
@@ -713,23 +737,10 @@ function printInlineResult(result: TestResult): void {
 
 // ─── Main ─────────────────────────────────────────────────────────────────────
 
-async function main(): Promise<void> {
+async function main(args: readonly string[] = Deno.args): Promise<void> {
   // ── Parse CLI arguments ──────────────────────────────────────────────────
-  let defaultTimeoutMs = 10_000;
-  const filterNames = new Set<string>();
-
-  for (let i = 0; i < Deno.args.length; i++) {
-    const arg = Deno.args[i];
-    if (arg === "--timeout" && i + 1 < Deno.args.length) {
-      defaultTimeoutMs = Number(Deno.args[++i]);
-    } else if (arg.startsWith("--timeout=")) {
-      defaultTimeoutMs = Number(arg.slice("--timeout=".length));
-    } else if (arg === "--debug" || arg === "-d") {
-      // already handled above at module level
-    } else if (!arg.startsWith("--")) {
-      filterNames.add(arg);
-    }
-  }
+  const { debugMode, defaultTimeoutMs, filterNames } = parseCliArgs(args);
+  await configureLogging(debugMode);
 
   const shouldRun = (name: string) =>
     filterNames.size === 0 || filterNames.has(name);
@@ -859,4 +870,4 @@ async function main(): Promise<void> {
   Deno.exit(0);
 }
 
-await main();
+if (import.meta.main) await main();


### PR DESCRIPTION
﻿## Summary

- extract the example test runner's CLI parsing into a small helper so it can be tested without starting examples
- cover the documented default timeout and `--timeout VALUE` handling
- keep the runner importable by guarding execution with `import.meta.main`

Fixes #887.

## Testing

- `deno fmt --check deno.json examples/test-examples/mod.ts examples/test-examples/mod.test.ts`
- `deno lint examples/test-examples/mod.ts examples/test-examples/mod.test.ts`
- `deno test --check --doc --allow-all --unstable-kv --trace-leaks --parallel examples/test-examples/mod.test.ts`
- `deno run -A examples/test-examples/mod.ts --timeout=123 cloudflare-workers`

## AI assistance

Prepared with assistance from Codex:gpt-5. I reviewed the issue, project instructions, diff, and local test output before opening this PR.