### PR TITLE
fix doc: change fedify init order on microblog tutorial

### DIFF
--- a/docs/tutorial/microblog.md
+++ b/docs/tutorial/microblog.md
@@ -167,6 +167,9 @@ Select *Hono*, *npm*, *in-process*, and *in-memory* in order:
   ElysiaJS
   Astro
   Express
+  Nuxt
+  SolidStart
+
 
 ? Choose the package manager to use
   deno

--- a/docs/tutorial/microblog.md
+++ b/docs/tutorial/microblog.md
@@ -150,7 +150,7 @@ fedify init microblog
 ~~~~
 
 When you run the `fedify init` command, you'll see a series of prompts.
-Select *Hono*, *npm*, *Hono*, *In-process*, and *In-memory* in order:
+Select *Hono*, *npm*, *in-process*, and *in-memory* in order:
 
 ~~~~ console
              ___      _____        _ _  __

--- a/docs/tutorial/microblog.md
+++ b/docs/tutorial/microblog.md
@@ -150,7 +150,7 @@ fedify init microblog
 ~~~~
 
 When you run the `fedify init` command, you'll see a series of prompts.
-Select *Node.js*, *npm*, *Hono*, *In-memory*, and *In-process* in order:
+Select *Hono*, *npm*, *Hono*, *In-process*, and *In-memory* in order:
 
 ~~~~ console
              ___      _____        _ _  __
@@ -159,36 +159,36 @@ Select *Node.js*, *npm*, *Hono*, *In-memory*, and *In-process* in order:
    __/       /       |  _|  __/ (_| | |  _| |_| |
   <__.|_|-|_|        |_|  \___|\__,_|_|_|  \__, |
                                            |___/
-
-? Choose the JavaScript runtime to use
-  Deno
-  Bun
-❯ Node.js
+? Choose the web framework to use
+  Bare-bones
+❯ Hono
+  Nitro
+  Next.js
+  ElysiaJS
+  Astro
+  Express
 
 ? Choose the package manager to use
-❯ npm
-  Yarn
+  deno
   pnpm
+  bun
+  yarn
+❯ npm
 
-? Choose the web framework to integrate Fedify with
-  Bare-bones
-  Fresh
-❯ Hono
-  Express
-  Nitro
+? Choose the message queue to use
+❯ in-process
+  redis
+  postgres
+  mysql
+  amqp
+- denokv (not supported with npm) (disabled)
 
-? Choose the key–value store to use for caching
-❯ In-memory
-  Redis
-  PostgreSQL
-  Deno KV
-
-? Choose the message queue to use for background jobs
-❯ In-process
-  Redis
-  PostgreSQL
-  AMQP (e.g., RabbitMQ)
-  Deno KV
+? Choose the key-value store to use
+❯ in-memory
+  redis
+  postgres
+  mysql
+- denokv (not supported with npm) (disabled)
 ~~~~
 
 > [!NOTE]


### PR DESCRIPTION
Why
---
`fedify init` order has been changed, but the documentation for microblog tutorial has been not changed.

How
---
since `fedify init` order has been changed, update the documentation to match the order for fedify version `2.3.1`.

What changed
---
 -  *microblog.md*: fix the order and details on `~~~~ console` section.

Additional Information
---
- I wasn't able to check each and every single documents to check if there are same issues on other ones.