### PR TITLE
Canonicalize and compare portable ActivityPub URIs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -92,6 +92,12 @@ To be released.
 
 ### @fedify/vocab-runtime
 
+ -  Added `canonicalizePortableUri()` and `arePortableUrisEqual()` for
+    comparing [FEP-ef61] portable ActivityPub URIs.  The helpers accept `ap:`
+    and `ap+ef61:` values with decoded or percent-encoded DID authorities,
+    normalize them to `ap+ef61:`, and ignore query hints such as `gateways`
+    during comparison.  [[#828], [#924]]
+
  -  Added the [FEP-7aa9] JSON-LD context to the preloaded context registry so
     FEP-7aa9 documents can be compacted and expanded without fetching the
     context remotely.  [[#810], [#914]]
@@ -108,8 +114,10 @@ To be released.
     error pages surface as document loading failures with the response URL and
     content type, rather than generic JSON parser crashes.  [[#912], [#913]]
 
+[#828]: https://github.com/fedify-dev/fedify/issues/828
 [#912]: https://github.com/fedify-dev/fedify/issues/912
 [#913]: https://github.com/fedify-dev/fedify/pull/913
+[#924]: https://github.com/fedify-dev/fedify/pull/924
 
 
 Version 2.3.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -93,10 +93,10 @@ To be released.
 ### @fedify/vocab-runtime
 
  -  Added `canonicalizePortableUri()` and `arePortableUrisEqual()` for
-    comparing [FEP-ef61] portable ActivityPub URIs.  The helpers accept `ap:`
-    and `ap+ef61:` values with decoded or percent-encoded DID authorities,
-    normalize them to `ap+ef61:`, and ignore query hints such as `gateways`
-    during comparison.  [[#828], [#924]]
+    comparing [FEP-ef61] portable ActivityPub URI strings.  The helpers accept
+    `ap:` and `ap+ef61:` values with decoded or percent-encoded DID
+    authorities, normalize them to `ap+ef61:`, and ignore query hints such as
+    `gateways` during comparison.  [[#828], [#924]]
 
  -  Added the [FEP-7aa9] JSON-LD context to the preloaded context registry so
     FEP-7aa9 documents can be compacted and expanded without fetching the

--- a/docs/manual/vocab.md
+++ b/docs/manual/vocab.md
@@ -113,6 +113,10 @@ Both the `ap:` and `ap+ef61:` schemes are accepted, whether the DID authority
 is decoded (e.g., `ap+ef61://did:key:.../actor`) or percent-encoded.  Fedify
 stores these IRIs as `URL` objects with a URL-safe authority internally, and
 serializes them as canonical `ap+ef61:` IRIs with the decoded DID authority.
+When comparing portable object IDs, use `canonicalizePortableUri()` or
+`arePortableUrisEqual()` from `@fedify/vocab-runtime`; these helpers remove
+query hints such as `gateways` according to [FEP-ef61].  Serialization keeps
+those query hints intact.
 
 > [!TIP]
 > You can instantiate an object from a JSON-LD document by calling the

--- a/docs/manual/vocab.md
+++ b/docs/manual/vocab.md
@@ -115,8 +115,10 @@ stores these IRIs as `URL` objects with a URL-safe authority internally, and
 serializes them as canonical `ap+ef61:` IRIs with the decoded DID authority.
 When comparing portable object IDs, use `canonicalizePortableUri()` or
 `arePortableUrisEqual()` from `@fedify/vocab-runtime`; these helpers remove
-query hints such as `gateways` according to [FEP-ef61].  Serialization keeps
-those query hints intact.
+query hints such as `gateways` according to [FEP-ef61].  Pass raw URI strings
+to these comparison helpers, because JavaScript `URL` objects normalize opaque
+path segments before Fedify can compare them.  Serialization keeps those query
+hints intact.
 
 > [!TIP]
 > You can instantiate an object from a JSON-LD document by calling the

--- a/packages/vocab-runtime/src/mod.ts
+++ b/packages/vocab-runtime/src/mod.ts
@@ -54,6 +54,8 @@ export {
   type PropertyPreprocessorContext,
 } from "./preprocessor.ts";
 export {
+  arePortableUrisEqual,
+  canonicalizePortableUri,
   expandIPv6Address,
   formatIri,
   haveSameIriOrigin,

--- a/packages/vocab-runtime/src/url.test.ts
+++ b/packages/vocab-runtime/src/url.test.ts
@@ -260,6 +260,17 @@ test("canonicalizePortableUri() normalizes path and fragment pct-encoding casing
   ));
 });
 
+test("canonicalizePortableUri() encodes raw path and fragment characters", () => {
+  deepStrictEqual(
+    canonicalizePortableUri("ap://did:key:z6Mkabc/\u00e9#\u00e9"),
+    "ap+ef61://did:key:z6Mkabc/%C3%A9#%C3%A9",
+  );
+  ok(arePortableUrisEqual(
+    "ap://did:key:z6Mkabc/\u00e9#\u00e9",
+    "ap://did:key:z6Mkabc/%C3%A9#%C3%A9",
+  ));
+});
+
 test("canonicalizePortableUri() normalizes DID scheme casing", () => {
   deepStrictEqual(
     canonicalizePortableUri("ap://DID:key:z6Mkabc/actor"),
@@ -360,9 +371,18 @@ test("arePortableUrisEqual() handles non-portable URI strings", () => {
       "https://example.com/actor",
     ),
   );
-  throws(
-    () => arePortableUrisEqual("ap://not-a-did/actor", "ap://not-a-did/actor"),
-    TypeError,
+  ok(arePortableUrisEqual("ap://not-a-did/actor", "ap://not-a-did/actor"));
+  ok(
+    !arePortableUrisEqual(
+      "ap://not-a-did/actor",
+      "ap://not-a-did/outbox",
+    ),
+  );
+  ok(
+    !arePortableUrisEqual(
+      "ap://not-a-did/actor",
+      "ap://did:key:z6Mkabc/actor",
+    ),
   );
 });
 

--- a/packages/vocab-runtime/src/url.test.ts
+++ b/packages/vocab-runtime/src/url.test.ts
@@ -262,9 +262,17 @@ test("canonicalizePortableUri() normalizes path and fragment pct-encoding casing
     canonicalizePortableUri("ap://did:key:z6Mkabc/actor%2fprofile%3aimage"),
     "ap+ef61://did:key:z6Mkabc/actor%2Fprofile%3Aimage",
   );
+  deepStrictEqual(
+    canonicalizePortableUri("ap://did:key:z6Mkabc/actor%2Dprofile#part%7Etwo"),
+    "ap+ef61://did:key:z6Mkabc/actor-profile#part~two",
+  );
   ok(arePortableUrisEqual(
     "ap://did:key:z6Mkabc/actor%2fprofile#part%2ftwo",
     "ap://did:key:z6Mkabc/actor%2Fprofile#part%2Ftwo",
+  ));
+  ok(arePortableUrisEqual(
+    "ap://did:key:z6Mkabc/actor%2Dprofile#part%7Etwo",
+    "ap://did:key:z6Mkabc/actor-profile#part~two",
   ));
 });
 
@@ -297,7 +305,7 @@ test("canonicalizePortableUri() preserves opaque path segments", () => {
   );
   deepStrictEqual(
     canonicalizePortableUri("ap://did:key:z6Mkabc/a/%2e%2e/b"),
-    "ap+ef61://did:key:z6Mkabc/a/%2E%2E/b",
+    "ap+ef61://did:key:z6Mkabc/a/../b",
   );
   ok(
     !arePortableUrisEqual(

--- a/packages/vocab-runtime/src/url.test.ts
+++ b/packages/vocab-runtime/src/url.test.ts
@@ -193,9 +193,6 @@ test("canonicalizePortableUri() emits comparison forms", () => {
     "ap://did:key:z6Mkabc/actor?gateways=https%3A%2F%2Fa.example",
     "ap+ef61://did:key:z6Mkabc/actor",
     "ap+ef61://did%3Akey%3Az6Mkabc/actor?gateways=https%3A%2F%2Fa.example",
-    new URL(
-      "ap+ef61://did%3Akey%3Az6Mkabc/actor?gateways=https%3A%2F%2Fa.example",
-    ),
   ];
   for (const iri of cases) {
     deepStrictEqual(
@@ -289,16 +286,19 @@ test("canonicalizePortableUri() rejects non-portable URIs", () => {
   for (const iri of cases) {
     throws(() => canonicalizePortableUri(iri), TypeError);
   }
+  throws(
+    () =>
+      canonicalizePortableUri(
+        new URL("ap+ef61://did%3Akey%3Az6Mkabc/actor") as unknown as string,
+      ),
+    TypeError,
+  );
 });
 
 test("arePortableUrisEqual() compares canonical portable URI forms", () => {
   ok(arePortableUrisEqual(
     "ap://did:key:z6Mkabc/actor",
     "ap+ef61://did%3Akey%3Az6Mkabc/actor?gateways=https%3A%2F%2Fa.example",
-  ));
-  ok(arePortableUrisEqual(
-    new URL("ap://did%3Akey%3Az6Mkabc/actor?gateways=https%3A%2F%2Fa.example"),
-    "ap+ef61://did:key:z6Mkabc/actor",
   ));
   ok(arePortableUrisEqual(
     "ap://DID:key:z6Mkabc/actor",

--- a/packages/vocab-runtime/src/url.test.ts
+++ b/packages/vocab-runtime/src/url.test.ts
@@ -229,6 +229,21 @@ test("canonicalizePortableUri() preserves DID-internal pct-encoded characters", 
   );
 });
 
+test("canonicalizePortableUri() normalizes authority pct-encoding casing", () => {
+  deepStrictEqual(
+    canonicalizePortableUri("ap://did:example:abc%2fdef/actor"),
+    "ap+ef61://did:example:abc%2Fdef/actor",
+  );
+  deepStrictEqual(
+    canonicalizePortableUri("ap://did%3Aexample%3Aabc%252fdef/actor"),
+    "ap+ef61://did:example:abc%2Fdef/actor",
+  );
+  ok(arePortableUrisEqual(
+    "ap://did:example:abc%2fdef/actor",
+    "ap://did:example:abc%2Fdef/actor",
+  ));
+});
+
 test("canonicalizePortableUri() normalizes DID scheme casing", () => {
   deepStrictEqual(
     canonicalizePortableUri("ap://DID:key:z6Mkabc/actor"),
@@ -237,6 +252,29 @@ test("canonicalizePortableUri() normalizes DID scheme casing", () => {
   deepStrictEqual(
     canonicalizePortableUri("ap://DID%3Akey%3Az6Mkabc/actor"),
     "ap+ef61://did:key:z6Mkabc/actor",
+  );
+});
+
+test("canonicalizePortableUri() preserves opaque path segments", () => {
+  deepStrictEqual(
+    canonicalizePortableUri("ap://did:key:z6Mkabc/a/../b?gateways=x"),
+    "ap+ef61://did:key:z6Mkabc/a/../b",
+  );
+  deepStrictEqual(
+    canonicalizePortableUri("ap://did:key:z6Mkabc/a/%2e%2e/b"),
+    "ap+ef61://did:key:z6Mkabc/a/%2e%2e/b",
+  );
+  ok(
+    !arePortableUrisEqual(
+      "ap://did:key:z6Mkabc/a/../b",
+      "ap://did:key:z6Mkabc/b",
+    ),
+  );
+  ok(
+    !arePortableUrisEqual(
+      "ap://did:key:z6Mkabc/a/%2e%2e/b",
+      "ap://did:key:z6Mkabc/b",
+    ),
   );
 });
 

--- a/packages/vocab-runtime/src/url.test.ts
+++ b/packages/vocab-runtime/src/url.test.ts
@@ -347,6 +347,14 @@ test("canonicalizePortableUri() rejects invalid path and fragment pct-encoding",
     () => canonicalizePortableUri("ap://did:key:z6Mkabc/actor#part%zz"),
     TypeError,
   );
+  throws(
+    () => canonicalizePortableUri("ap://did:key:z6Mkabc/\ud800"),
+    TypeError,
+  );
+  throws(
+    () => canonicalizePortableUri("ap://did:key:z6Mkabc/actor#\ud800"),
+    TypeError,
+  );
 });
 
 test("arePortableUrisEqual() compares canonical portable URI forms", () => {
@@ -412,6 +420,18 @@ test("arePortableUrisEqual() handles non-portable URI strings", () => {
     !arePortableUrisEqual(
       "ap://did:key:z6Mkabc/a%zz",
       "ap://did:key:z6Mkabc/a%25zz",
+    ),
+  );
+  ok(
+    !arePortableUrisEqual(
+      "ap://did:key:z6Mkabc/\ud800",
+      "ap://did:key:z6Mkabc/%EF%BF%BD",
+    ),
+  );
+  ok(
+    !arePortableUrisEqual(
+      "ap://did:key:z6Mkabc/actor#\ud800",
+      "ap://did:key:z6Mkabc/actor#%EF%BF%BD",
     ),
   );
 });

--- a/packages/vocab-runtime/src/url.test.ts
+++ b/packages/vocab-runtime/src/url.test.ts
@@ -239,9 +239,17 @@ test("canonicalizePortableUri() normalizes authority pct-encoding casing", () =>
     canonicalizePortableUri("ap://did%3Aexample%3Aabc%252fdef/actor"),
     "ap+ef61://did:example:abc%2Fdef/actor",
   );
+  deepStrictEqual(
+    canonicalizePortableUri("ap://did%3Akey%3Az6Mk%2Dabc/actor"),
+    "ap+ef61://did:key:z6Mk-abc/actor",
+  );
   ok(arePortableUrisEqual(
     "ap://did:example:abc%2fdef/actor",
     "ap://did:example:abc%2Fdef/actor",
+  ));
+  ok(arePortableUrisEqual(
+    "ap://did%3Akey%3Az6Mk%2Dabc/actor",
+    "ap://did:key:z6Mk-abc/actor",
   ));
 });
 

--- a/packages/vocab-runtime/src/url.test.ts
+++ b/packages/vocab-runtime/src/url.test.ts
@@ -241,6 +241,17 @@ test("canonicalizePortableUri() normalizes authority pct-encoding casing", () =>
   ));
 });
 
+test("canonicalizePortableUri() normalizes path and fragment pct-encoding casing", () => {
+  deepStrictEqual(
+    canonicalizePortableUri("ap://did:key:z6Mkabc/actor%2fprofile#part%2ftwo"),
+    "ap+ef61://did:key:z6Mkabc/actor%2Fprofile#part%2Ftwo",
+  );
+  ok(arePortableUrisEqual(
+    "ap://did:key:z6Mkabc/actor%2fprofile#part%2ftwo",
+    "ap://did:key:z6Mkabc/actor%2Fprofile#part%2Ftwo",
+  ));
+});
+
 test("canonicalizePortableUri() normalizes DID scheme casing", () => {
   deepStrictEqual(
     canonicalizePortableUri("ap://DID:key:z6Mkabc/actor"),
@@ -259,7 +270,7 @@ test("canonicalizePortableUri() preserves opaque path segments", () => {
   );
   deepStrictEqual(
     canonicalizePortableUri("ap://did:key:z6Mkabc/a/%2e%2e/b"),
-    "ap+ef61://did:key:z6Mkabc/a/%2e%2e/b",
+    "ap+ef61://did:key:z6Mkabc/a/%2E%2E/b",
   );
   ok(
     !arePortableUrisEqual(
@@ -321,6 +332,29 @@ test("arePortableUrisEqual() compares canonical portable URI forms", () => {
       "ap://did:key:z6Mkabc/actor#one",
       "ap://did:key:z6Mkabc/actor#two",
     ),
+  );
+});
+
+test("arePortableUrisEqual() handles non-portable URI strings", () => {
+  ok(arePortableUrisEqual(
+    "https://example.com/actor",
+    "https://example.com/actor",
+  ));
+  ok(
+    !arePortableUrisEqual(
+      "https://example.com/actor",
+      "https://example.com/outbox",
+    ),
+  );
+  ok(
+    !arePortableUrisEqual(
+      "ap://did:key:z6Mkabc/actor",
+      "https://example.com/actor",
+    ),
+  );
+  throws(
+    () => arePortableUrisEqual("ap://not-a-did/actor", "ap://not-a-did/actor"),
+    TypeError,
   );
 });
 

--- a/packages/vocab-runtime/src/url.test.ts
+++ b/packages/vocab-runtime/src/url.test.ts
@@ -232,6 +232,10 @@ test("canonicalizePortableUri() normalizes authority pct-encoding casing", () =>
     "ap+ef61://did:example:abc%2Fdef/actor",
   );
   deepStrictEqual(
+    canonicalizePortableUri("ap://did:example:abc%2fdef%3abar/actor"),
+    "ap+ef61://did:example:abc%2Fdef%3Abar/actor",
+  );
+  deepStrictEqual(
     canonicalizePortableUri("ap://did%3Aexample%3Aabc%252fdef/actor"),
     "ap+ef61://did:example:abc%2Fdef/actor",
   );
@@ -245,6 +249,10 @@ test("canonicalizePortableUri() normalizes path and fragment pct-encoding casing
   deepStrictEqual(
     canonicalizePortableUri("ap://did:key:z6Mkabc/actor%2fprofile#part%2ftwo"),
     "ap+ef61://did:key:z6Mkabc/actor%2Fprofile#part%2Ftwo",
+  );
+  deepStrictEqual(
+    canonicalizePortableUri("ap://did:key:z6Mkabc/actor%2fprofile%3aimage"),
+    "ap+ef61://did:key:z6Mkabc/actor%2Fprofile%3Aimage",
   );
   ok(arePortableUrisEqual(
     "ap://did:key:z6Mkabc/actor%2fprofile#part%2ftwo",

--- a/packages/vocab-runtime/src/url.test.ts
+++ b/packages/vocab-runtime/src/url.test.ts
@@ -1,6 +1,8 @@
 import { deepStrictEqual, ok, rejects, throws } from "node:assert";
 import { test } from "node:test";
 import {
+  arePortableUrisEqual,
+  canonicalizePortableUri,
   expandIPv6Address,
   formatIri,
   haveSameIriOrigin,
@@ -182,6 +184,106 @@ test("formatIri() emits canonical portable ActivityPub URI syntax", () => {
     "https://example.com/actor",
   );
   deepStrictEqual(formatIri("/actor"), "/actor");
+});
+
+test("canonicalizePortableUri() emits comparison forms", () => {
+  const cases = [
+    "ap://did:key:z6Mkabc/actor",
+    "ap://did%3Akey%3Az6Mkabc/actor",
+    "ap://did:key:z6Mkabc/actor?gateways=https%3A%2F%2Fa.example",
+    "ap+ef61://did:key:z6Mkabc/actor",
+    "ap+ef61://did%3Akey%3Az6Mkabc/actor?gateways=https%3A%2F%2Fa.example",
+    new URL(
+      "ap+ef61://did%3Akey%3Az6Mkabc/actor?gateways=https%3A%2F%2Fa.example",
+    ),
+  ];
+  for (const iri of cases) {
+    deepStrictEqual(
+      canonicalizePortableUri(iri),
+      "ap+ef61://did:key:z6Mkabc/actor",
+    );
+  }
+});
+
+test("canonicalizePortableUri() preserves paths and fragments", () => {
+  deepStrictEqual(
+    canonicalizePortableUri(
+      "ap://did:key:z6Mkabc/objects/1/attachments/2?gateways=https%3A%2F%2Fa.example#image",
+    ),
+    "ap+ef61://did:key:z6Mkabc/objects/1/attachments/2#image",
+  );
+  deepStrictEqual(
+    canonicalizePortableUri("ap://did:key:z6Mkabc/objects/1#reply"),
+    "ap+ef61://did:key:z6Mkabc/objects/1#reply",
+  );
+});
+
+test("canonicalizePortableUri() preserves DID-internal pct-encoded characters", () => {
+  deepStrictEqual(
+    canonicalizePortableUri("ap://did:example:abc%2Fdef/actor?x=1"),
+    "ap+ef61://did:example:abc%2Fdef/actor",
+  );
+  deepStrictEqual(
+    canonicalizePortableUri("ap://did%3Aweb%3Aexample.com%253A3000/u/1"),
+    "ap+ef61://did:web:example.com%3A3000/u/1",
+  );
+});
+
+test("canonicalizePortableUri() normalizes DID scheme casing", () => {
+  deepStrictEqual(
+    canonicalizePortableUri("ap://DID:key:z6Mkabc/actor"),
+    "ap+ef61://did:key:z6Mkabc/actor",
+  );
+  deepStrictEqual(
+    canonicalizePortableUri("ap://DID%3Akey%3Az6Mkabc/actor"),
+    "ap+ef61://did:key:z6Mkabc/actor",
+  );
+});
+
+test("canonicalizePortableUri() rejects non-portable URIs", () => {
+  const cases = [
+    "https://example.com/actor",
+    "at://did:plc:example/record",
+    "/actor",
+    "ap://not-a-did/actor",
+    "ap://did:key:z6Mkabc",
+  ];
+  for (const iri of cases) {
+    throws(() => canonicalizePortableUri(iri), TypeError);
+  }
+});
+
+test("arePortableUrisEqual() compares canonical portable URI forms", () => {
+  ok(arePortableUrisEqual(
+    "ap://did:key:z6Mkabc/actor",
+    "ap+ef61://did%3Akey%3Az6Mkabc/actor?gateways=https%3A%2F%2Fa.example",
+  ));
+  ok(arePortableUrisEqual(
+    new URL("ap://did%3Akey%3Az6Mkabc/actor?gateways=https%3A%2F%2Fa.example"),
+    "ap+ef61://did:key:z6Mkabc/actor",
+  ));
+  ok(arePortableUrisEqual(
+    "ap://DID:key:z6Mkabc/actor",
+    "ap://did:key:z6Mkabc/actor",
+  ));
+  ok(
+    !arePortableUrisEqual(
+      "ap://did:key:z6Mkabc/actor",
+      "ap://did:key:z6Mkdef/actor",
+    ),
+  );
+  ok(
+    !arePortableUrisEqual(
+      "ap://did:key:z6Mkabc/actor",
+      "ap://did:key:z6Mkabc/outbox",
+    ),
+  );
+  ok(
+    !arePortableUrisEqual(
+      "ap://did:key:z6Mkabc/actor#one",
+      "ap://did:key:z6Mkabc/actor#two",
+    ),
+  );
 });
 
 test("formatIri() preserves DID authority pct-encoded delimiters", () => {

--- a/packages/vocab-runtime/src/url.test.ts
+++ b/packages/vocab-runtime/src/url.test.ts
@@ -325,6 +325,14 @@ test("canonicalizePortableUri() rejects non-portable URIs", () => {
   );
 });
 
+test("canonicalizePortableUri() rejects invalid path and fragment pct-encoding", () => {
+  throws(() => canonicalizePortableUri("ap://did:key:z6Mkabc/a%zz"), TypeError);
+  throws(
+    () => canonicalizePortableUri("ap://did:key:z6Mkabc/actor#part%zz"),
+    TypeError,
+  );
+});
+
 test("arePortableUrisEqual() compares canonical portable URI forms", () => {
   ok(arePortableUrisEqual(
     "ap://did:key:z6Mkabc/actor",
@@ -382,6 +390,12 @@ test("arePortableUrisEqual() handles non-portable URI strings", () => {
     !arePortableUrisEqual(
       "ap://not-a-did/actor",
       "ap://did:key:z6Mkabc/actor",
+    ),
+  );
+  ok(
+    !arePortableUrisEqual(
+      "ap://did:key:z6Mkabc/a%zz",
+      "ap://did:key:z6Mkabc/a%25zz",
     ),
   );
 });

--- a/packages/vocab-runtime/src/url.ts
+++ b/packages/vocab-runtime/src/url.ts
@@ -64,6 +64,40 @@ export function formatIri(iri: string | URL): string {
 }
 
 /**
+ * Canonicalizes a FEP-ef61 portable ActivityPub URI for comparison.
+ *
+ * This accepts both `ap:` and `ap+ef61:` URI values with decoded or
+ * percent-encoded DID authorities.  The returned value uses the `ap+ef61:`
+ * scheme, a decoded DID authority, and no query component.
+ *
+ * @since 2.4.0
+ */
+export function canonicalizePortableUri(input: string | URL): string {
+  const parsed = parsePortableIri(input instanceof URL ? input.href : input);
+  if (parsed == null) {
+    throw new TypeError("Invalid portable ActivityPub IRI.");
+  }
+  const authority = decodePortableAuthority(parsed.host).replace(
+    DID_SCHEME_PATTERN,
+    "did:",
+  );
+  return `ap+ef61://${authority}${parsed.pathname}${parsed.hash}`;
+}
+
+/**
+ * Checks whether two FEP-ef61 portable ActivityPub URIs identify the same
+ * portable object.
+ *
+ * @since 2.4.0
+ */
+export function arePortableUrisEqual(
+  left: string | URL,
+  right: string | URL,
+): boolean {
+  return canonicalizePortableUri(left) === canonicalizePortableUri(right);
+}
+
+/**
  * Checks whether two IRIs have the same origin.
  */
 export function haveSameIriOrigin(left: URL, right: URL): boolean {

--- a/packages/vocab-runtime/src/url.ts
+++ b/packages/vocab-runtime/src/url.ts
@@ -67,22 +67,23 @@ export function formatIri(iri: string | URL): string {
 /**
  * Canonicalizes a FEP-ef61 portable ActivityPub URI for comparison.
  *
- * This accepts both `ap:` and `ap+ef61:` URI values with decoded or
+ * This accepts both `ap:` and `ap+ef61:` URI strings with decoded or
  * percent-encoded DID authorities.  The returned value uses the `ap+ef61:`
- * scheme, a decoded DID authority, and no query component.
+ * scheme, a decoded DID authority, and no query component.  Pass the raw URI
+ * string, not a `URL` object, because JavaScript `URL` normalizes opaque path
+ * segments before Fedify can compare them.
  *
  * @since 2.4.0
  */
-export function canonicalizePortableUri(input: string | URL): string {
-  const iri = input instanceof URL ? input.href : input;
-  const parsed = parsePortableIri(iri);
+export function canonicalizePortableUri(input: string): string {
+  if (typeof input !== "string") {
+    throw new TypeError("Invalid portable ActivityPub IRI.");
+  }
+  const parsed = parsePortableIri(input);
   if (parsed == null) {
     throw new TypeError("Invalid portable ActivityPub IRI.");
   }
-  const match = iri.match(PORTABLE_IRI_PATTERN);
-  if (match == null) {
-    throw new TypeError("Invalid portable ActivityPub IRI.");
-  }
+  const match = input.match(PORTABLE_IRI_PATTERN)!;
   // parsePortableIri() validates the value but returns a URL, which normalizes
   // opaque path segments.  Use the raw match for path and fragment comparison.
   // parsed.host is the encodeURIComponent() output from parsePortableIri(), so
@@ -101,8 +102,8 @@ export function canonicalizePortableUri(input: string | URL): string {
  * @since 2.4.0
  */
 export function arePortableUrisEqual(
-  left: string | URL,
-  right: string | URL,
+  left: string,
+  right: string,
 ): boolean {
   return canonicalizePortableUri(left) === canonicalizePortableUri(right);
 }

--- a/packages/vocab-runtime/src/url.ts
+++ b/packages/vocab-runtime/src/url.ts
@@ -219,6 +219,9 @@ function normalizePercentEncoding(value: string): string {
 }
 
 function normalizePortableComponent(value: string): string {
+  if (INVALID_PERCENT_ENCODING_PATTERN.test(value)) {
+    throw new TypeError("Invalid portable ActivityPub IRI component.");
+  }
   return value.replace(
     /%[0-9A-Fa-f]{2}|[^%]+|%/g,
     (match) =>

--- a/packages/vocab-runtime/src/url.ts
+++ b/packages/vocab-runtime/src/url.ts
@@ -242,7 +242,14 @@ function normalizePortableComponent(value: string): string {
         );
         return /[A-Za-z0-9._~-]/.test(decoded) ? decoded : upper;
       }
-      return encodeURI(match);
+      try {
+        return encodeURI(match);
+      } catch (error) {
+        if (error instanceof URIError) {
+          throw new TypeError("Invalid portable ActivityPub IRI component.");
+        }
+        throw error;
+      }
     },
   );
 }

--- a/packages/vocab-runtime/src/url.ts
+++ b/packages/vocab-runtime/src/url.ts
@@ -12,6 +12,7 @@ export class UrlError extends Error {
 const PORTABLE_IRI_PATTERN =
   /^(ap|ap\+ef61):\/\/([^/?#]*)([^?#]*)(\?[^#]*)?(#.*)?$/i;
 const INVALID_PERCENT_ENCODING_PATTERN = /%(?![0-9A-Fa-f]{2})/;
+const PERCENT_ENCODING_PATTERN = /%[0-9A-Fa-f]{2}/g;
 const DID_SCHEME_PATTERN = /^did:/i;
 const DID_PATTERN = /^did:[a-z0-9]+:[-A-Za-z0-9._%]+(?::[-A-Za-z0-9._%]+)*$/i;
 
@@ -73,15 +74,24 @@ export function formatIri(iri: string | URL): string {
  * @since 2.4.0
  */
 export function canonicalizePortableUri(input: string | URL): string {
-  const parsed = parsePortableIri(input instanceof URL ? input.href : input);
+  const iri = input instanceof URL ? input.href : input;
+  const parsed = parsePortableIri(iri);
   if (parsed == null) {
     throw new TypeError("Invalid portable ActivityPub IRI.");
   }
-  const authority = decodePortableAuthority(parsed.host).replace(
-    DID_SCHEME_PATTERN,
-    "did:",
+  const match = iri.match(PORTABLE_IRI_PATTERN);
+  if (match == null) {
+    throw new TypeError("Invalid portable ActivityPub IRI.");
+  }
+  // parsePortableIri() validates the value but returns a URL, which normalizes
+  // opaque path segments.  Use the raw match for path and fragment comparison.
+  // parsed.host is the encodeURIComponent() output from parsePortableIri(), so
+  // decodePortableAuthority() reverses the shared percent-encoded authority
+  // path here rather than the raw did:-prefixed branch.
+  const authority = normalizePercentEncoding(
+    decodePortableAuthority(parsed.host).replace(DID_SCHEME_PATTERN, "did:"),
   );
-  return `ap+ef61://${authority}${parsed.pathname}${parsed.hash}`;
+  return `ap+ef61://${authority}${match[3]}${match[5] ?? ""}`;
 }
 
 /**
@@ -175,6 +185,13 @@ function decodePortableAuthority(authority: string): string {
     throw new TypeError("Invalid portable ActivityPub IRI authority.");
   }
   return decoded;
+}
+
+function normalizePercentEncoding(value: string): string {
+  return value.replace(
+    PERCENT_ENCODING_PATTERN,
+    (match) => match.toUpperCase(),
+  );
 }
 
 function parseAtUri(uri: string): URL {

--- a/packages/vocab-runtime/src/url.ts
+++ b/packages/vocab-runtime/src/url.ts
@@ -73,6 +73,9 @@ export function formatIri(iri: string | URL): string {
  * string, not a `URL` object, because JavaScript `URL` normalizes opaque path
  * segments before Fedify can compare them.
  *
+ * @param input The raw portable ActivityPub URI string to canonicalize.
+ * @returns The canonical portable ActivityPub URI string.
+ * @throws {TypeError} If the input is not a valid portable ActivityPub IRI.
  * @since 2.4.0
  */
 export function canonicalizePortableUri(input: string): string {
@@ -103,6 +106,10 @@ export function canonicalizePortableUri(input: string): string {
 /**
  * Checks whether two FEP-ef61 portable ActivityPub URIs identify the same
  * portable object.
+ *
+ * Non-string or non-portable inputs are compared by strict string equality.
+ * Portable URI inputs are compared through {@link canonicalizePortableUri},
+ * which can throw a `TypeError` for malformed portable authorities or paths.
  *
  * @since 2.4.0
  */

--- a/packages/vocab-runtime/src/url.ts
+++ b/packages/vocab-runtime/src/url.ts
@@ -89,13 +89,15 @@ export function canonicalizePortableUri(input: string): string {
   // parsed.host is the encodeURIComponent() output from parsePortableIri(), so
   // decodePortableAuthority() reverses the shared percent-encoded authority
   // path here rather than the raw did:-prefixed branch.
-  // Only the authority gets percent-encoding case normalization.  The path and
-  // fragment stay byte-for-byte from the raw match so their pct-encoding case
-  // remains part of the opaque portable object identity.
   const authority = normalizePercentEncoding(
     decodePortableAuthority(parsed.host).replace(DID_SCHEME_PATTERN, "did:"),
   );
-  return `ap+ef61://${authority}${match[3]}${match[5] ?? ""}`;
+  // Keep path and fragment text from the raw match to avoid URL dot-segment
+  // normalization, but still normalize percent-escape hex casing per URI
+  // comparison rules.
+  const path = normalizePercentEncoding(match[3]);
+  const fragment = match[5] == null ? "" : normalizePercentEncoding(match[5]);
+  return `ap+ef61://${authority}${path}${fragment}`;
 }
 
 /**
@@ -108,6 +110,12 @@ export function arePortableUrisEqual(
   left: string,
   right: string,
 ): boolean {
+  if (
+    typeof left !== "string" || typeof right !== "string" ||
+    !PORTABLE_IRI_PATTERN.test(left) || !PORTABLE_IRI_PATTERN.test(right)
+  ) {
+    return left === right;
+  }
   return canonicalizePortableUri(left) === canonicalizePortableUri(right);
 }
 

--- a/packages/vocab-runtime/src/url.ts
+++ b/packages/vocab-runtime/src/url.ts
@@ -96,10 +96,10 @@ export function canonicalizePortableUri(input: string): string {
     decodePortableAuthority(parsed.host).replace(DID_SCHEME_PATTERN, "did:"),
   );
   // Keep path and fragment text from the raw match to avoid URL dot-segment
-  // normalization, but still normalize percent-escape hex casing per URI
-  // comparison rules.
-  const path = normalizePercentEncoding(match[3]);
-  const fragment = match[5] == null ? "" : normalizePercentEncoding(match[5]);
+  // normalization, but still encode raw characters and normalize
+  // percent-escape hex casing per URI comparison rules.
+  const path = normalizePortableComponent(match[3]);
+  const fragment = match[5] == null ? "" : normalizePortableComponent(match[5]);
   return `ap+ef61://${authority}${path}${fragment}`;
 }
 
@@ -107,9 +107,10 @@ export function canonicalizePortableUri(input: string): string {
  * Checks whether two FEP-ef61 portable ActivityPub URIs identify the same
  * portable object.
  *
- * Non-string or non-portable inputs are compared by strict string equality.
- * Portable URI inputs are compared through {@link canonicalizePortableUri},
- * which can throw a `TypeError` for malformed portable authorities or paths.
+ * Non-string inputs return `false`.  Non-portable URI strings use strict string
+ * equality.  Portable URI strings are compared through
+ * {@link canonicalizePortableUri}; malformed portable URI strings return
+ * `false` unless they are exactly equal.
  *
  * @since 2.4.0
  */
@@ -117,13 +118,17 @@ export function arePortableUrisEqual(
   left: string,
   right: string,
 ): boolean {
-  if (
-    typeof left !== "string" || typeof right !== "string" ||
-    !PORTABLE_IRI_PATTERN.test(left) || !PORTABLE_IRI_PATTERN.test(right)
-  ) {
-    return left === right;
+  if (typeof left !== "string" || typeof right !== "string") return false;
+  if (left === right) return true;
+  if (!PORTABLE_IRI_PATTERN.test(left) || !PORTABLE_IRI_PATTERN.test(right)) {
+    return false;
   }
-  return canonicalizePortableUri(left) === canonicalizePortableUri(right);
+  try {
+    return canonicalizePortableUri(left) === canonicalizePortableUri(right);
+  } catch (error) {
+    if (error instanceof TypeError) return false;
+    throw error;
+  }
 }
 
 /**
@@ -210,6 +215,16 @@ function normalizePercentEncoding(value: string): string {
   return value.replace(
     PERCENT_ENCODING_PATTERN,
     (match) => match.toUpperCase(),
+  );
+}
+
+function normalizePortableComponent(value: string): string {
+  return value.replace(
+    /%[0-9A-Fa-f]{2}|[^%]+|%/g,
+    (match) =>
+      match.startsWith("%") && match.length === 3
+        ? match.toUpperCase()
+        : encodeURI(match),
   );
 }
 

--- a/packages/vocab-runtime/src/url.ts
+++ b/packages/vocab-runtime/src/url.ts
@@ -89,6 +89,9 @@ export function canonicalizePortableUri(input: string): string {
   // parsed.host is the encodeURIComponent() output from parsePortableIri(), so
   // decodePortableAuthority() reverses the shared percent-encoded authority
   // path here rather than the raw did:-prefixed branch.
+  // Only the authority gets percent-encoding case normalization.  The path and
+  // fragment stay byte-for-byte from the raw match so their pct-encoding case
+  // remains part of the opaque portable object identity.
   const authority = normalizePercentEncoding(
     decodePortableAuthority(parsed.host).replace(DID_SCHEME_PATTERN, "did:"),
   );

--- a/packages/vocab-runtime/src/url.ts
+++ b/packages/vocab-runtime/src/url.ts
@@ -92,7 +92,7 @@ export function canonicalizePortableUri(input: string): string {
   // parsed.host is the encodeURIComponent() output from parsePortableIri(), so
   // decodePortableAuthority() reverses the shared percent-encoded authority
   // path here rather than the raw did:-prefixed branch.
-  const authority = normalizePercentEncoding(
+  const authority = normalizePortableAuthority(
     decodePortableAuthority(parsed.host).replace(DID_SCHEME_PATTERN, "did:"),
   );
   // Keep path and fragment text from the raw match to avoid URL dot-segment
@@ -215,6 +215,16 @@ function normalizePercentEncoding(value: string): string {
   return value.replace(
     PERCENT_ENCODING_PATTERN,
     (match) => match.toUpperCase(),
+  );
+}
+
+function normalizePortableAuthority(authority: string): string {
+  return normalizePercentEncoding(authority).replace(
+    PERCENT_ENCODING_PATTERN,
+    (match) => {
+      const decoded = String.fromCharCode(Number.parseInt(match.slice(1), 16));
+      return /[A-Za-z0-9._~-]/.test(decoded) ? decoded : match;
+    },
   );
 }
 

--- a/packages/vocab-runtime/src/url.ts
+++ b/packages/vocab-runtime/src/url.ts
@@ -233,9 +233,9 @@ function normalizePortableComponent(value: string): string {
     throw new TypeError("Invalid portable ActivityPub IRI component.");
   }
   return value.replace(
-    /%[0-9A-Fa-f]{2}|[^%]+|%/g,
+    /%[0-9A-Fa-f]{2}|[^%]+/g,
     (match) => {
-      if (match.startsWith("%") && match.length === 3) {
+      if (match.startsWith("%")) {
         const upper = match.toUpperCase();
         const decoded = String.fromCharCode(
           Number.parseInt(upper.slice(1), 16),

--- a/packages/vocab-runtime/src/url.ts
+++ b/packages/vocab-runtime/src/url.ts
@@ -234,10 +234,16 @@ function normalizePortableComponent(value: string): string {
   }
   return value.replace(
     /%[0-9A-Fa-f]{2}|[^%]+|%/g,
-    (match) =>
-      match.startsWith("%") && match.length === 3
-        ? match.toUpperCase()
-        : encodeURI(match),
+    (match) => {
+      if (match.startsWith("%") && match.length === 3) {
+        const upper = match.toUpperCase();
+        const decoded = String.fromCharCode(
+          Number.parseInt(upper.slice(1), 16),
+        );
+        return /[A-Za-z0-9._~-]/.test(decoded) ? decoded : upper;
+      }
+      return encodeURI(match);
+    },
   );
 }
 


### PR DESCRIPTION
Closes #828.


What changed
------------

This adds `canonicalizePortableUri()` and `arePortableUrisEqual()` to `@fedify/vocab-runtime` for comparing FEP-ef61 portable ActivityPub URI identifiers.

It also documents the new helpers in *docs/manual/vocab.md*, exports them from *packages/vocab-runtime/src/mod.ts*, adds regression coverage in *packages/vocab-runtime/src/url.test.ts*, and records the change in *CHANGES.md*.


How it works
------------

The new canonicalization helper reuses the existing portable IRI parser in *packages/vocab-runtime/src/url.ts* instead of introducing a second parser. That keeps validation behavior aligned with the URI handling added for #826: both `ap:` and `ap+ef61:` inputs are accepted, decoded and percent-encoded DID authorities are normalized through the same code path, malformed portable authorities are rejected consistently, and JavaScript `URL` instances using URL-safe authorities work the same way as string inputs.

For comparison, the helper emits a string form with the `ap+ef61:` scheme, a decoded DID authority, no query component, and the original path and fragment. Removing the query component follows FEP-ef61’s comparison rule, which treats query parameters such as `gateways` as location hints rather than object identity. Preserving the path and fragment keeps the identity boundary strict where the URI syntax still carries object-specific meaning.

The canonicalization also normalizes only the leading DID scheme from `DID:` to `did:`. It deliberately does not lowercase the whole DID authority, because DID method-specific identifiers may have their own case-sensitive rules. This matches the existing portable-origin comparison behavior while avoiding a broader transformation than the runtime already relies on.

`arePortableUrisEqual()` is intentionally a thin wrapper over `canonicalizePortableUri()`. That keeps the public API simple and makes equality semantics auditable from a single canonical form rather than duplicating comparison logic.


Why this approach
-----------------

FEP-ef61 distinguishes serialization from comparison. Fedify already serializes portable IRIs with `formatIri()`, and serialization needs to preserve query hints because they can help consumers find a portable actor through gateways. Object identity comparison has a different rule: query hints must be ignored. Adding a separate comparison helper avoids changing serialization behavior for generated vocabulary classes while still giving callers a spec-aware way to compare portable identifiers.

The implementation stays scoped to issue #828. It does not convert compatible HTTP gateway identifiers, dereference gateways, resolve DID documents, verify FEP-8b32 proofs, or extend FEP-fe34 cryptographic origin checks. Those concerns depend on gateway and trust-model behavior outside this issue, while the comparison helper is a small runtime primitive that later work can build on.

The tests cover decoded and encoded authorities, both supported schemes, query stripping, path and fragment preservation, DID-internal percent escapes, DID scheme casing, non-equivalent authorities, non-equivalent paths, non-equivalent fragments, and unsupported or malformed inputs. These cases are intended to pin down the boundary between accepted portable URI spellings and the narrower canonical form used for comparison.


Verification
------------

 -  `mise run test:deno packages/vocab-runtime/src/url.test.ts`
 -  `mise run check-each vocab-runtime`
 -  `mise run check:md`
 -  `mise run test-each vocab-runtime`

`mise run test-each vocab-runtime` completed successfully. The selected package reported that it has no `test:bun` script.