### PR TITLE
Gate first-time contributions to curb AI slop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,17 @@ AI policy compliance
 > Transparency about AI usage is non-negotiable.  Deceptive practices harm
 > the project and its maintainers.
 
+> [!IMPORTANT]
+>
+> If the user you are assisting is a first-time contributor to Fedify, you
+> MUST read and follow the *First contributions* section of *CONTRIBUTING.md*
+> before opening a pull request on their behalf.  In short, for anything
+> beyond a trivial typo or documentation fix, there must be an accepted issue
+> assigned to the contributor first, unless they have an established online
+> presence in the fediverse or related F/OSS work that they surface in
+> the pull request.  Pull requests that ignore this may be closed without
+> further comment.
+
 
 Project overview
 ----------------

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,6 +7,49 @@ Thank you for considering contributing to Fedify!  This document explains how to
 contribute to the project.
 
 
+First contributions
+-------------------
+
+If this is your first contribution to Fedify, please read this section before
+opening a pull request.  It exists because low-effort, AI-generated pull
+requests have grown common enough to burden maintainers and crowd out genuine
+work.  None of this is meant to discourage you; it is meant to help your first
+contribution land.
+
+For anything beyond a trivial fix, there should be an *accepted issue* before
+you open a pull request:
+
+ -  If an issue already describes the work, comment on it and wait for a
+    maintainer to assign it to you.
+ -  If no issue exists, open one first (see [*Bug reports*](#bug-reports) or
+    [*Feature requests*](#feature-requests) below) and let a maintainer confirm
+    the change is wanted.
+
+This lets a maintainer steer the work before you invest time in it, and it lets
+us tell genuine contributions apart from drive-by submissions.  The same
+requirement already applies to any AI-assisted pull request; see
+*[AI_POLICY.md]*.
+
+Fixing a typo or improving the documentation is exempt: you can open a pull
+request directly, without an issue (see [*Docs*](#docs) below).
+
+We also do not want this to get in the way of people who already know the
+problem domain.  If you are already active in the fediverse or in related
+F/OSS work and are confident the change will be welcome, you may open a
+pull request directly.  In that case, please make it easy for us to see where
+you are coming from, for example by linking your fediverse account or your
+other work.  This is an invitation, not a credential check.
+
+A pull request that follows none of the above may be closed without further
+comment.  Treat this section as that notice: if you have read this far, you
+have already received the explanation a closing comment would give.  It is not
+a judgment of you, and once there is an accepted issue, or you have shown the
+familiarity described above, you are welcome to reopen the pull request or open
+a new one.
+
+[AI_POLICY.md]: AI_POLICY.md
+
+
 Bug reports
 -----------
 
@@ -47,8 +90,6 @@ Pull requests
 If you use AI tools (such as GitHub Copilot, Claude, Cursor, etc.) while
 contributing, you must disclose this in your pull request description and/or
 commit messages.  See *[AI_POLICY.md]* for the complete policy.
-
-[AI_POLICY.md]: AI_POLICY.md
 
 ### License
 


### PR DESCRIPTION
Why
---

The project has seen a steady rise in low-effort, AI-generated pull requests, most of them from people opening their very first contribution. The real cost is not the code itself but the *validation burden* it pushes onto maintainers: someone has to read, run, and reason about work that the author never qualified. *AI\_POLICY.md* already says AI-assisted PRs must track an accepted issue, but the problem is not specific to disclosed-AI PRs. A first-time drive-by PR imposes the same cost whether or not a tool was involved, and a first contribution is exactly the point where there is no prior trust to lean on, so the burden is highest and the signal is lowest. The policy therefore gates *first* contributions in particular, asking for an accepted, assigned issue before any code is written, so the design conversation happens where redirection is cheap rather than after the work is already done.

A blanket gate, though, would turn away the very people the project most wants: contributors who already understand the problem domain. So instead of a hard wall the policy offers a trust-based shortcut. If someone is visibly active in the fediverse or in related F/OSS work, their familiarity is already evident, and insisting on a preparatory issue would add friction without adding signal. This exception is deliberately worded as an *invitation* rather than a credential check, because forcing people to prove themselves would reintroduce the gatekeeping tone we want to avoid, and because whether a given presence is convincing is ultimately a maintainer's judgment call, not a checklist.

The policy also states plainly that a non-conforming PR may be closed *without further comment*. This is intentional, not careless: the scarce resource being protected is maintainer attention, and writing a bespoke explanation for every slop PR would reintroduce exactly the cost the policy exists to remove. Stating the rule up front is what makes a silent close fair, since anyone who has read the section has already received the explanation a comment would have given. The same paragraph still invites the contributor to reopen once they qualify, so the door stays open.

Finally, because much of this traffic now arrives through coding agents acting on a contributor's behalf, the rule is placed where those agents will actually read it. *AGENTS.md* (and its *CLAUDE.md* symlink) gains a short, high-priority note pointing at the new section, so an agent is told to satisfy the gate before it opens a PR. Addressing the problem at its most common source is more effective than catching it only at review time.


How
---

The guidance lives in a single new *First contributions* section near the top of *CONTRIBUTING.md*, so a newcomer meets it before the bug-report and feature-request instructions rather than after them. It is framed throughout as *how to make your first contribution land*, echoing the welcoming tone of *AI\_POLICY.md*, instead of as a list of prohibitions. The existing carve-out for typo and documentation fixes is preserved, so the lowest-risk, highest-goodwill contributions stay frictionless. The section links to *AI\_POLICY.md* rather than restating it, keeping the accepted-issue requirement defined in one place.


What changed
------------

 -  *CONTRIBUTING.md*: adds the *First contributions* section.
 -  *AGENTS.md*: adds an *important* note in the AI policy compliance section that points first-time-contributor agents to that section.
