### PR TITLE
Add SHA-256 digest and hashlink helpers for portable media

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -151,6 +151,10 @@ To be released.
 
 ### @fedify/vocab-runtime
 
+ -  Added SHA-256 `digestMultibase` and simple `hl:` hashlink helpers for
+    computing, parsing, creating, and verifying portable media resource
+    digests as required by [FEP-ef61].  [[#831], [#935]]
+
  -  Added the [FEP-ef61] JSON-LD context to the preloaded context registry so
     portable actor and media documents can compact and expand `gateways` and
     `digestMultibase` without fetching the context remotely.  [[#830], [#928]]
@@ -184,9 +188,11 @@ To be released.
     content type, rather than generic JSON parser crashes.  [[#912], [#913]]
 
 [#828]: https://github.com/fedify-dev/fedify/issues/828
+[#831]: https://github.com/fedify-dev/fedify/issues/831
 [#912]: https://github.com/fedify-dev/fedify/issues/912
 [#913]: https://github.com/fedify-dev/fedify/pull/913
 [#924]: https://github.com/fedify-dev/fedify/pull/924
+[#935]: https://github.com/fedify-dev/fedify/pull/935
 
 ### @fedify/cli
 

--- a/docs/manual/vocab.md
+++ b/docs/manual/vocab.md
@@ -246,21 +246,40 @@ const actor = new Person({
 Each gateway must be an HTTP(S) base URI with no path, query, or fragment.
 
 Links and media/document objects expose `digestMultibase` for the integrity
-digest required when portable objects reference external resources:
+digest required when portable objects reference external resources.  Use
+`computeDigestMultibase()` to compute the SHA-256 multihash and
+`createHashlink()` to construct a metadata-free `hl:` URI:
 
 ~~~~ typescript twoslash
 import { Image } from "@fedify/vocab";
+import {
+  computeDigestMultibase,
+  createHashlink,
+  verifyDigestMultibase,
+  verifyHashlink,
+} from "@fedify/vocab-runtime";
+
+const bytes = new TextEncoder().encode("image data");
+const digestMultibase = await computeDigestMultibase(bytes);
+const hashlink = createHashlink(digestMultibase);
 
 const image = new Image({
-  url: new URL("hl:zQmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n"),
+  url: new URL(hashlink),
   mediaType: "image/png",
-  digestMultibase: "zQmdfTbBqBPQ7VNxZEYEj14VmRuZBkqFbiwReogJgS1zR1n",
+  digestMultibase,
 });
+
+await verifyDigestMultibase(bytes, digestMultibase);  // true
+await verifyHashlink(bytes, hashlink);  // true
 ~~~~
 
 The vocabulary layer stores and serializes the `digestMultibase` value exactly
-as provided.  Computing SHA-256 digests, parsing hashlinks, and verifying media
-bytes are handled by separate helper APIs.
+as provided.  The verification helpers return `false` when the bytes do not
+match.  `parseDigestMultibase()` and `parseHashlink()` validate values when the
+decoded digest or hashlink components are needed.  These helpers accept only
+SHA-256 digests and simple `hl:` URIs without metadata; malformed values,
+unsupported hash algorithms, metadata-bearing hashlinks, and legacy `?hl=`
+URLs cause a `TypeError`.
 
 [FEP-ef61]: https://w3id.org/fep/ef61
 

--- a/packages/vocab-runtime/src/digest.test.ts
+++ b/packages/vocab-runtime/src/digest.test.ts
@@ -123,6 +123,14 @@ test("parseDigestMultibase() rejects malformed values", async () => {
     0x12,
     addMulticodecPrefix(32, new Uint8Array(32)),
   );
+  const base2 = decoder.decode(encodeMultibase("base2", multihash));
+  equal(base2.length, 273);
+  deepStrictEqual(parseDigestMultibase(base2).digest, new Uint8Array(32));
+  throws(
+    () => parseDigestMultibase(`${base2}0`),
+    new TypeError("Invalid digestMultibase encoding."),
+  );
+
   const padded = decoder.decode(encodeMultibase("base64pad", multihash));
   equal(padded.endsWith("=="), true);
   deepStrictEqual(parseDigestMultibase(padded).digest, new Uint8Array(32));

--- a/packages/vocab-runtime/src/digest.test.ts
+++ b/packages/vocab-runtime/src/digest.test.ts
@@ -174,6 +174,17 @@ test("parseDigestMultibase() rejects malformed values", async () => {
 });
 
 test("simple hashlink helpers reject metadata and malformed forms", async () => {
+  for (const terminator of ["\n", "\r", "\r\n", "\u2028", "\u2029"]) {
+    const malformedHashlink = `${hashlink}${terminator}`;
+    throws(
+      () => parseHashlink(malformedHashlink),
+      new TypeError("Invalid simple hashlink."),
+    );
+    await rejects(
+      () => verifyHashlink(bytes, malformedHashlink),
+      new TypeError("Invalid simple hashlink."),
+    );
+  }
   throws(
     () => parseHashlink(`${hashlink}:zmetadata`),
     new TypeError("Invalid simple hashlink."),

--- a/packages/vocab-runtime/src/digest.test.ts
+++ b/packages/vocab-runtime/src/digest.test.ts
@@ -1,0 +1,167 @@
+import { deepStrictEqual, equal, rejects, throws } from "node:assert/strict";
+import { test } from "node:test";
+import { addMulticodecPrefix } from "./internal/multicodec.ts";
+import { encodeMultibase } from "./multibase/mod.ts";
+import {
+  computeDigestMultibase,
+  createHashlink,
+  parseDigestMultibase,
+  parseHashlink,
+  verifyDigestMultibase,
+  verifyHashlink,
+} from "./digest.ts";
+
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+const bytes = encoder.encode("Hello World!");
+// Test vector from draft-sporny-hashlink-07, appendix B.1.
+const digestMultibase = "zQmWvQxTqbG2Z9HPJgG57jjwR154cKhbtJenbyYTWkjgF3e";
+const hashlink = `hl:${digestMultibase}`;
+
+test("computeDigestMultibase() computes a SHA-256 multihash", async () => {
+  equal(await computeDigestMultibase(bytes), digestMultibase);
+  const parsed = parseDigestMultibase(digestMultibase);
+  equal(parsed.algorithm, "sha2-256");
+  deepStrictEqual(
+    parsed.digest,
+    new Uint8Array(await crypto.subtle.digest("SHA-256", bytes)),
+  );
+});
+
+test("createHashlink() and parseHashlink() round-trip simple hashlinks", () => {
+  equal(createHashlink(digestMultibase), hashlink);
+  deepStrictEqual(parseHashlink(hashlink), { digestMultibase });
+  deepStrictEqual(parseHashlink(new URL(hashlink)), { digestMultibase });
+
+  const base64DigestMultibase = decoder.decode(
+    encodeMultibase(
+      "base64",
+      addMulticodecPrefix(
+        0x12,
+        addMulticodecPrefix(32, new Uint8Array(32).fill(0xff)),
+      ),
+    ),
+  );
+  const base64Hashlink = createHashlink(base64DigestMultibase);
+  equal(
+    base64Hashlink,
+    "hl:mEiD//////////////////////////////////////////w",
+  );
+  deepStrictEqual(parseHashlink(base64Hashlink), {
+    digestMultibase: base64DigestMultibase,
+  });
+  deepStrictEqual(parseHashlink(new URL(base64Hashlink)), {
+    digestMultibase: base64DigestMultibase,
+  });
+});
+
+test("digest and hashlink verification accepts matching bytes", async () => {
+  equal(await verifyDigestMultibase(bytes, digestMultibase), true);
+  equal(await verifyHashlink(bytes, hashlink), true);
+  equal(await verifyHashlink(bytes, new URL(hashlink)), true);
+});
+
+test("digest and hashlink verification rejects non-matching bytes", async () => {
+  const different = encoder.encode("Hello World?");
+  equal(await verifyDigestMultibase(different, digestMultibase), false);
+  equal(await verifyHashlink(different, hashlink), false);
+});
+
+test("parseDigestMultibase() rejects unsupported algorithms", () => {
+  const sha1Multihash = addMulticodecPrefix(
+    0x11,
+    addMulticodecPrefix(20, new Uint8Array(20)),
+  );
+  const value = decoder.decode(encodeMultibase("base58btc", sha1Multihash));
+  throws(
+    () => parseDigestMultibase(value),
+    new TypeError("Unsupported digest algorithm: 0x11"),
+  );
+});
+
+test("parseDigestMultibase() rejects malformed values", async () => {
+  throws(
+    () => parseDigestMultibase("not-multibase"),
+    new TypeError("Invalid digestMultibase encoding."),
+  );
+
+  const missingLength = decoder.decode(
+    encodeMultibase("base58btc", Uint8Array.of(0x12)),
+  );
+  throws(
+    () => parseDigestMultibase(missingLength),
+    new TypeError("Invalid digestMultibase multihash."),
+  );
+
+  const multihash = addMulticodecPrefix(
+    0x12,
+    addMulticodecPrefix(32, new Uint8Array(32)),
+  );
+  const padded = decoder.decode(encodeMultibase("base64pad", multihash));
+  equal(padded.endsWith("=="), true);
+  deepStrictEqual(parseDigestMultibase(padded).digest, new Uint8Array(32));
+  throws(
+    () => parseDigestMultibase(padded.slice(0, -1)),
+    new TypeError("Invalid digestMultibase encoding."),
+  );
+  throws(
+    () => createHashlink(`${padded}=`),
+    new TypeError("Invalid digestMultibase encoding."),
+  );
+
+  const overlongAlgorithm = decoder.decode(
+    encodeMultibase(
+      "base58btc",
+      Uint8Array.of(0x92, 0x00, 0x20, ...new Uint8Array(32)),
+    ),
+  );
+  throws(
+    () => parseDigestMultibase(overlongAlgorithm),
+    new TypeError("Invalid digestMultibase multihash."),
+  );
+
+  const overlongLength = decoder.decode(
+    encodeMultibase(
+      "base58btc",
+      Uint8Array.of(0x12, 0xa0, 0x00, ...new Uint8Array(32)),
+    ),
+  );
+  throws(
+    () => parseDigestMultibase(overlongLength),
+    new TypeError("Invalid digestMultibase multihash."),
+  );
+
+  const shortDigest = decoder.decode(
+    encodeMultibase(
+      "base58btc",
+      addMulticodecPrefix(0x12, addMulticodecPrefix(31, new Uint8Array(31))),
+    ),
+  );
+  throws(
+    () => parseDigestMultibase(shortDigest),
+    new TypeError("Invalid SHA-256 digest length."),
+  );
+  await rejects(
+    () => verifyDigestMultibase(bytes, shortDigest),
+    new TypeError("Invalid SHA-256 digest length."),
+  );
+});
+
+test("simple hashlink helpers reject metadata and malformed forms", () => {
+  throws(
+    () => parseHashlink(`${hashlink}:zmetadata`),
+    new TypeError("Invalid simple hashlink."),
+  );
+  throws(
+    () => parseHashlink(`https://example.com/file?hl=${digestMultibase}`),
+    new TypeError("Invalid simple hashlink."),
+  );
+  throws(
+    () => parseHashlink("hl:not-multibase"),
+    new TypeError("Invalid digestMultibase encoding."),
+  );
+  throws(
+    () => createHashlink("not-multibase"),
+    new TypeError("Invalid digestMultibase encoding."),
+  );
+});

--- a/packages/vocab-runtime/src/digest.test.ts
+++ b/packages/vocab-runtime/src/digest.test.ts
@@ -173,9 +173,13 @@ test("parseDigestMultibase() rejects malformed values", async () => {
   );
 });
 
-test("simple hashlink helpers reject metadata and malformed forms", () => {
+test("simple hashlink helpers reject metadata and malformed forms", async () => {
   throws(
     () => parseHashlink(`${hashlink}:zmetadata`),
+    new TypeError("Invalid simple hashlink."),
+  );
+  await rejects(
+    () => verifyHashlink(bytes, `${hashlink}:zmetadata`),
     new TypeError("Invalid simple hashlink."),
   );
   throws(
@@ -184,6 +188,10 @@ test("simple hashlink helpers reject metadata and malformed forms", () => {
   );
   throws(
     () => parseHashlink("hl:not-multibase"),
+    new TypeError("Invalid digestMultibase encoding."),
+  );
+  await rejects(
+    () => verifyHashlink(bytes, "hl:not-multibase"),
     new TypeError("Invalid digestMultibase encoding."),
   );
   throws(

--- a/packages/vocab-runtime/src/digest.test.ts
+++ b/packages/vocab-runtime/src/digest.test.ts
@@ -31,8 +31,27 @@ test("computeDigestMultibase() computes a SHA-256 multihash", async () => {
 test("digest helpers accept SharedArrayBuffer-backed bytes", async () => {
   const sharedBytes = new Uint8Array(new SharedArrayBuffer(bytes.length));
   sharedBytes.set(bytes);
+  Object.defineProperty(sharedBytes, "slice", {
+    value: () => {
+      throw new Error("Shared input must not be copied with slice().");
+    },
+  });
   equal(await computeDigestMultibase(sharedBytes), digestMultibase);
   equal(await verifyDigestMultibase(sharedBytes, digestMultibase), true);
+});
+
+test("digest helpers ignore spoofed shared buffer tags", async () => {
+  const taggedBytes = bytes.slice();
+  Object.defineProperty(taggedBytes.buffer, Symbol.toStringTag, {
+    value: "SharedArrayBuffer",
+  });
+  Object.defineProperty(taggedBytes, "slice", {
+    value: () => {
+      throw new Error("ArrayBuffer input must not be copied.");
+    },
+  });
+  equal(await computeDigestMultibase(taggedBytes), digestMultibase);
+  equal(await verifyDigestMultibase(taggedBytes, digestMultibase), true);
 });
 
 test("createHashlink() and parseHashlink() round-trip simple hashlinks", () => {

--- a/packages/vocab-runtime/src/digest.test.ts
+++ b/packages/vocab-runtime/src/digest.test.ts
@@ -28,6 +28,13 @@ test("computeDigestMultibase() computes a SHA-256 multihash", async () => {
   );
 });
 
+test("digest helpers accept SharedArrayBuffer-backed bytes", async () => {
+  const sharedBytes = new Uint8Array(new SharedArrayBuffer(bytes.length));
+  sharedBytes.set(bytes);
+  equal(await computeDigestMultibase(sharedBytes), digestMultibase);
+  equal(await verifyDigestMultibase(sharedBytes, digestMultibase), true);
+});
+
 test("createHashlink() and parseHashlink() round-trip simple hashlinks", () => {
   equal(createHashlink(digestMultibase), hashlink);
   deepStrictEqual(parseHashlink(hashlink), { digestMultibase });

--- a/packages/vocab-runtime/src/digest.ts
+++ b/packages/vocab-runtime/src/digest.ts
@@ -142,6 +142,13 @@ export function parseDigestMultibase(value: string): ParsedDigestMultibase {
   return { algorithm: "sha2-256", digest };
 }
 
+function extractDigestMultibase(value: string | URL): string {
+  const hashlink = value instanceof URL ? value.href : value;
+  const match = /^hl:([^:]+)$/i.exec(hashlink);
+  if (match == null) throw new TypeError("Invalid simple hashlink.");
+  return match[1];
+}
+
 /**
  * Parses a metadata-free `hl:` hashlink and validates its resource digest.
  *
@@ -152,10 +159,7 @@ export function parseDigestMultibase(value: string): ParsedDigestMultibase {
  * @since 2.4.0
  */
 export function parseHashlink(value: string | URL): ParsedHashlink {
-  const hashlink = value instanceof URL ? value.href : value;
-  const match = /^hl:([^:]+)$/i.exec(hashlink);
-  if (match == null) throw new TypeError("Invalid simple hashlink.");
-  const digestMultibase = match[1];
+  const digestMultibase = extractDigestMultibase(value);
   parseDigestMultibase(digestMultibase);
   return { digestMultibase };
 }
@@ -190,10 +194,10 @@ export async function verifyDigestMultibase(
   const actual = new Uint8Array(
     await crypto.subtle.digest("SHA-256", toWebCryptoBytes(bytes)),
   );
-  let difference = expected.length ^ actual.length;
-  const length = Math.max(expected.length, actual.length);
-  for (let i = 0; i < length; i++) {
-    difference |= (expected[i] ?? 0) ^ (actual[i] ?? 0);
+  if (expected.length !== actual.length) return false;
+  let difference = 0;
+  for (let i = 0; i < expected.length; i++) {
+    difference |= expected[i] ^ actual[i];
   }
   return difference === 0;
 }
@@ -211,6 +215,6 @@ export async function verifyHashlink(
   bytes: Uint8Array,
   hashlink: string | URL,
 ): Promise<boolean> {
-  const { digestMultibase } = parseHashlink(hashlink);
+  const digestMultibase = extractDigestMultibase(hashlink);
   return await verifyDigestMultibase(bytes, digestMultibase);
 }

--- a/packages/vocab-runtime/src/digest.ts
+++ b/packages/vocab-runtime/src/digest.ts
@@ -24,6 +24,12 @@ function isCanonicalVarintPrefix(
   return true;
 }
 
+function toWebCryptoBytes(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
+  return bytes.buffer instanceof ArrayBuffer
+    ? new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength)
+    : bytes.slice();
+}
+
 /**
  * A parsed SHA-256 resource digest.
  *
@@ -60,7 +66,7 @@ export async function computeDigestMultibase(
   bytes: Uint8Array,
 ): Promise<string> {
   const digest = new Uint8Array(
-    await crypto.subtle.digest("SHA-256", bytes.slice()),
+    await crypto.subtle.digest("SHA-256", toWebCryptoBytes(bytes)),
   );
   const lengthAndDigest = addMulticodecPrefix(digest.length, digest);
   const multihash = addMulticodecPrefix(
@@ -175,7 +181,7 @@ export async function verifyDigestMultibase(
 ): Promise<boolean> {
   const expected = parseDigestMultibase(digestMultibase).digest;
   const actual = new Uint8Array(
-    await crypto.subtle.digest("SHA-256", bytes.slice()),
+    await crypto.subtle.digest("SHA-256", toWebCryptoBytes(bytes)),
   );
   let difference = expected.length ^ actual.length;
   const length = Math.max(expected.length, actual.length);

--- a/packages/vocab-runtime/src/digest.ts
+++ b/packages/vocab-runtime/src/digest.ts
@@ -11,6 +11,10 @@ import {
 const SHA2_256_MULTIHASH_CODE = 0x12;
 const SHA2_256_DIGEST_LENGTH = 32;
 const textDecoder = new TextDecoder();
+const getArrayBufferByteLength = Object.getOwnPropertyDescriptor(
+  ArrayBuffer.prototype,
+  "byteLength",
+)!.get!;
 
 function isCanonicalVarintPrefix(
   data: Uint8Array,
@@ -25,10 +29,12 @@ function isCanonicalVarintPrefix(
 }
 
 function toWebCryptoBytes(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
-  return Object.prototype.toString.call(bytes.buffer) ===
-      "[object SharedArrayBuffer]"
-    ? bytes.slice()
-    : bytes as Uint8Array<ArrayBuffer>;
+  try {
+    getArrayBufferByteLength.call(bytes.buffer);
+    return bytes as Uint8Array<ArrayBuffer>;
+  } catch {
+    return new Uint8Array(bytes);
+  }
 }
 
 /**

--- a/packages/vocab-runtime/src/digest.ts
+++ b/packages/vocab-runtime/src/digest.ts
@@ -1,0 +1,203 @@
+import {
+  addMulticodecPrefix,
+  getMulticodecPrefix,
+} from "./internal/multicodec.ts";
+import {
+  decodeMultibase,
+  encodeMultibase,
+  encodingFromBaseData,
+} from "./multibase/mod.ts";
+
+const SHA2_256_MULTIHASH_CODE = 0x12;
+const SHA2_256_DIGEST_LENGTH = 32;
+const textDecoder = new TextDecoder();
+
+function isCanonicalVarintPrefix(
+  data: Uint8Array,
+  prefix: ReturnType<typeof getMulticodecPrefix>,
+): boolean {
+  const canonical = addMulticodecPrefix(prefix.code, new Uint8Array());
+  if (canonical.length !== prefix.prefixLength) return false;
+  for (let i = 0; i < canonical.length; i++) {
+    if (data[i] !== canonical[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * A parsed SHA-256 resource digest.
+ *
+ * @since 2.4.0
+ */
+export interface ParsedDigestMultibase {
+  /** The multihash algorithm represented by the digest. */
+  readonly algorithm: "sha2-256";
+
+  /** The raw 32-byte SHA-256 digest. */
+  readonly digest: Uint8Array;
+}
+
+/**
+ * A parsed simple hashlink.
+ *
+ * @since 2.4.0
+ */
+export interface ParsedHashlink {
+  /** The multibase-encoded multihash carried by the hashlink. */
+  readonly digestMultibase: string;
+}
+
+/**
+ * Computes the SHA-256 digest of a byte sequence and encodes it as a
+ * base58-btc multibase multihash suitable for FEP-ef61's
+ * `digestMultibase` property.
+ *
+ * @param bytes The bytes to digest.
+ * @returns The base58-btc multibase-encoded SHA-256 multihash.
+ * @since 2.4.0
+ */
+export async function computeDigestMultibase(
+  bytes: Uint8Array,
+): Promise<string> {
+  const digest = new Uint8Array(
+    await crypto.subtle.digest("SHA-256", bytes.slice()),
+  );
+  const lengthAndDigest = addMulticodecPrefix(digest.length, digest);
+  const multihash = addMulticodecPrefix(
+    SHA2_256_MULTIHASH_CODE,
+    lengthAndDigest,
+  );
+  return textDecoder.decode(encodeMultibase("base58btc", multihash));
+}
+
+/**
+ * Parses and validates a SHA-256 `digestMultibase` value.
+ *
+ * @param value The multibase-encoded multihash to parse.
+ * @returns The digest algorithm and raw digest bytes.
+ * @throws {TypeError} If the value is malformed or uses an unsupported hash
+ *                      algorithm.
+ * @since 2.4.0
+ */
+export function parseDigestMultibase(value: string): ParsedDigestMultibase {
+  let multihash: Uint8Array;
+  try {
+    multihash = decodeMultibase(value);
+  } catch (error) {
+    throw new TypeError("Invalid digestMultibase encoding.", { cause: error });
+  }
+  const encoding = encodingFromBaseData(value);
+  const canonicalValue = textDecoder.decode(
+    encodeMultibase(encoding.name, multihash),
+  );
+  if (value !== canonicalValue) {
+    throw new TypeError("Invalid digestMultibase encoding.");
+  }
+
+  let algorithmPrefix: ReturnType<typeof getMulticodecPrefix>;
+  try {
+    algorithmPrefix = getMulticodecPrefix(multihash);
+  } catch (error) {
+    throw new TypeError("Invalid digestMultibase multihash.", { cause: error });
+  }
+  if (!isCanonicalVarintPrefix(multihash, algorithmPrefix)) {
+    throw new TypeError("Invalid digestMultibase multihash.");
+  }
+  if (algorithmPrefix.code !== SHA2_256_MULTIHASH_CODE) {
+    throw new TypeError(
+      `Unsupported digest algorithm: 0x${algorithmPrefix.code.toString(16)}`,
+    );
+  }
+
+  const lengthAndDigest = multihash.subarray(algorithmPrefix.prefixLength);
+  let lengthPrefix: ReturnType<typeof getMulticodecPrefix>;
+  try {
+    lengthPrefix = getMulticodecPrefix(lengthAndDigest);
+  } catch (error) {
+    throw new TypeError("Invalid digestMultibase multihash.", { cause: error });
+  }
+  if (!isCanonicalVarintPrefix(lengthAndDigest, lengthPrefix)) {
+    throw new TypeError("Invalid digestMultibase multihash.");
+  }
+  const digest = lengthAndDigest.slice(lengthPrefix.prefixLength);
+  if (
+    lengthPrefix.code !== SHA2_256_DIGEST_LENGTH ||
+    digest.length !== SHA2_256_DIGEST_LENGTH
+  ) {
+    throw new TypeError("Invalid SHA-256 digest length.");
+  }
+  return { algorithm: "sha2-256", digest };
+}
+
+/**
+ * Parses a metadata-free `hl:` hashlink and validates its resource digest.
+ *
+ * @param value The simple hashlink to parse.
+ * @returns The `digestMultibase` value carried by the hashlink.
+ * @throws {TypeError} If the hashlink is malformed, contains metadata, or
+ *                      carries an invalid or unsupported digest.
+ * @since 2.4.0
+ */
+export function parseHashlink(value: string | URL): ParsedHashlink {
+  const hashlink = value instanceof URL ? value.href : value;
+  const match = /^hl:([^:]+)$/i.exec(hashlink);
+  if (match == null) throw new TypeError("Invalid simple hashlink.");
+  const digestMultibase = match[1];
+  parseDigestMultibase(digestMultibase);
+  return { digestMultibase };
+}
+
+/**
+ * Creates a metadata-free `hl:` hashlink from a `digestMultibase` value.
+ *
+ * @param digestMultibase The SHA-256 multibase multihash to embed.
+ * @returns The simple hashlink.
+ * @throws {TypeError} If the digest is malformed or unsupported.
+ * @since 2.4.0
+ */
+export function createHashlink(digestMultibase: string): string {
+  parseDigestMultibase(digestMultibase);
+  return `hl:${digestMultibase}`;
+}
+
+/**
+ * Verifies that bytes match a SHA-256 `digestMultibase` value.
+ *
+ * @param bytes The bytes to verify.
+ * @param digestMultibase The expected digest.
+ * @returns Whether the bytes match the digest.
+ * @throws {TypeError} If the digest is malformed or unsupported.
+ * @since 2.4.0
+ */
+export async function verifyDigestMultibase(
+  bytes: Uint8Array,
+  digestMultibase: string,
+): Promise<boolean> {
+  const expected = parseDigestMultibase(digestMultibase).digest;
+  const actual = new Uint8Array(
+    await crypto.subtle.digest("SHA-256", bytes.slice()),
+  );
+  let difference = expected.length ^ actual.length;
+  const length = Math.max(expected.length, actual.length);
+  for (let i = 0; i < length; i++) {
+    difference |= (expected[i] ?? 0) ^ (actual[i] ?? 0);
+  }
+  return difference === 0;
+}
+
+/**
+ * Verifies that bytes match the resource digest in a simple hashlink.
+ *
+ * @param bytes The bytes to verify.
+ * @param hashlink The simple hashlink containing the expected digest.
+ * @returns Whether the bytes match the hashlink digest.
+ * @throws {TypeError} If the hashlink or digest is malformed or unsupported.
+ * @since 2.4.0
+ */
+export async function verifyHashlink(
+  bytes: Uint8Array,
+  hashlink: string | URL,
+): Promise<boolean> {
+  const { digestMultibase } = parseHashlink(hashlink);
+  return await verifyDigestMultibase(bytes, digestMultibase);
+}

--- a/packages/vocab-runtime/src/digest.ts
+++ b/packages/vocab-runtime/src/digest.ts
@@ -147,8 +147,10 @@ export function parseDigestMultibase(value: string): ParsedDigestMultibase {
 
 function extractDigestMultibase(value: string | URL): string {
   const hashlink = value instanceof URL ? value.href : value;
-  const match = /^hl:([^:]+)$/i.exec(hashlink);
-  if (match == null) throw new TypeError("Invalid simple hashlink.");
+  const match = /^hl:([^:\r\n\u2028\u2029]+)$/i.exec(hashlink);
+  if (match == null || match[0].length !== hashlink.length) {
+    throw new TypeError("Invalid simple hashlink.");
+  }
   return match[1];
 }
 

--- a/packages/vocab-runtime/src/digest.ts
+++ b/packages/vocab-runtime/src/digest.ts
@@ -25,9 +25,10 @@ function isCanonicalVarintPrefix(
 }
 
 function toWebCryptoBytes(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
-  return bytes.buffer instanceof ArrayBuffer
-    ? new Uint8Array(bytes.buffer, bytes.byteOffset, bytes.byteLength)
-    : bytes.slice();
+  return Object.prototype.toString.call(bytes.buffer) ===
+      "[object SharedArrayBuffer]"
+    ? bytes.slice()
+    : bytes as Uint8Array<ArrayBuffer>;
 }
 
 /**

--- a/packages/vocab-runtime/src/digest.ts
+++ b/packages/vocab-runtime/src/digest.ts
@@ -146,7 +146,7 @@ export function parseDigestMultibase(value: string): ParsedDigestMultibase {
 }
 
 function extractDigestMultibase(value: string | URL): string {
-  const hashlink = value instanceof URL ? value.href : value;
+  const hashlink = typeof value === "string" ? value : value.href;
   const match = /^hl:([^:\r\n\u2028\u2029]+)$/i.exec(hashlink);
   if (match == null || match[0].length !== hashlink.length) {
     throw new TypeError("Invalid simple hashlink.");

--- a/packages/vocab-runtime/src/digest.ts
+++ b/packages/vocab-runtime/src/digest.ts
@@ -10,6 +10,7 @@ import {
 
 const SHA2_256_MULTIHASH_CODE = 0x12;
 const SHA2_256_DIGEST_LENGTH = 32;
+const MAX_DIGEST_MULTIBASE_LENGTH = 1 + (SHA2_256_DIGEST_LENGTH + 2) * 8;
 const textDecoder = new TextDecoder();
 const getArrayBufferByteLength = Object.getOwnPropertyDescriptor(
   ArrayBuffer.prototype,
@@ -96,6 +97,9 @@ export async function computeDigestMultibase(
  * @since 2.4.0
  */
 export function parseDigestMultibase(value: string): ParsedDigestMultibase {
+  if (value.length > MAX_DIGEST_MULTIBASE_LENGTH) {
+    throw new TypeError("Invalid digestMultibase encoding.");
+  }
   let multihash: Uint8Array;
   try {
     multihash = decodeMultibase(value);

--- a/packages/vocab-runtime/src/digest.ts
+++ b/packages/vocab-runtime/src/digest.ts
@@ -14,7 +14,7 @@ const textDecoder = new TextDecoder();
 const getArrayBufferByteLength = Object.getOwnPropertyDescriptor(
   ArrayBuffer.prototype,
   "byteLength",
-)!.get!;
+)?.get;
 
 function isCanonicalVarintPrefix(
   data: Uint8Array,
@@ -29,12 +29,15 @@ function isCanonicalVarintPrefix(
 }
 
 function toWebCryptoBytes(bytes: Uint8Array): Uint8Array<ArrayBuffer> {
-  try {
-    getArrayBufferByteLength.call(bytes.buffer);
-    return bytes as Uint8Array<ArrayBuffer>;
-  } catch {
-    return new Uint8Array(bytes);
+  if (getArrayBufferByteLength != null) {
+    try {
+      getArrayBufferByteLength.call(bytes.buffer);
+      return bytes as Uint8Array<ArrayBuffer>;
+    } catch {
+      // SharedArrayBuffer input needs to be copied for Web Crypto.
+    }
   }
+  return new Uint8Array(bytes);
 }
 
 /**

--- a/packages/vocab-runtime/src/mod.ts
+++ b/packages/vocab-runtime/src/mod.ts
@@ -34,6 +34,16 @@ export {
   isDecimal,
   parseDecimal,
 } from "./decimal.ts";
+export {
+  computeDigestMultibase,
+  createHashlink,
+  type ParsedDigestMultibase,
+  type ParsedHashlink,
+  parseDigestMultibase,
+  parseHashlink,
+  verifyDigestMultibase,
+  verifyHashlink,
+} from "./digest.ts";
 export { LanguageString } from "./langstr.ts";
 export {
   decodeMultibase,


### PR DESCRIPTION
[FEP-ef61] allows portable objects and their media to be available through more than one gateway. A media URL alone cannot establish that two gateways returned the same resource, or that a resource has remained unchanged after an object was signed. The FEP therefore requires external resources to carry a SHA-256 `digestMultibase` value and recommends hashlinks for their identifiers.

Fedify already exposes `digestMultibase` in its vocabulary types, but applications had no matching runtime support for producing or checking those values. Each application would otherwise need to assemble multihashes by hand, choose a multibase representation, parse `hl:` URIs, and reproduce the same validation rules. Besides duplicating subtle binary encoding code, that would make portable media behave differently across Deno, Node.js, Bun, and browser-like WebCrypto environments.

This PR puts that boundary in `@fedify/vocab-runtime`. The helpers use Web Crypto API for SHA-256 and build on Fedify's existing multibase and multicodec code, so they do not add a second encoding stack or a runtime dependency on `digitalbazaar/hashlink`. The Hashlink Internet-Draft is expired and describes more than FEP-ef61 needs, so the API deliberately supports only metadata-free `hl:` URIs. Metadata-bearing hashlinks and legacy `?hl=` parameters are rejected instead of becoming accidental compatibility commitments.

Parsing is intentionally strict. A digest must contain a canonical multibase encoding of a canonical SHA-256 multihash with a 32-byte payload. Unsupported algorithms, overlong varints, incorrect padding, malformed lengths, and noncanonical encodings are rejected. This keeps equivalent digests from acquiring multiple accepted spellings and ensures that values created, parsed, serialized, and verified by different Fedify components agree exactly. Verification returns `false` for valid digests that do not match the supplied bytes, while malformed inputs remain programmer-visible `TypeError`s.

The implementation and its public exports live in *packages/vocab-runtime/src/digest.ts* and *packages/vocab-runtime/src/mod.ts*. The regression coverage in *packages/vocab-runtime/src/digest.test.ts* includes the Hashlink draft's `Hello World!` vector, valid non-base58 multibase input, canonical padding, malformed multihashes, unsupported algorithms, metadata rejection, and matching and non-matching byte sequences. The portable-object section of *docs/manual/vocab.md* now shows how the digest and hashlink helpers fit the existing vocabulary properties, and *CHANGES.md* records the new API.

Closes #831.

[FEP-ef61]: https://w3id.org/fep/ef61