### PR TITLE
Fix split-origin WebFinger subjects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,8 +18,16 @@ To be released.
     collections instead of being treated as unknown routes.
     [[#849], [#851] by ChanHaeng Lee]
 
+ -  Fixed split-origin WebFinger responses for `acct:` aliases on the web
+    origin host.  When a local actor is queried through the server-origin
+    `acct:` alias, Fedify now returns the canonical handle-host `acct:` URI as
+    the JRD `subject` and keeps the queried `acct:` URI in `aliases`.
+    [[#920], [#921]]
+
 [#849]: https://github.com/fedify-dev/fedify/issues/849
 [#851]: https://github.com/fedify-dev/fedify/pull/851
+[#920]: https://github.com/fedify-dev/fedify/issues/920
+[#921]: https://github.com/fedify-dev/fedify/pull/921
 
 ### @fedify/cli
 

--- a/packages/fedify/src/federation/webfinger.test.ts
+++ b/packages/fedify/src/federation/webfinger.test.ts
@@ -402,22 +402,47 @@ test("handleWebFinger()", async (t) => {
   });
 
   await t.step("handleHost", async () => {
-    const u = new URL(url);
-    u.searchParams.set("resource", "acct:someone@example.com");
+    let u = new URL("https://ap.example.com/.well-known/webfinger");
+    u.searchParams.set("resource", "acct:someone@ap.example.com");
     let context = createContext(u);
     let request = context.request;
     let response = await handleWebFinger(request, {
       context,
-      host: "handle.example.com",
+      host: "example.com",
       actorDispatcher,
       onNotFound,
     });
     assertEquals(response.status, 200);
     assertEquals(await response.json(), {
-      ...expected,
-      aliases: [...expected.aliases, "acct:someone@handle.example.com"],
+      subject: "acct:someone@example.com",
+      aliases: [
+        "https://ap.example.com/users/someone",
+        "acct:someone@ap.example.com",
+      ],
+      links: [
+        {
+          href: "https://ap.example.com/users/someone",
+          rel: "self",
+          type: "application/activity+json",
+        },
+        {
+          href: "https://ap.example.com/@someone",
+          rel: "http://webfinger.net/rel/profile-page",
+        },
+        {
+          href: "https://ap.example.com/@someone",
+          rel: "alternate",
+          type: "text/html",
+        },
+        {
+          href: "https://ap.example.com/icon.jpg",
+          rel: "http://webfinger.net/rel/avatar",
+          type: "image/jpeg",
+        },
+      ],
     });
 
+    u = new URL(url);
     u.searchParams.set("resource", "acct:someone@handle.example.com");
     context = createContext(u);
     request = context.request;

--- a/packages/fedify/src/federation/webfinger.test.ts
+++ b/packages/fedify/src/federation/webfinger.test.ts
@@ -269,6 +269,8 @@ test("handleWebFinger()", async (t) => {
       ? "someone"
       : username === "bar"
       ? "someone2"
+      : username === "qux"
+      ? "someone2"
       : null;
   };
 
@@ -431,6 +433,47 @@ test("handleWebFinger()", async (t) => {
         },
         {
           href: "https://ap.example.com/@someone",
+          rel: "alternate",
+          type: "text/html",
+        },
+        {
+          href: "https://ap.example.com/icon.jpg",
+          rel: "http://webfinger.net/rel/avatar",
+          type: "image/jpeg",
+        },
+      ],
+    });
+
+    u.searchParams.set("resource", "acct:qux@ap.example.com");
+    context = createContext(u);
+    request = context.request;
+    response = await handleWebFinger(request, {
+      context,
+      host: "example.com",
+      actorDispatcher,
+      actorHandleMapper,
+      onNotFound,
+    });
+    assertEquals(response.status, 200);
+    assertEquals(await response.json(), {
+      subject: "acct:bar@example.com",
+      aliases: [
+        "https://ap.example.com/users/someone2",
+        "acct:qux@ap.example.com",
+        "acct:bar@ap.example.com",
+      ],
+      links: [
+        {
+          href: "https://ap.example.com/users/someone2",
+          rel: "self",
+          type: "application/activity+json",
+        },
+        {
+          href: "https://ap.example.com/@someone2",
+          rel: "http://webfinger.net/rel/profile-page",
+        },
+        {
+          href: "https://ap.example.com/@someone2",
           rel: "alternate",
           type: "text/html",
         },

--- a/packages/fedify/src/federation/webfinger.ts
+++ b/packages/fedify/src/federation/webfinger.ts
@@ -164,6 +164,7 @@ async function handleWebFingerInternal<TContextData>(
   }
 
   let identifier: string | null = null;
+  let acctUsername: string | null = null;
   const uriParsed = context.parseUri(resourceUrl);
   if (uriParsed?.type != "actor") {
     const match = /^acct:([^@]+)@([^@]+)$/.exec(resource);
@@ -185,8 +186,9 @@ async function handleWebFingerInternal<TContextData>(
       if (normalizedHost != context.url.host && normalizedHost != host) {
         return await onNotFound(request);
       } else {
-        identifier = await mapUsernameToIdentifier(match[1]);
-        resourceUrl = new URL(`acct:${match[1]}@${normalizedHost}`);
+        acctUsername = match[1];
+        identifier = await mapUsernameToIdentifier(acctUsername);
+        resourceUrl = new URL(`acct:${acctUsername}@${normalizedHost}`);
       }
     }
   } else {
@@ -255,8 +257,7 @@ async function handleWebFingerInternal<TContextData>(
     host !== context.url.host &&
     !resourceUrl.href.endsWith(`@${host}`)
   ) {
-    const username = resourceUrl.href.replace(/^acct:/, "").replace(/@.*$/, "");
-    subject = `acct:${actor.preferredUsername ?? username}@${host}`;
+    subject = `acct:${actor.preferredUsername ?? acctUsername}@${host}`;
     aliases.push(resourceUrl.href);
   }
   const jrd: ResourceDescriptor = {

--- a/packages/fedify/src/federation/webfinger.ts
+++ b/packages/fedify/src/federation/webfinger.ts
@@ -240,6 +240,7 @@ async function handleWebFingerInternal<TContextData>(
   }
 
   const aliases: string[] = [];
+  let subject = resourceUrl.href;
   if (resourceUrl.protocol != "acct:" && actor.preferredUsername != null) {
     aliases.push(`acct:${actor.preferredUsername}@${host ?? context.url.host}`);
     if (host != null && host !== context.url.host) {
@@ -255,10 +256,11 @@ async function handleWebFingerInternal<TContextData>(
     !resourceUrl.href.endsWith(`@${host}`)
   ) {
     const username = resourceUrl.href.replace(/^acct:/, "").replace(/@.*$/, "");
-    aliases.push(`acct:${username}@${host}`);
+    subject = `acct:${actor.preferredUsername ?? username}@${host}`;
+    aliases.push(resourceUrl.href);
   }
   const jrd: ResourceDescriptor = {
-    subject: resourceUrl.href,
+    subject,
     aliases,
     links,
   };

--- a/packages/fedify/src/federation/webfinger.ts
+++ b/packages/fedify/src/federation/webfinger.ts
@@ -259,6 +259,12 @@ async function handleWebFingerInternal<TContextData>(
   ) {
     subject = `acct:${actor.preferredUsername ?? acctUsername}@${host}`;
     aliases.push(resourceUrl.href);
+    if (
+      actor.preferredUsername != null && actor.preferredUsername !== "" &&
+      actor.preferredUsername !== acctUsername
+    ) {
+      aliases.push(`acct:${actor.preferredUsername}@${context.url.host}`);
+    }
   }
   const jrd: ResourceDescriptor = {
     subject,

--- a/packages/fedify/src/federation/webfinger.ts
+++ b/packages/fedify/src/federation/webfinger.ts
@@ -1,4 +1,4 @@
-import { Link as LinkObject } from "@fedify/vocab";
+import { type LanguageString, Link as LinkObject } from "@fedify/vocab";
 import type { Link, ResourceDescriptor } from "@fedify/webfinger";
 import { getLogger } from "@logtape/logtape";
 import type { Span, Tracer } from "@opentelemetry/api";
@@ -13,6 +13,53 @@ import type {
 import type { RequestContext } from "./context.ts";
 
 const logger = getLogger(["fedify", "webfinger", "server"]);
+
+interface WebFingerSubjectAndAliasesOptions {
+  resourceUrl: URL;
+  actorUri: URL;
+  preferredUsername: string | LanguageString | null | undefined;
+  acctUsername: string | null;
+  host: string | undefined;
+  contextHost: string;
+}
+
+function getWebFingerSubjectAndAliases(
+  {
+    resourceUrl,
+    actorUri,
+    preferredUsername,
+    acctUsername,
+    host,
+    contextHost,
+  }: WebFingerSubjectAndAliasesOptions,
+): Pick<ResourceDescriptor, "subject" | "aliases"> {
+  const aliases: string[] = [];
+  let subject = resourceUrl.href;
+  if (resourceUrl.protocol != "acct:" && preferredUsername != null) {
+    aliases.push(`acct:${preferredUsername}@${host ?? contextHost}`);
+    if (host != null && host !== contextHost) {
+      aliases.push(`acct:${preferredUsername}@${contextHost}`);
+    }
+  }
+  if (resourceUrl.href !== actorUri.href) {
+    aliases.push(actorUri.href);
+  }
+  if (
+    resourceUrl.protocol === "acct:" && host != null &&
+    host !== contextHost &&
+    !resourceUrl.href.endsWith(`@${host}`)
+  ) {
+    subject = `acct:${preferredUsername ?? acctUsername}@${host}`;
+    aliases.push(resourceUrl.href);
+    if (
+      preferredUsername != null && preferredUsername !== "" &&
+      preferredUsername !== acctUsername
+    ) {
+      aliases.push(`acct:${preferredUsername}@${contextHost}`);
+    }
+  }
+  return { subject, aliases };
+}
 
 /**
  * Parameters for {@link handleWebFinger}.
@@ -202,10 +249,11 @@ async function handleWebFingerInternal<TContextData>(
     logger.error("Actor {identifier} not found.", { identifier });
     return await onNotFound(request);
   }
+  const actorUri = context.getActorUri(identifier);
   const links: Link[] = [
     {
       rel: "self",
-      href: context.getActorUri(identifier).href,
+      href: actorUri.href,
       type: "application/activity+json",
     },
   ];
@@ -241,31 +289,14 @@ async function handleWebFingerInternal<TContextData>(
     }
   }
 
-  const aliases: string[] = [];
-  let subject = resourceUrl.href;
-  if (resourceUrl.protocol != "acct:" && actor.preferredUsername != null) {
-    aliases.push(`acct:${actor.preferredUsername}@${host ?? context.url.host}`);
-    if (host != null && host !== context.url.host) {
-      aliases.push(`acct:${actor.preferredUsername}@${context.url.host}`);
-    }
-  }
-  if (resourceUrl.href !== context.getActorUri(identifier).href) {
-    aliases.push(context.getActorUri(identifier).href);
-  }
-  if (
-    resourceUrl.protocol === "acct:" && host != null &&
-    host !== context.url.host &&
-    !resourceUrl.href.endsWith(`@${host}`)
-  ) {
-    subject = `acct:${actor.preferredUsername ?? acctUsername}@${host}`;
-    aliases.push(resourceUrl.href);
-    if (
-      actor.preferredUsername != null && actor.preferredUsername !== "" &&
-      actor.preferredUsername !== acctUsername
-    ) {
-      aliases.push(`acct:${actor.preferredUsername}@${context.url.host}`);
-    }
-  }
+  const { subject, aliases } = getWebFingerSubjectAndAliases({
+    resourceUrl,
+    actorUri,
+    preferredUsername: actor.preferredUsername,
+    acctUsername,
+    host,
+    contextHost: context.url.host,
+  });
   const jrd: ResourceDescriptor = {
     subject,
     aliases,


### PR DESCRIPTION
Fixes #920.


Why this change is needed
-------------------------

In split-origin deployments, the public fediverse handle and the ActivityPub server can live on different hosts. A server may receive a WebFinger request for an `acct:` URI on the server origin after a remote implementation starts from an actor URL and checks the reciprocal account identity.

Fedify already accepted that server-origin `acct:` URI as an alias when the actor was local. The response still used the queried alias as `subject`, though, which made the alias look canonical to clients that stop at the WebFinger subject. The canonical handle-host identity was present only in `aliases`, too late for that lookup path.


How this fixes it
-----------------

The handler in *packages/fedify/src/federation/webfinger.ts* now keeps the normalized query URI separate from the JRD subject. For an `acct:` query on the web-origin host, it returns the handle-host `acct:` URI as `subject` and keeps the queried server-origin `acct:` URI in `aliases`. Canonical handle-host queries and actor-URI queries keep their existing behavior.

The regression test in *packages/fedify/src/federation/webfinger.test.ts* uses the split-origin shape directly: `ap.example.com` for the web origin and `example.com` for the handle host. That makes the expected subject unambiguous: `acct:someone@example.com`, with `acct:someone@ap.example.com` retained as an alias.

*CHANGES.md* documents the behavior change for 2.0.22.