### PR TITLE
Support FEP-fe34 cryptographic origins for portable objects

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,11 @@ To be released.
 
 ### @fedify/fedify
 
+ -  Updated `verifyObject()` so [FEP-8b32] proofs signed by `did:key`
+    verification methods can authenticate portable objects whose owner is an
+    `ap:` or `ap+ef61:` URI with the same [FEP-fe34] cryptographic origin.
+    [[#829], [#926]]
+
  -  Added local `did:key` verification method resolution for
     [FEP-8b32] Object Integrity Proofs.  `verifyProof()` can now verify
     Ed25519 `eddsa-jcs-2022` proofs whose `verificationMethod` is a
@@ -63,6 +68,7 @@ To be released.
     `esnext.temporal` lib reference.  [[#823], [#925]]
 
 [FEP-8b32]: https://w3id.org/fep/8b32
+[FEP-fe34]: https://w3id.org/fep/fe34
 [FEP-ef61]: https://w3id.org/fep/ef61
 [Standard Schema]: https://standardschema.dev/
 [#206]: https://github.com/fedify-dev/fedify/issues/206
@@ -74,11 +80,19 @@ To be released.
 [#812]: https://github.com/fedify-dev/fedify/pull/812
 [#823]: https://github.com/fedify-dev/fedify/issues/823
 [#827]: https://github.com/fedify-dev/fedify/issues/827
+[#829]: https://github.com/fedify-dev/fedify/issues/829
 [#915]: https://github.com/fedify-dev/fedify/pull/915
 [#923]: https://github.com/fedify-dev/fedify/pull/923
 [#925]: https://github.com/fedify-dev/fedify/pull/925
+[#926]: https://github.com/fedify-dev/fedify/pull/926
 
 ### @fedify/vocab
+
+ -  Updated [FEP-fe34] cross-origin checks to understand cryptographic origins
+    for [FEP-ef61] portable ActivityPub IDs and DID URLs.  Generated property
+    accessors and `lookupObject()` now treat `ap:`/`ap+ef61:` IDs and matching
+    `did:key` verification method IDs as same-origin when their DID components
+    match.  [[#829], [#926]]
 
  -  Added support for [FEP-ef61] portable ActivityPub IRIs in generated
     vocabulary codecs.  `ap:` and `ap+ef61:` values with decoded or
@@ -103,6 +117,12 @@ To be released.
 [#914]: https://github.com/fedify-dev/fedify/pull/914
 
 ### @fedify/vocab-runtime
+
+ -  Added `getFe34Origin()` and `haveSameFe34Origin()` for comparing ordinary
+    web origins and [FEP-ef61] cryptographic origins with one shared
+    [FEP-fe34] helper.  HTTP(S) URLs keep web-origin semantics, while
+    `ap:`/`ap+ef61:` URIs and DID URLs use their DID component as the origin.
+    [[#829], [#926]]
 
  -  Added `canonicalizePortableUri()` and `arePortableUrisEqual()` for
     comparing [FEP-ef61] portable ActivityPub URI strings.  The helpers accept
@@ -3363,7 +3383,6 @@ Released on October 14, 2025.
     Node.js's `--experimental-require-module` flag and resolves dual package
     hazard issues.  [[#429], [#431]]
 
-[FEP-fe34]: https://w3id.org/fep/fe34
 [RFC 6570]: https://tools.ietf.org/html/rfc6570
 [FEP-5711]: https://w3id.org/fep/5711
 [OStatus 1.0 Draft 2]: https://www.w3.org/community/ostatus/wiki/images/9/93/OStatus_1.0_Draft_2.pdf

--- a/docs/manual/context-advanced.md
+++ b/docs/manual/context-advanced.md
@@ -446,6 +446,11 @@ contains an `@id` with a different origin from the requested URL, the method
 returns `null` by default to prevent content-spoofing attacks. Control this
 behavior with the `crossOrigin` option:
 
+HTTP(S) IDs are compared by web origin.  Portable `ap:`/`ap+ef61:` IDs and DID
+URLs are compared by their cryptographic DID origin, so
+`ap+ef61://did:key:z.../actor` and `did:key:z...#z...` are same-origin when the
+DID matches.
+
 ~~~~ typescript twoslash
 import { type Context } from "@fedify/fedify";
 const ctx = null as unknown as Context<void>;

--- a/docs/manual/context.md
+++ b/docs/manual/context.md
@@ -455,6 +455,8 @@ const note = await ctx.lookupObject(
 > For example, if you request `https://example.com/notes/123` but the fetched
 > document has `@id: "https://malicious.com/notes/456"`, the method will
 > refuse to return the object and log a warning instead.
+> For portable `ap:`/`ap+ef61:` IDs and DID URLs, Fedify compares the
+> cryptographic DID origin rather than an HTTP origin.
 >
 > You can control this behavior using the `crossOrigin` option:
 >

--- a/docs/manual/send.md
+++ b/docs/manual/send.md
@@ -1090,6 +1090,9 @@ is a DID URL such as `did:key:z...#z...` does not require fetching that
 verification method as a JSON-LD document.  This is the key lookup mechanism
 used by [FEP-ef61] portable objects; policy checks that relate a portable
 object ID to its proof are handled separately from proof verification itself.
+When `verifyObject()` checks whether a proof authenticates an object's actor or
+attribution, it treats matching portable `ap:`/`ap+ef61:` IDs and `did:key`
+controllers as the same [FEP-fe34] cryptographic origin.
 
 > [!TIP]
 > HTTPS Signatures, Linked Data Signatures, and Object Integrity Proofs can
@@ -1108,6 +1111,7 @@ object ID to its proof are handled separately from proof verification itself.
 
 [FEP-8b32]: https://w3id.org/fep/8b32
 [FEP-ef61]: https://w3id.org/fep/ef61
+[FEP-fe34]: https://w3id.org/fep/fe34
 
 
 Activity transformers

--- a/docs/manual/vocab.md
+++ b/docs/manual/vocab.md
@@ -601,6 +601,12 @@ This security model ensures that objects and their properties respect origin
 boundaries, preventing malicious actors from impersonating content from other
 servers.
 
+For ordinary HTTP(S) object IDs, the origin is the web origin: scheme, host,
+and port.  For [FEP-ef61] portable IDs, Fedify uses the cryptographic origin
+defined by the portable identifier.  An `ap:` or `ap+ef61:` URI is owned by the
+DID in its authority component, and a DID URL such as `did:key:z...#z...` is
+owned by its DID component.
+
 [FEP-fe34]: https://w3id.org/fep/fe34
 
 ### Same-origin policy for properties
@@ -632,6 +638,11 @@ Fedify will not trust the embedded `Note` object because its `@id` has a
 different origin (`different-origin.com`) than the parent activity's origin
 (`example.com`).  Instead, it will fetch the `Note` object directly from
 `https://different-origin.com/notes/456` to verify its authenticity.
+
+The same rule applies to cryptographic origins.  For example,
+`ap+ef61://did:key:zAlice/actor` and `did:key:zAlice#zAlice` share the
+`did:key:zAlice` origin, but `ap+ef61://did:key:zBob/actor` is a different
+origin.
 
 ### Controlling origin checks
 

--- a/packages/fedify/src/sig/proof.test.ts
+++ b/packages/fedify/src/sig/proof.test.ts
@@ -1150,6 +1150,55 @@ test("verifyObject() rejects HTTPS keys claiming a portable DID controller", asy
   assertEquals(verified, null);
 });
 
+test("verifyObject() rejects HTTPS keys claiming an exact DID attribution", async () => {
+  const victimDid = "did:key:z6MkVictim";
+  const keyId = new URL("https://attacker.example/keys/ed25519");
+  const note = new Note({
+    id: parseIri("ap://did:key:z6MkVictim/objects/1"),
+    attribution: new URL(victimDid),
+    content: "Spoofed DID-attributed note",
+  });
+  const signed = await signObject(note, ed25519PrivateKey, keyId, {
+    contextLoader: mockDocumentLoader,
+    context: [
+      "https://www.w3.org/ns/activitystreams",
+      "https://w3id.org/security/data-integrity/v1",
+    ],
+  });
+  const jsonLd = await signed.toJsonLd({
+    format: "compact",
+    contextLoader: mockDocumentLoader,
+    context: [
+      "https://www.w3.org/ns/activitystreams",
+      "https://w3id.org/security/data-integrity/v1",
+    ],
+  });
+
+  const verified = await verifyObject(Note, jsonLd, {
+    documentLoader: async (url) => {
+      if (url === keyId.href) {
+        return {
+          documentUrl: url,
+          contextUrl: null,
+          document: {
+            "@context": "https://w3id.org/security/multikey/v1",
+            id: keyId.href,
+            type: "Multikey",
+            controller: victimDid,
+            publicKeyMultibase: await exportMultibaseKey(
+              ed25519PublicKey.publicKey,
+            ),
+          },
+        };
+      }
+      throw new TypeError(`Unexpected fetch: ${url}`);
+    },
+    contextLoader: mockDocumentLoader,
+  });
+
+  assertEquals(verified, null);
+});
+
 test("verifyObject() rejects did:key proofs from another portable attribution origin", async () => {
   const did = await exportDidKey(ed25519PublicKey.publicKey);
   const keyId = new URL(`${did}#${did.substring("did:key:".length)}`);

--- a/packages/fedify/src/sig/proof.test.ts
+++ b/packages/fedify/src/sig/proof.test.ts
@@ -1019,3 +1019,168 @@ test("verifyObject()", async () => {
   assertInstanceOf(note, Note);
   assertEquals(note.content, "Hello world");
 });
+
+test("verifyObject() accepts did:key proofs for matching portable attribution origin", async () => {
+  const did = await exportDidKey(ed25519PublicKey.publicKey);
+  const keyId = new URL(`${did}#${did.substring("did:key:".length)}`);
+  const note = new Note({
+    id: parseIri(`ap://did:key:${did.substring("did:key:".length)}/objects/1`),
+    attribution: parseIri(
+      `ap://did:key:${did.substring("did:key:".length)}/actor`,
+    ),
+    content: "Portable note",
+  });
+  const signed = await signObject(note, ed25519PrivateKey, keyId, {
+    contextLoader: mockDocumentLoader,
+    context: [
+      "https://www.w3.org/ns/activitystreams",
+      "https://w3id.org/security/data-integrity/v1",
+    ],
+  });
+  const jsonLd = await signed.toJsonLd({
+    format: "compact",
+    contextLoader: mockDocumentLoader,
+    context: [
+      "https://www.w3.org/ns/activitystreams",
+      "https://w3id.org/security/data-integrity/v1",
+    ],
+  });
+
+  const verified = await verifyObject(Note, jsonLd, {
+    documentLoader() {
+      throw new TypeError("did:key must not use the document loader");
+    },
+    contextLoader: mockDocumentLoader,
+  });
+
+  assertInstanceOf(verified, Note);
+  assertEquals(verified.content, "Portable note");
+});
+
+test("verifyObject() accepts multiple portable attributions from the same did:key origin", async () => {
+  const did = await exportDidKey(ed25519PublicKey.publicKey);
+  const method = did.substring("did:key:".length);
+  const keyId = new URL(`${did}#${method}`);
+  const create = new Create({
+    id: parseIri(`ap://did:key:${method}/activities/1`),
+    actor: parseIri(`ap://did:key:${method}/actor`),
+    attribution: parseIri(`ap://did:key:${method}/profile`),
+    object: new Note({
+      id: parseIri(`ap://did:key:${method}/objects/1`),
+      content: "Portable note",
+    }),
+  });
+  const signed = await signObject(create, ed25519PrivateKey, keyId, {
+    contextLoader: mockDocumentLoader,
+    context: [
+      "https://www.w3.org/ns/activitystreams",
+      "https://w3id.org/security/data-integrity/v1",
+    ],
+  });
+  const jsonLd = await signed.toJsonLd({
+    format: "compact",
+    contextLoader: mockDocumentLoader,
+    context: [
+      "https://www.w3.org/ns/activitystreams",
+      "https://w3id.org/security/data-integrity/v1",
+    ],
+  });
+
+  const verified = await verifyObject(Create, jsonLd, {
+    documentLoader() {
+      throw new TypeError("did:key must not use the document loader");
+    },
+    contextLoader: mockDocumentLoader,
+  });
+
+  assertInstanceOf(verified, Create);
+  assertEquals(verified.actorId, parseIri(`ap://did:key:${method}/actor`));
+  assertEquals(
+    verified.attributionId,
+    parseIri(`ap://did:key:${method}/profile`),
+  );
+});
+
+test("verifyObject() rejects HTTPS keys claiming a portable DID controller", async () => {
+  const victimDid = "did:key:z6MkVictim";
+  const keyId = new URL("https://attacker.example/keys/ed25519");
+  const note = new Note({
+    id: parseIri("ap://did:key:z6MkVictim/objects/1"),
+    attribution: parseIri("ap://did:key:z6MkVictim/actor"),
+    content: "Spoofed portable note",
+  });
+  const signed = await signObject(note, ed25519PrivateKey, keyId, {
+    contextLoader: mockDocumentLoader,
+    context: [
+      "https://www.w3.org/ns/activitystreams",
+      "https://w3id.org/security/data-integrity/v1",
+    ],
+  });
+  const jsonLd = await signed.toJsonLd({
+    format: "compact",
+    contextLoader: mockDocumentLoader,
+    context: [
+      "https://www.w3.org/ns/activitystreams",
+      "https://w3id.org/security/data-integrity/v1",
+    ],
+  });
+
+  const verified = await verifyObject(Note, jsonLd, {
+    documentLoader: async (url) => {
+      if (url === keyId.href) {
+        return {
+          documentUrl: url,
+          contextUrl: null,
+          document: {
+            "@context": "https://w3id.org/security/multikey/v1",
+            id: keyId.href,
+            type: "Multikey",
+            controller: victimDid,
+            publicKeyMultibase: await exportMultibaseKey(
+              ed25519PublicKey.publicKey,
+            ),
+          },
+        };
+      }
+      throw new TypeError(`Unexpected fetch: ${url}`);
+    },
+    contextLoader: mockDocumentLoader,
+  });
+
+  assertEquals(verified, null);
+});
+
+test("verifyObject() rejects did:key proofs from another portable attribution origin", async () => {
+  const did = await exportDidKey(ed25519PublicKey.publicKey);
+  const keyId = new URL(`${did}#${did.substring("did:key:".length)}`);
+  const note = new Note({
+    id: parseIri(`ap://did:key:${did.substring("did:key:".length)}/objects/1`),
+    attribution: parseIri("ap://did:key:z6MkOther/actor"),
+    content: "Portable note",
+  });
+  const signed = await signObject(note, ed25519PrivateKey, keyId, {
+    contextLoader: mockDocumentLoader,
+    context: [
+      "https://www.w3.org/ns/activitystreams",
+      "https://w3id.org/security/data-integrity/v1",
+    ],
+  });
+  const jsonLd = await signed.toJsonLd({
+    format: "compact",
+    contextLoader: mockDocumentLoader,
+    context: [
+      "https://www.w3.org/ns/activitystreams",
+      "https://w3id.org/security/data-integrity/v1",
+    ],
+  });
+
+  assertEquals(
+    await verifyObject(Note, jsonLd, {
+      documentLoader() {
+        throw new TypeError("did:key must not use the document loader");
+      },
+      contextLoader: mockDocumentLoader,
+    }),
+    null,
+  );
+});

--- a/packages/fedify/src/sig/proof.ts
+++ b/packages/fedify/src/sig/proof.ts
@@ -5,7 +5,7 @@ import {
   Multikey,
   type Object,
 } from "@fedify/vocab";
-import type { DocumentLoader } from "@fedify/vocab-runtime";
+import { type DocumentLoader, haveSameFe34Origin } from "@fedify/vocab-runtime";
 import { getLogger } from "@logtape/logtape";
 import {
   type MeterProvider,
@@ -584,6 +584,7 @@ export async function verifyObject<T extends Object>(
   for await (const proof of object.getProofs(options)) {
     const key = await verifyProof(jsonLd, proof, options);
     if (key === null) return null;
+    if (proof.verificationMethodId == null) return null;
     if (key.controllerId == null) {
       logger.debug(
         "Key {keyId} does not have a controller.",
@@ -591,7 +592,11 @@ export async function verifyObject<T extends Object>(
       );
       continue;
     }
-    attributions.delete(key.controllerId.href);
+    deleteAuthenticatedAttribution(
+      attributions,
+      key.controllerId,
+      proof.verificationMethodId,
+    );
   }
   if (attributions.size > 0) {
     logger.debug(
@@ -601,4 +606,29 @@ export async function verifyObject<T extends Object>(
     return null;
   }
   return object;
+}
+
+function deleteAuthenticatedAttribution(
+  attributions: Set<string>,
+  controllerId: URL,
+  verificationMethodId: URL,
+): void {
+  attributions.delete(controllerId.href);
+  if (
+    !hasCryptographicOrigin(controllerId.href) ||
+    !hasCryptographicOrigin(verificationMethodId.href) ||
+    !haveSameFe34Origin(controllerId, verificationMethodId)
+  ) return;
+  for (const attribution of [...attributions]) {
+    if (
+      hasCryptographicOrigin(attribution) &&
+      haveSameFe34Origin(controllerId, attribution)
+    ) {
+      attributions.delete(attribution);
+    }
+  }
+}
+
+function hasCryptographicOrigin(iri: string): boolean {
+  return /^did:/i.test(iri) || /^ap(?:\+ef61)?:\/\//i.test(iri);
 }

--- a/packages/fedify/src/sig/proof.ts
+++ b/packages/fedify/src/sig/proof.ts
@@ -613,11 +613,21 @@ function deleteAuthenticatedAttribution(
   controllerId: URL,
   verificationMethodId: URL,
 ): void {
-  attributions.delete(controllerId.href);
+  const controllerHasCryptographicOrigin = hasCryptographicOrigin(
+    controllerId.href,
+  );
+  const verificationMethodMatchesController =
+    controllerHasCryptographicOrigin &&
+    hasCryptographicOrigin(verificationMethodId.href) &&
+    haveSameFe34Origin(controllerId, verificationMethodId);
   if (
-    !hasCryptographicOrigin(controllerId.href) ||
-    !hasCryptographicOrigin(verificationMethodId.href) ||
-    !haveSameFe34Origin(controllerId, verificationMethodId)
+    !controllerHasCryptographicOrigin ||
+    verificationMethodMatchesController
+  ) {
+    attributions.delete(controllerId.href);
+  }
+  if (
+    !verificationMethodMatchesController
   ) return;
   for (const attribution of [...attributions]) {
     if (

--- a/packages/vocab-runtime/src/internal/jsonld-cache.ts
+++ b/packages/vocab-runtime/src/internal/jsonld-cache.ts
@@ -1,6 +1,6 @@
 import type { DocumentLoader } from "../docloader.ts";
 import jsonld from "../jsonld.ts";
-import { formatIri, haveSameIriOrigin } from "../url.ts";
+import { formatIri, haveSameFe34Origin, haveSameIriOrigin } from "../url.ts";
 
 const noJsonLdContext = Symbol("noJsonLdContext");
 
@@ -28,7 +28,8 @@ export function isTrustedIriOrigin(
   right: URL | null | undefined,
 ): boolean {
   return options.crossOrigin === "trust" || left == null ||
-    (right != null && haveSameIriOrigin(left, right));
+    (right != null &&
+      (haveSameIriOrigin(left, right) || haveSameFe34Origin(left, right)));
 }
 
 /**

--- a/packages/vocab-runtime/src/mod.ts
+++ b/packages/vocab-runtime/src/mod.ts
@@ -58,6 +58,8 @@ export {
   canonicalizePortableUri,
   expandIPv6Address,
   formatIri,
+  getFe34Origin,
+  haveSameFe34Origin,
   haveSameIriOrigin,
   isValidPublicIPv4Address,
   isValidPublicIPv6Address,

--- a/packages/vocab-runtime/src/url.test.ts
+++ b/packages/vocab-runtime/src/url.test.ts
@@ -213,6 +213,14 @@ test("getFe34Origin() computes web and cryptographic origins", () => {
     getFe34Origin("did:KEY:z6Mkabc#z6Mkabc"),
     "did:key:z6Mkabc",
   );
+  deepStrictEqual(
+    getFe34Origin("ap://did%3Aweb%3Afoo%2Dbar.example/actor"),
+    "did:web:foo-bar.example",
+  );
+  deepStrictEqual(
+    getFe34Origin("did:web:foo%2dbar.example#key"),
+    "did:web:foo-bar.example",
+  );
 });
 
 test("getFe34Origin() rejects unsupported or malformed identifiers", () => {
@@ -258,6 +266,14 @@ test("haveSameFe34Origin() compares web and cryptographic origins", () => {
   ok(haveSameFe34Origin(
     "ap://did:KEY:z6Mkabc/actor",
     "did:key:z6Mkabc#z6Mkabc",
+  ));
+  ok(haveSameFe34Origin(
+    "ap://did%3Aweb%3Afoo%2Dbar.example/actor",
+    "ap://did:web:foo-bar.example/note",
+  ));
+  ok(haveSameFe34Origin(
+    "ap://did%3Aexample%3Aabc%252fdef/actor",
+    "did:example:abc%2Fdef#key",
   ));
   ok(
     !haveSameFe34Origin(

--- a/packages/vocab-runtime/src/url.test.ts
+++ b/packages/vocab-runtime/src/url.test.ts
@@ -5,6 +5,8 @@ import {
   canonicalizePortableUri,
   expandIPv6Address,
   formatIri,
+  getFe34Origin,
+  haveSameFe34Origin,
   haveSameIriOrigin,
   isValidPublicIPv4Address,
   isValidPublicIPv6Address,
@@ -140,6 +142,14 @@ test("parseIri() rejects malformed portable DID authorities", () => {
 
 test("haveSameIriOrigin() compares portable IRI authorities", () => {
   ok(haveSameIriOrigin(
+    new URL("ftp://example.com/pub/1"),
+    new URL("ftp://example.com/pub/2"),
+  ));
+  ok(haveSameIriOrigin(
+    new URL("mailto:alice@example.com"),
+    new URL("mailto:alice@example.com"),
+  ));
+  ok(haveSameIriOrigin(
     parseIri("ap://did:key:z6Mkabc/actor"),
     parseIri("ap://did:key:z6Mkabc/outbox"),
   ));
@@ -161,6 +171,98 @@ test("haveSameIriOrigin() compares portable IRI authorities", () => {
       parseIri("ap://did:key:z6Mkdef/actor"),
     ),
   );
+});
+
+test("getFe34Origin() computes web and cryptographic origins", () => {
+  deepStrictEqual(
+    getFe34Origin("https://Example.COM:443/users/alice"),
+    "https://example.com",
+  );
+  deepStrictEqual(
+    getFe34Origin(new URL("http://example.com:8080/notes/1")),
+    "http://example.com:8080",
+  );
+  deepStrictEqual(
+    getFe34Origin(
+      "ap://did:key:z6Mkabc/actor?gateways=https%3A%2F%2Fa.example",
+    ),
+    "did:key:z6Mkabc",
+  );
+  deepStrictEqual(
+    getFe34Origin("ap+ef61://did%3Akey%3Az6Mkabc/objects/1#fragment"),
+    "did:key:z6Mkabc",
+  );
+  deepStrictEqual(
+    getFe34Origin(new URL("ap+ef61://did%3Akey%3Az6Mkabc/actor")),
+    "did:key:z6Mkabc",
+  );
+  deepStrictEqual(
+    getFe34Origin("did:key:z6Mkabc#z6Mkabc"),
+    "did:key:z6Mkabc",
+  );
+  deepStrictEqual(
+    getFe34Origin(new URL("did:key:z6Mkabc?service=activitypub#key")),
+    "did:key:z6Mkabc",
+  );
+  deepStrictEqual(
+    getFe34Origin("did:key:z6Mkabc/path/to/resource?service=activitypub#key"),
+    "did:key:z6Mkabc",
+  );
+});
+
+test("getFe34Origin() rejects unsupported or malformed identifiers", () => {
+  for (
+    const iri of [
+      "mailto:alice@example.com",
+      "ap://not-a-did/actor",
+      "ap://did:key/actor",
+      "did:key",
+      "did:key:",
+      "did:",
+    ]
+  ) {
+    throws(() => getFe34Origin(iri), TypeError);
+  }
+});
+
+test("haveSameFe34Origin() compares web and cryptographic origins", () => {
+  ok(haveSameFe34Origin(
+    "https://example.com/users/alice",
+    "https://example.com/notes/1",
+  ));
+  ok(
+    !haveSameFe34Origin(
+      "https://example.com/users/alice",
+      "http://example.com/users/alice",
+    ),
+  );
+  ok(
+    !haveSameFe34Origin(
+      "https://example.com/users/alice",
+      "https://example.com:8443/users/alice",
+    ),
+  );
+  ok(haveSameFe34Origin(
+    "ap://did:key:z6Mkabc/actor",
+    "ap+ef61://did%3Akey%3Az6Mkabc/objects/1",
+  ));
+  ok(haveSameFe34Origin(
+    "ap+ef61://did:key:z6Mkabc/actor",
+    "did:key:z6Mkabc#z6Mkabc",
+  ));
+  ok(
+    !haveSameFe34Origin(
+      "ap+ef61://did:key:z6Mkabc/actor",
+      "did:key:z6Mkdef#z6Mkdef",
+    ),
+  );
+  ok(
+    !haveSameFe34Origin(
+      "ap+ef61://did:key:z6Mkabc/actor",
+      "https://example.com/actor",
+    ),
+  );
+  ok(!haveSameFe34Origin("ap://not-a-did/actor", "ap://not-a-did/actor"));
 });
 
 test("parseIri() normalizes portable URL instances", () => {

--- a/packages/vocab-runtime/src/url.test.ts
+++ b/packages/vocab-runtime/src/url.test.ts
@@ -32,15 +32,16 @@ test("parseIri() accepts portable ActivityPub URI schemes", () => {
   }
 });
 
-test("parseIri() accepts DID schemes case-insensitively", () => {
+test("parseIri() normalizes DID scheme and method casing", () => {
   const cases = [
     "ap://DID:key:z6Mkabc/actor",
     "ap://DID%3Akey%3Az6Mkabc/actor",
+    "ap://did:KEY:z6Mkabc/actor",
   ];
   for (const iri of cases) {
     deepStrictEqual(
       parseIri(iri),
-      new URL("ap+ef61://DID%3Akey%3Az6Mkabc/actor"),
+      new URL("ap+ef61://did%3Akey%3Az6Mkabc/actor"),
     );
   }
 });
@@ -208,6 +209,10 @@ test("getFe34Origin() computes web and cryptographic origins", () => {
     getFe34Origin("did:key:z6Mkabc/path/to/resource?service=activitypub#key"),
     "did:key:z6Mkabc",
   );
+  deepStrictEqual(
+    getFe34Origin("did:KEY:z6Mkabc#z6Mkabc"),
+    "did:key:z6Mkabc",
+  );
 });
 
 test("getFe34Origin() rejects unsupported or malformed identifiers", () => {
@@ -248,6 +253,10 @@ test("haveSameFe34Origin() compares web and cryptographic origins", () => {
   ));
   ok(haveSameFe34Origin(
     "ap+ef61://did:key:z6Mkabc/actor",
+    "did:key:z6Mkabc#z6Mkabc",
+  ));
+  ok(haveSameFe34Origin(
+    "ap://did:KEY:z6Mkabc/actor",
     "did:key:z6Mkabc#z6Mkabc",
   ));
   ok(

--- a/packages/vocab-runtime/src/url.ts
+++ b/packages/vocab-runtime/src/url.ts
@@ -93,7 +93,7 @@ export function canonicalizePortableUri(input: string): string {
   // decodePortableAuthority() reverses the shared percent-encoded authority
   // path here rather than the raw did:-prefixed branch.
   const authority = normalizePortableAuthority(
-    decodePortableAuthority(parsed.host).replace(DID_SCHEME_PATTERN, "did:"),
+    getDidUrlOrigin(decodePortableAuthority(parsed.host)),
   );
   // Keep path and fragment text from the raw match to avoid URL dot-segment
   // normalization, but still encode raw characters and normalize
@@ -194,7 +194,7 @@ function getComparableIriOrigin(iri: URL): string {
   if (iri.host !== "") {
     const host = iri.protocol === "ap+ef61:"
       ? encodeURIComponent(
-        decodePortableAuthority(iri.host).replace(DID_SCHEME_PATTERN, "did:"),
+        getDidUrlOrigin(decodePortableAuthority(iri.host)),
       )
       : iri.host;
     return `${iri.protocol}//${host}`;
@@ -203,13 +203,15 @@ function getComparableIriOrigin(iri: URL): string {
 }
 
 function getPortableCryptographicOrigin(iri: URL): string {
-  return decodePortableAuthority(iri.host).replace(DID_SCHEME_PATTERN, "did:");
+  return getDidUrlOrigin(decodePortableAuthority(iri.host));
 }
 
 function getDidUrlOrigin(iri: string): string {
   const did = iri.split(/[/?#]/, 1)[0].replace(DID_SCHEME_PATTERN, "did:");
   if (!DID_PATTERN.test(did)) throw new TypeError("Invalid DID URL.");
-  return did;
+  const parts = did.split(":");
+  parts[1] = parts[1].toLowerCase();
+  return parts.join(":");
 }
 
 function parsePortableIri(iri: string): URL | null {
@@ -220,7 +222,7 @@ function parsePortableIri(iri: string): URL | null {
   // current FEP-ef61 interoperability, but normalize it to a percent-encoded
   // URL authority internally.  The ap: URI syntax may change later; see:
   // https://bnewbold.leaflet.pub/3mph4hzvbdc2v
-  const authority = decodePortableAuthority(match[2]);
+  const authority = getDidUrlOrigin(decodePortableAuthority(match[2]));
   if (!DID_PATTERN.test(authority)) {
     throw new TypeError("Invalid portable ActivityPub IRI authority.");
   }

--- a/packages/vocab-runtime/src/url.ts
+++ b/packages/vocab-runtime/src/url.ts
@@ -132,6 +132,56 @@ export function arePortableUrisEqual(
 }
 
 /**
+ * Computes an IRI's FEP-fe34 origin.
+ *
+ * HTTP(S) IRIs use their web origin.  FEP-ef61 portable ActivityPub IRIs and
+ * DID URLs use their DID as a cryptographic origin.
+ *
+ * @throws {TypeError} If the IRI does not have a supported FEP-fe34 origin.
+ * @since 2.4.0
+ */
+export function getFe34Origin(input: string | URL): string {
+  if (input instanceof URL) {
+    const portable = normalizePortableUrl(input);
+    if (portable != null) return getPortableCryptographicOrigin(portable);
+    if (input.protocol === "did:") return getDidUrlOrigin(input.href);
+    if (input.protocol === "http:" || input.protocol === "https:") {
+      return input.origin;
+    }
+    throw new TypeError("Unsupported FEP-fe34 origin IRI.");
+  }
+
+  const portable = parsePortableIri(input);
+  if (portable != null) return getPortableCryptographicOrigin(portable);
+  if (DID_SCHEME_PATTERN.test(input)) return getDidUrlOrigin(input);
+
+  const parsed = new URL(input);
+  if (parsed.protocol === "http:" || parsed.protocol === "https:") {
+    return parsed.origin;
+  }
+  throw new TypeError("Unsupported FEP-fe34 origin IRI.");
+}
+
+/**
+ * Checks whether two IRIs have the same FEP-fe34 origin.
+ *
+ * Malformed or unsupported IRIs are treated as non-matching.
+ *
+ * @since 2.4.0
+ */
+export function haveSameFe34Origin(
+  left: string | URL,
+  right: string | URL,
+): boolean {
+  try {
+    return getFe34Origin(left) === getFe34Origin(right);
+  } catch (error) {
+    if (error instanceof TypeError) return false;
+    throw error;
+  }
+}
+
+/**
  * Checks whether two IRIs have the same origin.
  */
 export function haveSameIriOrigin(left: URL, right: URL): boolean {
@@ -150,6 +200,16 @@ function getComparableIriOrigin(iri: URL): string {
     return `${iri.protocol}//${host}`;
   }
   return iri.href;
+}
+
+function getPortableCryptographicOrigin(iri: URL): string {
+  return decodePortableAuthority(iri.host).replace(DID_SCHEME_PATTERN, "did:");
+}
+
+function getDidUrlOrigin(iri: string): string {
+  const did = iri.split(/[/?#]/, 1)[0].replace(DID_SCHEME_PATTERN, "did:");
+  if (!DID_PATTERN.test(did)) throw new TypeError("Invalid DID URL.");
+  return did;
 }
 
 function parsePortableIri(iri: string): URL | null {

--- a/packages/vocab-runtime/src/url.ts
+++ b/packages/vocab-runtime/src/url.ts
@@ -211,7 +211,7 @@ function getDidUrlOrigin(iri: string): string {
   if (!DID_PATTERN.test(did)) throw new TypeError("Invalid DID URL.");
   const parts = did.split(":");
   parts[1] = parts[1].toLowerCase();
-  return parts.join(":");
+  return normalizePortableAuthority(parts.join(":"));
 }
 
 function parsePortableIri(iri: string): URL | null {

--- a/packages/vocab/src/lookup.test.ts
+++ b/packages/vocab/src/lookup.test.ts
@@ -416,6 +416,127 @@ test("FEP-fe34: lookupObject() cross-origin security", {
     );
   });
 
+  await t.step(
+    "same-authority non-FE34 IRIs are still trusted",
+    async () => {
+      // deno-lint-ignore require-await
+      const atProtoDocumentLoader = async (url: string) => {
+        if (url === "https://gateway.example/at-item") {
+          return {
+            documentUrl: "at://did%3Aplc%3Aexample/collection/item",
+            contextUrl: null,
+            document: {
+              "@context": "https://www.w3.org/ns/activitystreams",
+              type: "Note",
+              id: "at://did:plc:example/collection/reply",
+              content: "AT Protocol note",
+            },
+          };
+        }
+        throw new Error(`Unexpected URL: ${url}`);
+      };
+
+      const result = await lookupObject(
+        "https://gateway.example/at-item",
+        {
+          documentLoader: atProtoDocumentLoader,
+          contextLoader: mockDocumentLoader,
+        },
+      );
+
+      assertInstanceOf(result, Note);
+      deepStrictEqual(
+        result.id,
+        new URL("at://did%3Aplc%3Aexample/collection/reply"),
+      );
+      deepStrictEqual(result.content, "AT Protocol note");
+    },
+  );
+
+  await t.step(
+    "portable object IDs are trusted by DID cryptographic origin",
+    async () => {
+      // deno-lint-ignore require-await
+      const portableDocumentLoader = async (url: string) => {
+        if (
+          url ===
+            "https://gateway.example/.well-known/apgateway/did:key:z6Mkabc/note"
+        ) {
+          return {
+            documentUrl: "ap+ef61://did:key:z6Mkabc/note",
+            contextUrl: null,
+            document: {
+              "@context": "https://www.w3.org/ns/activitystreams",
+              type: "Note",
+              id: "ap://did:key:z6Mkabc/note",
+              content: "Portable note",
+            },
+          };
+        }
+        throw new Error(`Unexpected URL: ${url}`);
+      };
+
+      const result = await lookupObject(
+        "https://gateway.example/.well-known/apgateway/did:key:z6Mkabc/note",
+        {
+          documentLoader: portableDocumentLoader,
+          contextLoader: mockDocumentLoader,
+        },
+      );
+
+      assertInstanceOf(result, Note);
+      deepStrictEqual(result.content, "Portable note");
+    },
+  );
+
+  await t.step(
+    "portable object IDs reject mismatched cryptographic origins",
+    async () => {
+      // deno-lint-ignore require-await
+      const portableDocumentLoader = async (url: string) => {
+        if (
+          url ===
+            "https://gateway.example/.well-known/apgateway/did:key:z6Mkabc/note"
+        ) {
+          return {
+            documentUrl: "ap+ef61://did:key:z6Mkabc/note",
+            contextUrl: null,
+            document: {
+              "@context": "https://www.w3.org/ns/activitystreams",
+              type: "Note",
+              id: "ap://did:key:z6Mkdef/note",
+              content: "Spoofed portable note",
+            },
+          };
+        }
+        throw new Error(`Unexpected URL: ${url}`);
+      };
+
+      const result = await lookupObject(
+        "https://gateway.example/.well-known/apgateway/did:key:z6Mkabc/note",
+        {
+          documentLoader: portableDocumentLoader,
+          contextLoader: mockDocumentLoader,
+        },
+      );
+
+      deepStrictEqual(result, null);
+      await rejects(
+        () =>
+          lookupObject(
+            "https://gateway.example/.well-known/apgateway/did:key:z6Mkabc/note",
+            {
+              documentLoader: portableDocumentLoader,
+              contextLoader: mockDocumentLoader,
+              crossOrigin: "throw",
+            },
+          ),
+        Error,
+        "The object's @id (ap+ef61://did%3Akey%3Az6Mkdef/note) has a different origin than the document URL (ap+ef61://did:key:z6Mkabc/note)",
+      );
+    },
+  );
+
   await t.step("objects without @id are trusted", async () => {
     // deno-lint-ignore require-await
     const noIdDocumentLoader = async (url: string) => {

--- a/packages/vocab/src/lookup.ts
+++ b/packages/vocab/src/lookup.ts
@@ -2,6 +2,7 @@ import type { GetUserAgentOptions } from "@fedify/vocab-runtime";
 import {
   type DocumentLoader,
   getDocumentLoader,
+  haveSameFe34Origin,
   haveSameIriOrigin,
   parseIri,
   type RemoteDocument,
@@ -335,7 +336,8 @@ async function lookupObjectInternal(
   }
   if (
     options.crossOrigin !== "trust" && object.id != null &&
-    !haveSameIriOrigin(object.id, documentUrl)
+    !haveSameIriOrigin(object.id, documentUrl) &&
+    !haveSameFe34Origin(object.id, documentUrl)
   ) {
     if (options.crossOrigin === "throw") {
       throw new Error(

--- a/packages/vocab/src/vocab.test.ts
+++ b/packages/vocab/src/vocab.test.ts
@@ -47,6 +47,7 @@ import {
   InteractionRule,
   Link,
   Measure,
+  Multikey,
   Note,
   Object,
   Offer,
@@ -3800,6 +3801,30 @@ test("FEP-fe34: Same origin objects are trusted", async () => {
   deepStrictEqual(result?.content, "This is a legitimate note");
 });
 
+test("FEP-fe34: Same-authority non-FE34 embedded objects are trusted", async () => {
+  const create = await Create.fromJsonLd({
+    "@context": "https://www.w3.org/ns/activitystreams",
+    "@type": "Create",
+    "@id": "at://did:plc:example/collection/item",
+    "actor": "at://did:plc:example/actor/self",
+    "object": {
+      "@type": "Note",
+      "@id": "at://did:plc:example/collection/reply",
+      "content": "Embedded AT Protocol note",
+    },
+  });
+
+  const result = await create.getObject({
+    // deno-lint-ignore require-await
+    documentLoader: async (url) => {
+      throw new Error(`Unexpected fetch: ${url}`);
+    },
+  });
+
+  assertInstanceOf(result, Note);
+  deepStrictEqual(result.content, "Embedded AT Protocol note");
+});
+
 test(
   "FEP-fe34: Embedded cross-origin objects from JSON-LD are ignored by default",
   async () => {
@@ -3948,6 +3973,74 @@ test(
     const result = await create.getObject({ documentLoader });
     assertInstanceOf(result, Note);
     deepStrictEqual(result.content, "Fetched portable note");
+  },
+);
+
+test(
+  "FEP-fe34: DID verification methods share portable actor cryptographic origin",
+  async () => {
+    const person = await Person.fromJsonLd({
+      "@id": "ap://did:key:z6MkOwner/actor",
+      "@type": ["https://www.w3.org/ns/activitystreams#Person"],
+      "https://w3id.org/security#assertionMethod": [{
+        "@id": "did:key:z6MkOwner#z6MkOwner",
+        "@type": ["https://w3id.org/security#Multikey"],
+        "https://w3id.org/security#controller": [{
+          "@id": "did:key:z6MkOwner",
+        }],
+      }],
+    });
+
+    // deno-lint-ignore require-await
+    const documentLoader = async (url: string) => {
+      throw new Error(`Unexpected fetch: ${url}`);
+    };
+
+    const methods = [];
+    for await (const method of person.getAssertionMethods({ documentLoader })) {
+      methods.push(method);
+    }
+
+    deepStrictEqual(methods.length, 1);
+    assertInstanceOf(methods[0], Multikey);
+    deepStrictEqual(
+      methods[0].id,
+      new URL("did:key:z6MkOwner#z6MkOwner"),
+    );
+  },
+);
+
+test(
+  "FEP-fe34: DID verification methods from another cryptographic origin are untrusted",
+  async () => {
+    const person = await Person.fromJsonLd({
+      "@id": "ap://did:key:z6MkOwner/actor",
+      "@type": ["https://www.w3.org/ns/activitystreams#Person"],
+      "https://w3id.org/security#assertionMethod": [{
+        "@id": "did:key:z6MkOther#z6MkOther",
+        "@type": ["https://w3id.org/security#Multikey"],
+        "https://w3id.org/security#controller": [{
+          "@id": "did:key:z6MkOther",
+        }],
+      }],
+    });
+
+    let fetches = 0;
+    const methods = [];
+    for await (
+      const method of person.getAssertionMethods({
+        suppressError: true,
+        // deno-lint-ignore require-await
+        documentLoader: async (url) => {
+          fetches++;
+          throw new Error(`Unexpected fetch: ${url}`);
+        },
+      })
+    ) {
+      methods.push(method);
+    }
+    deepStrictEqual(methods, []);
+    deepStrictEqual(fetches, 1);
   },
 );
 


### PR DESCRIPTION
Closes #829.


Why
---

Fedify already had two pieces of the portable-object story: [FEP-ef61] URI parsing and local `did:key` verification method resolution for FEP-8b32 proofs.  What was still missing was the policy layer between them.  A portable object whose ID is `ap://did:key:.../objects/1` should be able to carry an embedded `did:key:...#...` verification method or a matching portable actor without being treated as cross-origin just because the schemes differ.

This PR adds that bridge by comparing the FEP-fe34 origin of web URLs, portable `ap:`/`ap+ef61:` IDs, and DID URLs.  HTTP(S) IDs keep the existing web-origin behavior.  Portable IDs and DID URLs use their DID component as the cryptographic origin.

The proof path is intentionally narrower than the vocabulary lookup path.  A proof can authenticate portable attributions by cryptographic origin only when the verification method ID is itself in the same cryptographic origin as the claimed controller.  That keeps locally resolved `did:key` verification methods working while preventing an attacker-hosted HTTPS key document from claiming a victim DID controller and signing for that DID's portable objects.

[FEP-ef61]: https://w3id.org/fep/ef61


How
---

 -  *packages/vocab-runtime/src/url.ts* now exposes `getFe34Origin()` and `haveSameFe34Origin()`.  They compare ordinary HTTP(S) origins and DID-based cryptographic origins through one helper.
 -  *packages/vocab-runtime/src/internal/jsonld-cache.ts* and *packages/vocab/src/lookup.ts* use the new FE34 comparison as an addition to the existing IRI-origin comparison, not a replacement.  This preserves existing same-authority behavior for non-FE34 schemes such as `at://`.
 -  *packages/fedify/src/sig/proof.ts* uses FE34 origin matching when deciding whether a verified proof authenticates portable actors and attributions, but only after checking that the verification method ID is also in the matching cryptographic origin.
 -  The manual pages under *docs/manual/* now describe how Fedify treats cryptographic origins in lookup, vocabulary property accessors, and object proof verification.


Testing
-------

The test coverage includes matching and mismatched portable DID origins, multiple same-origin portable attributions, same-authority non-FE34 IRIs, and the HTTPS-key spoofing case described above.

Verified with:

~~~~ console
mise run test:deno -- packages/vocab-runtime/src/url.test.ts
mise run test:deno -- packages/vocab/src/lookup.test.ts --filter "FEP-fe34"
mise run test:deno -- packages/vocab/src/vocab.test.ts --filter "FEP-fe34"
mise run test:deno -- packages/fedify/src/sig/proof.test.ts --filter "verifyObject"
mise run check-each vocab-runtime vocab fedify
mise run test-each vocab-runtime vocab fedify
mise run check:md
~~~~
