### PR TITLE
Add fedify.com.es as a CLI tunnel service

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -210,8 +210,14 @@ To be released.
 
 ### @fedify/cli
 
+ -  Added `fedify.com.es` as a tunneling service.  The CLI pins the service's
+    SSH host key and rejects a mismatched server before exposing a local port.
+    [[#940]]
+
  -  Switched the CLI's Temporal runtime dependency from
     `@js-temporal/polyfill` to `temporal-polyfill`.  [[#823], [#925]]
+
+[#940]: https://github.com/fedify-dev/fedify/pull/940
 
 ### @fedify/debugger
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -214,6 +214,9 @@ To be released.
     SSH host key and rejects a mismatched server before exposing a local port.
     [[#940]]
 
+ -  Removed `localhost.run` as a tunneling service.  The service is no longer
+    available, and the CLI now rejects attempts to use it.  [[#940]]
+
  -  Switched the CLI's Temporal runtime dependency from
     `@js-temporal/polyfill` to `temporal-polyfill`.  [[#823], [#925]]
 

--- a/deno.lock
+++ b/deno.lock
@@ -18,17 +18,21 @@
     "jsr:@fresh/core@^2.1.4": "2.3.3",
     "jsr:@fresh/core@^2.3.3": "2.3.3",
     "jsr:@fresh/plugin-vite@^1.0.7": "1.1.2",
-    "jsr:@hongminhee/localtunnel@0.3": "0.3.0",
-    "jsr:@hono/hono@^4.7.1": "4.12.26",
-    "jsr:@hono/hono@^4.8.3": "4.12.26",
-    "jsr:@logtape/file@^2.2.0": "2.2.0",
+    "jsr:@hongminhee/localtunnel@0.3": "0.3.1",
+    "jsr:@hongminhee/localtunnel@0.5": "0.5.0",
+    "jsr:@hono/hono@^4.7.1": "4.12.30",
+    "jsr:@hono/hono@^4.8.3": "4.12.30",
+    "jsr:@logtape/file@^2.2.0": "2.2.4",
     "jsr:@logtape/logtape@^1.0.4": "1.3.11",
-    "jsr:@logtape/logtape@^2.2.0": "2.2.0",
-    "jsr:@optique/config@^1.1.0": "1.1.0",
-    "jsr:@optique/core@^1.1.0": "1.1.0",
+    "jsr:@logtape/logtape@^2.2.0": "2.2.4",
+    "jsr:@logtape/logtape@^2.2.4": "2.2.4",
+    "jsr:@optique/config@^1.1.0": "1.1.1",
+    "jsr:@optique/core@^1.1.0": "1.1.1",
+    "jsr:@optique/core@^1.1.1": "1.1.1",
     "jsr:@optique/discover@1.1.0": "1.1.0",
-    "jsr:@optique/discover@^1.1.0": "1.1.0",
-    "jsr:@optique/run@^1.1.0": "1.1.0",
+    "jsr:@optique/discover@^1.1.0": "1.1.1",
+    "jsr:@optique/run@^1.1.0": "1.1.1",
+    "jsr:@optique/run@^1.1.1": "1.1.1",
     "jsr:@standard-schema/spec@^1.1.0": "1.1.0",
     "jsr:@std/assert@0.224": "0.224.0",
     "jsr:@std/assert@0.226": "0.226.0",
@@ -39,7 +43,8 @@
     "jsr:@std/data-structures@0.224": "0.224.1",
     "jsr:@std/data-structures@^1.0.11": "1.0.11",
     "jsr:@std/dotenv@~0.225.5": "0.225.7",
-    "jsr:@std/encoding@^1.0.10": "1.0.10",
+    "jsr:@std/encoding@^1.0.10": "1.0.11",
+    "jsr:@std/encoding@^1.0.11": "1.0.11",
     "jsr:@std/fmt@0.224": "0.224.0",
     "jsr:@std/fmt@1": "1.0.10",
     "jsr:@std/fmt@^1.0.7": "1.0.10",
@@ -48,7 +53,7 @@
     "jsr:@std/fs@^1.0.19": "1.0.24",
     "jsr:@std/fs@^1.0.3": "1.0.24",
     "jsr:@std/html@^1.0.5": "1.0.7",
-    "jsr:@std/http@^1.0.21": "1.1.1",
+    "jsr:@std/http@^1.0.21": "1.1.2",
     "jsr:@std/internal@0.224": "0.224.0",
     "jsr:@std/internal@1": "1.0.14",
     "jsr:@std/internal@^1.0.12": "1.0.14",
@@ -60,17 +65,17 @@
     "jsr:@std/media-types@^1.1.0": "1.1.0",
     "jsr:@std/net@^1.0.6": "1.0.6",
     "jsr:@std/path@0.224": "0.224.0",
-    "jsr:@std/path@1": "1.1.5",
-    "jsr:@std/path@^1.0.6": "1.1.5",
-    "jsr:@std/path@^1.1.0": "1.1.5",
-    "jsr:@std/path@^1.1.1": "1.1.5",
-    "jsr:@std/path@^1.1.2": "1.1.5",
-    "jsr:@std/path@^1.1.5": "1.1.5",
+    "jsr:@std/path@1": "1.1.6",
+    "jsr:@std/path@^1.0.6": "1.1.6",
+    "jsr:@std/path@^1.1.0": "1.1.6",
+    "jsr:@std/path@^1.1.1": "1.1.6",
+    "jsr:@std/path@^1.1.2": "1.1.6",
+    "jsr:@std/path@^1.1.5": "1.1.6",
     "jsr:@std/semver@^1.0.6": "1.0.8",
     "jsr:@std/testing@0.224": "0.224.0",
     "jsr:@std/uuid@^1.0.9": "1.1.1",
     "jsr:@std/yaml@^1.0.8": "1.1.0",
-    "jsr:@valibot/valibot@^1.4.0": "1.4.1",
+    "jsr:@valibot/valibot@^1.4.0": "1.4.2",
     "npm:@alinea/suite@~0.6.3": "0.6.3",
     "npm:@astrojs/node@^10.0.3": "10.0.5_astro@5.18.1__@types+node@24.12.2__mysql2@3.22.3___@types+node@24.12.2_@types+node@24.12.2_mysql2@3.22.3__@types+node@24.12.2",
     "npm:@babel/preset-react@^7.27.1": "7.28.5_@babel+core@7.29.7",
@@ -79,7 +84,7 @@
     "npm:@cloudflare/workers-types@^4.20260511.1": "4.20260511.1",
     "npm:@deno/astro-adapter@~0.3.2": "0.3.2_@opentelemetry+api@1.9.1_astro@5.18.1__@types+node@24.12.2__mysql2@3.22.3___@types+node@24.12.2_@types+node@24.12.2_mysql2@3.22.3__@types+node@24.12.2",
     "npm:@fxts/core@^1.21.1": "1.26.0",
-    "npm:@hongminhee/localtunnel@0.3": "0.3.0",
+    "npm:@hongminhee/localtunnel@0.5": "0.5.0",
     "npm:@inquirer/prompts@^7.8.4": "7.10.1_@types+node@24.12.2",
     "npm:@jimp/core@^1.6.1": "1.6.1",
     "npm:@jimp/wasm-webp@^1.6.1": "1.6.1",
@@ -236,7 +241,7 @@
     "@fresh/build-id@1.0.1": {
       "integrity": "12a2ec25fd52ae9ec68c26848a5696cd1c9b537f7c983c7e56e4fb1e7e816c20",
       "dependencies": [
-        "jsr:@std/encoding"
+        "jsr:@std/encoding@^1.0.10"
       ]
     },
     "@fresh/core@2.3.3": {
@@ -244,7 +249,7 @@
       "dependencies": [
         "jsr:@deno/esbuild-plugin",
         "jsr:@fresh/build-id",
-        "jsr:@std/encoding",
+        "jsr:@std/encoding@^1.0.10",
         "jsr:@std/fmt@^1.0.8",
         "jsr:@std/fs@^1.0.19",
         "jsr:@std/html",
@@ -282,8 +287,14 @@
         "npm:vite@^7.1.4"
       ]
     },
-    "@hongminhee/localtunnel@0.3.0": {
-      "integrity": "4ad858acd963b5fad45b188d54cf751ac8fbe0aae495e1d3ce607e3730270ff4",
+    "@hongminhee/localtunnel@0.3.1": {
+      "integrity": "7f390d0b4c19c747418d8995e968c1f8476d76eb3f7658bc6cc24fc3d58269f6",
+      "dependencies": [
+        "jsr:@logtape/logtape@^1.0.4"
+      ]
+    },
+    "@hongminhee/localtunnel@0.5.0": {
+      "integrity": "74cf3cf764efecfa178e19526ceba97ebe4632d47301813f534c69b744fd8229",
       "dependencies": [
         "jsr:@logtape/logtape@^1.0.4"
       ]
@@ -297,10 +308,20 @@
     "@hono/hono@4.12.26": {
       "integrity": "f473c70caaa2bb4aad40354195aef58a58c685692d701e1349d1abbf08da22bd"
     },
+    "@hono/hono@4.12.30": {
+      "integrity": "cd8e61aedab7e765e4e262728273ee0fdea3bc667af5eb6badd2772223b544fc"
+    },
     "@logtape/file@2.2.0": {
       "integrity": "60a1a8ec1256b88aacc65464f3f82a554bc49252cc9d4e4e4b2736237a227d52",
       "dependencies": [
         "jsr:@logtape/logtape@^2.2.0",
+        "jsr:@std/path@^1.1.0"
+      ]
+    },
+    "@logtape/file@2.2.4": {
+      "integrity": "04c8fe76b30fa854ad903eff380af90060163cc1289f268d3d43b541b4c3c7e1",
+      "dependencies": [
+        "jsr:@logtape/logtape@^2.2.4",
         "jsr:@std/path@^1.1.0"
       ]
     },
@@ -316,27 +337,53 @@
     "@logtape/logtape@2.2.0": {
       "integrity": "537ceb4de93d00780a5d81ca8e053c4774ee95b1d32ab665a3d07ae302e8ea53"
     },
+    "@logtape/logtape@2.2.4": {
+      "integrity": "8ee23b7c8d4b2e28c43a3a16027a7a27ed3d453c395c7d91b9960640399201ec"
+    },
     "@optique/config@1.1.0": {
       "integrity": "9f9425156860e72f46717b8be8b01f0868f47465e9cd1d3788f4ba5038a355c9",
       "dependencies": [
-        "jsr:@optique/core",
+        "jsr:@optique/core@^1.1.0",
+        "npm:@standard-schema/spec@^1.1.0"
+      ]
+    },
+    "@optique/config@1.1.1": {
+      "integrity": "59dcdcb723b74a1ecf5ac0d3a0dc7fde172b81cfd10aec7d9eaf95e49b5c6634",
+      "dependencies": [
+        "jsr:@optique/core@^1.1.1",
         "npm:@standard-schema/spec@^1.1.0"
       ]
     },
     "@optique/core@1.1.0": {
       "integrity": "f864b1918415fd2a94c0b8ee6a31b6e6faeb2a972e6e75f0be4cf2d201e3fcf4"
     },
+    "@optique/core@1.1.1": {
+      "integrity": "8288c0adcf42951c59fb450de016873ece1a71f976ccaca3da9618e56e284447"
+    },
     "@optique/discover@1.1.0": {
       "integrity": "dec51dd8ba79e70a1557e4f55e58a792c4ab10cbf63f7382dad80c902801d1b6",
       "dependencies": [
-        "jsr:@optique/core",
-        "jsr:@optique/run"
+        "jsr:@optique/core@^1.1.0",
+        "jsr:@optique/run@^1.1.0"
+      ]
+    },
+    "@optique/discover@1.1.1": {
+      "integrity": "1f406072542af8187bffe33269f1798dd5ad81635b53817558f0e3fe71cdb885",
+      "dependencies": [
+        "jsr:@optique/core@^1.1.1",
+        "jsr:@optique/run@^1.1.1"
       ]
     },
     "@optique/run@1.1.0": {
       "integrity": "4773919cde888d4b35dc8e34a3e87fab544ab9d00c7d5312de5a77b230a0cffe",
       "dependencies": [
-        "jsr:@optique/core"
+        "jsr:@optique/core@^1.1.0"
+      ]
+    },
+    "@optique/run@1.1.1": {
+      "integrity": "a05a670c360ba9725b20c37dde4265b1661265edb71dbaaae05a11bb09d833eb",
+      "dependencies": [
+        "jsr:@optique/core@^1.1.1"
       ]
     },
     "@standard-schema/spec@1.1.0": {
@@ -388,6 +435,9 @@
     "@std/encoding@1.0.10": {
       "integrity": "8783c6384a2d13abd5e9e87a7ae0520a30e9f56aeeaa3bdf910a3eaaf5c811a1"
     },
+    "@std/encoding@1.0.11": {
+      "integrity": "e7cef2f0b3153bccc17431e7c864a1de03a4b6d9647389c43e08aaa775d37385"
+    },
     "@std/fmt@0.224.0": {
       "integrity": "e20e9a2312a8b5393272c26191c0a68eda8d2c4b08b046bad1673148f1d69851"
     },
@@ -413,7 +463,13 @@
     "@std/http@1.1.1": {
       "integrity": "e343a9a80aea07c716b91be5c79df764144430ad2dd7c9121ed7443f08dc74f7",
       "dependencies": [
-        "jsr:@std/encoding"
+        "jsr:@std/encoding@^1.0.10"
+      ]
+    },
+    "@std/http@1.1.2": {
+      "integrity": "1c0473590d5e5b75b30b2be4833c08047dd799aeea35624fd34ec58d67fc9240",
+      "dependencies": [
+        "jsr:@std/encoding@^1.0.11"
       ]
     },
     "@std/internal@0.224.0": {
@@ -455,6 +511,12 @@
         "jsr:@std/internal@^1.0.14"
       ]
     },
+    "@std/path@1.1.6": {
+      "integrity": "c68485c2a4dfbb5ae3cc74fae4e8c4e5d874cf8a8ed12927917235c758b46cbe",
+      "dependencies": [
+        "jsr:@std/internal@^1.0.14"
+      ]
+    },
     "@std/semver@1.0.8": {
       "integrity": "dc830e8b8b6a380c895d53fbfd1258dc253704ca57bbe1629ac65fd7830179b7"
     },
@@ -489,6 +551,9 @@
     },
     "@valibot/valibot@1.4.1": {
       "integrity": "9be12a3f73f3fd00fa44ae189bc1bb3ab4d9088ec2e32a6ab370ae4fca29ee6e"
+    },
+    "@valibot/valibot@1.4.2": {
+      "integrity": "14f7fbb7474a8ade216224062d1e8b23cd17ecbb5176fc23595e846778c4725d"
     }
   },
   "npm": {
@@ -1548,8 +1613,8 @@
         "tslib"
       ]
     },
-    "@hongminhee/localtunnel@0.3.0": {
-      "integrity": "sha512-GRn02MyJIal6DjgDiaLDQhaiTvYlqTLq97bpTNqp2qGnwy4c77pHm6kWPBdSOjmLGPCf2bb/USFKQBgUhafbuA==",
+    "@hongminhee/localtunnel@0.5.0": {
+      "integrity": "sha512-1UZvlLwQJQ2vMmVY5+VdzR+7XIg0uA0TDZDv6m+vTipBX5uG0mnCPW2wRc+ZdqjMW11AygbfLskuDC6IuTxQ0w==",
       "dependencies": [
         "@logtape/logtape"
       ]
@@ -2422,8 +2487,8 @@
       "integrity": "sha512-6xReMW9p+paJgqoFRpOE2nogJFvzPfaLHLIlyADYjKMUcwDyjKZxryIbgcU+gxiTygn8yCjld1HoI0ET4/iZeA==",
       "tarball": "https://npm.jsr.io/~/11/@jsr/std__internal/1.0.12.tgz"
     },
-    "@logtape/logtape@1.3.7": {
-      "integrity": "sha512-YgF+q9op97oLLPwc7TcTNIllTArVtTwkwyKky6XVzAXQcBrvFXXtMuwJSryONAyOUSItrx994O/HABOrszZyFg=="
+    "@logtape/logtape@1.3.11": {
+      "integrity": "sha512-mxkQOyySbjNGweavPudypBf0qZJxLOTXl2NAXYnsZF/ds5dQpTLA7YMSJbc8uFWlTkG+YjAnVL8tQWivIVPOJg=="
     },
     "@lukeed/csprng@1.1.0": {
       "integrity": "sha512-Z7C/xXCiGWsg0KuKsHTKJxbWhpI3Vs5GwLfOean7MGyVFGqdRgBbAjOCh6u4bbjPc/8MJ2pZmK/0DLdCbivLDA=="
@@ -9575,7 +9640,7 @@
       },
       "packages/cli": {
         "dependencies": [
-          "jsr:@hongminhee/localtunnel@0.3",
+          "jsr:@hongminhee/localtunnel@0.5",
           "jsr:@hono/hono@^4.8.3",
           "jsr:@valibot/valibot@^1.4.0",
           "npm:@cfworker/json-schema@^4.1.1",
@@ -9598,7 +9663,7 @@
         "packageJson": {
           "dependencies": [
             "npm:@cfworker/json-schema@^4.1.1",
-            "npm:@hongminhee/localtunnel@0.3",
+            "npm:@hongminhee/localtunnel@0.5",
             "npm:@inquirer/prompts@^7.8.4",
             "npm:@jimp/core@^1.6.1",
             "npm:@jimp/wasm-webp@^1.6.1",

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -177,7 +177,7 @@ Below is an example configuration file showing all available options:
 # Global settings (apply to all commands)
 debug = false
 userAgent = "MyApp/1.0"
-tunnelService = "pinggy.io"  # "serveo.net" or "pinggy.io"
+tunnelService = "fedify.com.es"  # Or "serveo.net" or "pinggy.io"
 
 [webfinger]
 allowPrivateAddress = false
@@ -1018,10 +1018,10 @@ when using the `-a`/`--authorized-fetch` option.  The authorized fetch feature
 requires a temporary server to be exposed to the public internet, and this
 option allows you to choose the tunneling service.  Available services can be
 found in the output of the `fedify lookup --help` command.  For example, to use
-serveo.net as the tunneling service:
+fedify.com.es as the tunneling service:
 
 ~~~~ sh
-fedify lookup --authorized-fetch --tunnel-service serveo.net @user@example.com
+fedify lookup --authorized-fetch --tunnel-service fedify.com.es @user@example.com
 ~~~~
 
 ### `-u`/`--user-agent`: Custom `User-Agent` header
@@ -1248,10 +1248,10 @@ about the security implications of exposing the server to the public internet.
 The `--tunnel-service` option is used to specify which tunneling service to use
 for exposing the ephemeral inbox server to the public internet.  Available
 services can be found in the output of the `fedify inbox --help` command.
-For example, to use serveo.net as the tunneling service:
+For example, to use fedify.com.es as the tunneling service:
 
 ~~~~ sh
-fedify inbox --tunnel-service serveo.net
+fedify inbox --tunnel-service fedify.com.es
 ~~~~
 
 > [!NOTE]
@@ -1502,10 +1502,10 @@ fedify relay -p mastodon --no-tunnel
 The `--tunnel-service` option specifies which tunneling service to use for
 exposing the relay server to the public internet.  Available services can be
 found in the output of the `fedify relay --help` command.  For example, to use
-serveo.net as the tunneling service:
+fedify.com.es as the tunneling service:
 
 ~~~~ sh
-fedify relay -p mastodon --tunnel-service serveo.net
+fedify relay -p mastodon --tunnel-service fedify.com.es
 ~~~~
 
 > [!NOTE]
@@ -1556,11 +1556,11 @@ fedify tunnel 3000
 The `-s`/`--service` option is used to specify the tunneling service to use.
 The `--tunnel-service` is an alias for consistency with other commands that
 support tunneling.  Available services can be found in the output of the
-`fedify tunnel --help` command.  For example, to use serveo.net, run the below
-command:
+`fedify tunnel --help` command.  For example, to use fedify.com.es, run the
+below command:
 
 ~~~~ sh
-fedify tunnel --service serveo.net 3000
+fedify tunnel --service fedify.com.es 3000
 ~~~~
 
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -177,7 +177,7 @@ Below is an example configuration file showing all available options:
 # Global settings (apply to all commands)
 debug = false
 userAgent = "MyApp/1.0"
-tunnelService = "localhost.run"  # "localhost.run", "serveo.net", or "pinggy.io"
+tunnelService = "pinggy.io"  # "serveo.net" or "pinggy.io"
 
 [webfinger]
 allowPrivateAddress = false

--- a/docs/manual/test.md
+++ b/docs/manual/test.md
@@ -23,7 +23,6 @@ that help you do that:
  -  [`fedify tunnel`](../cli.md#fedify-tunnel-exposing-a-local-http-server-to-the-public-internet)
  -  [ngrok]
  -  [serveo]
- -  [localhost.run]
  -  [Tailscale Funnel]
 
 > [!NOTE]
@@ -52,7 +51,6 @@ that help you do that:
 
 [ngrok]: https://ngrok.com/
 [serveo]: https://serveo.net/
-[localhost.run]: https://localhost.run/
 [Tailscale Funnel]: https://tailscale.com/kb/1223/funnel
 [x-forwarded-fetch]: https://github.com/dahlia/x-forwarded-fetch
 

--- a/docs/tutorial/astro-blog.md
+++ b/docs/tutorial/astro-blog.md
@@ -1049,7 +1049,7 @@ You'll see output like this after a few seconds:
 
 > [!NOTE]
 > The tunnel uses one of several free tunneling services
-> (serveo.net or pinggy.io).  The URL changes each
+> (fedify.com.es, serveo.net, or pinggy.io).  The URL changes each
 > time you run the command.  Once you've introduced SQLite persistence
 > (in a later chapter), delete *blog.db* whenever the tunnel URL
 > changes—otherwise the ActivityPub IDs stored in the database (actor

--- a/docs/tutorial/astro-blog.md
+++ b/docs/tutorial/astro-blog.md
@@ -1049,7 +1049,7 @@ You'll see output like this after a few seconds:
 
 > [!NOTE]
 > The tunnel uses one of several free tunneling services
-> (localhost.run, serveo.net, or pinggy.io).  The URL changes each
+> (serveo.net or pinggy.io).  The URL changes each
 > time you run the command.  Once you've introduced SQLite persistence
 > (in a later chapter), delete *blog.db* whenever the tunnel URL
 > changes—otherwise the ActivityPub IDs stored in the database (actor

--- a/docs/tutorial/content-sharing.md
+++ b/docs/tutorial/content-sharing.md
@@ -1906,11 +1906,11 @@ The exact subdomain changes every session.  We will refer to it as
 the commands below.
 
 > [!TIP]
-> `fedify tunnel` rotates between two free SSH-based services
-> (`serveo.net`, `pinggy.io`) so it does not depend
+> `fedify tunnel` rotates between three free SSH-based services
+> (`fedify.com.es`, `serveo.net`, `pinggy.io`) so it does not depend
 > on you signing up for anything.  If a session drops or refuses to
 > start, run the command again, or pin a specific service with `-s`,
-> for example `fedify tunnel -s pinggy.io 3000`.  When both
+> for example `fedify tunnel -s pinggy.io 3000`.  When all three
 > misbehave, [`cloudflared tunnel --url http://localhost:3000`] and
 > [`ngrok http 3000`] are good fallbacks; the rest of the tutorial
 > works with whichever public URL you ended up with.

--- a/docs/tutorial/content-sharing.md
+++ b/docs/tutorial/content-sharing.md
@@ -1906,11 +1906,11 @@ The exact subdomain changes every session.  We will refer to it as
 the commands below.
 
 > [!TIP]
-> `fedify tunnel` rotates between three free SSH-based services
-> (`localhost.run`, `serveo.net`, `pinggy.io`) so it does not depend
+> `fedify tunnel` rotates between two free SSH-based services
+> (`serveo.net`, `pinggy.io`) so it does not depend
 > on you signing up for anything.  If a session drops or refuses to
 > start, run the command again, or pin a specific service with `-s`,
-> for example `fedify tunnel -s localhost.run 3000`.  When all three
+> for example `fedify tunnel -s pinggy.io 3000`.  When both
 > misbehave, [`cloudflared tunnel --url http://localhost:3000`] and
 > [`ngrok http 3000`] are good fallbacks; the rest of the tutorial
 > works with whichever public URL you ended up with.

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -5,7 +5,7 @@
   "exports": "./src/mod.ts",
   "imports": {
     "@cfworker/json-schema": "npm:@cfworker/json-schema@^4.1.1",
-    "@hongminhee/localtunnel": "jsr:@hongminhee/localtunnel@^0.3.0",
+    "@hongminhee/localtunnel": "jsr:@hongminhee/localtunnel@^0.5.0",
     "@inquirer/prompts": "npm:@inquirer/prompts@^7.8.4",
     "@jimp/core": "npm:@jimp/core@^1.6.1",
     "@jimp/wasm-webp": "npm:@jimp/wasm-webp@^1.6.1",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -84,7 +84,7 @@
     "@optique/discover": "catalog:",
     "@optique/run": "catalog:",
     "@standard-schema/spec": "catalog:",
-    "@hongminhee/localtunnel": "^0.3.0",
+    "@hongminhee/localtunnel": "^0.5.0",
     "@inquirer/prompts": "^7.8.4",
     "@jimp/core": "^1.6.1",
     "@jimp/wasm-webp": "^1.6.1",

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,3 +1,4 @@
+import { SERVICES } from "@hongminhee/localtunnel";
 import { createConfigContext } from "@optique/config";
 import { message } from "@optique/core";
 import { printError } from "@optique/run";
@@ -126,7 +127,7 @@ export const configSchema = object({
   debug: optional(boolean()),
   userAgent: optional(string()),
   tunnelService: optional(
-    picklist(["localhost.run", "serveo.net", "pinggy.io"]),
+    picklist(Object.keys(SERVICES) as (keyof typeof SERVICES)[]),
   ),
 
   // Command-specific sections

--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -1,4 +1,3 @@
-import { SERVICES } from "@hongminhee/localtunnel";
 import { createConfigContext } from "@optique/config";
 import { message } from "@optique/core";
 import { printError } from "@optique/run";
@@ -19,6 +18,7 @@ import {
   pipe,
   string,
 } from "valibot";
+import { TUNNEL_SERVICE_NAMES } from "./tunnelservice.ts";
 
 /**
  * Schema for the webfinger command configuration.
@@ -126,9 +126,7 @@ export const configSchema = object({
   // Global settings
   debug: optional(boolean()),
   userAgent: optional(string()),
-  tunnelService: optional(
-    picklist(Object.keys(SERVICES) as (keyof typeof SERVICES)[]),
-  ),
+  tunnelService: optional(picklist(TUNNEL_SERVICE_NAMES)),
 
   // Command-specific sections
   webfinger: optional(webfingerSchema),

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -1,5 +1,4 @@
 import { getUserAgent } from "@fedify/vocab-runtime";
-import { SERVICES } from "@hongminhee/localtunnel";
 import { bindConfig } from "@optique/config";
 import {
   choice,
@@ -18,18 +17,17 @@ import {
   withDefault,
 } from "@optique/core";
 import { type Config, configContext } from "./config.ts";
+import { TUNNEL_SERVICE_NAMES } from "./tunnelservice.ts";
 
 /**
  * Available tunneling services for exposing local servers to the public internet.
  */
-export const TUNNEL_SERVICES = Object.keys(
-  SERVICES,
-) as readonly (keyof typeof SERVICES)[];
+export const TUNNEL_SERVICES = TUNNEL_SERVICE_NAMES;
 
 /**
  * Type representing a valid tunneling service.
  */
-export type TunnelService = typeof TUNNEL_SERVICES[number];
+export type { TunnelService } from "./tunnelservice.ts";
 
 /**
  * Creates a tunnel service option with customizable option names.

--- a/packages/cli/src/options.ts
+++ b/packages/cli/src/options.ts
@@ -1,4 +1,5 @@
 import { getUserAgent } from "@fedify/vocab-runtime";
+import { SERVICES } from "@hongminhee/localtunnel";
 import { bindConfig } from "@optique/config";
 import {
   choice,
@@ -21,11 +22,9 @@ import { type Config, configContext } from "./config.ts";
 /**
  * Available tunneling services for exposing local servers to the public internet.
  */
-export const TUNNEL_SERVICES = [
-  "localhost.run",
-  "serveo.net",
-  "pinggy.io",
-] as const;
+export const TUNNEL_SERVICES = Object.keys(
+  SERVICES,
+) as readonly (keyof typeof SERVICES)[];
 
 /**
  * Type representing a valid tunneling service.

--- a/packages/cli/src/tempserver.ts
+++ b/packages/cli/src/tempserver.ts
@@ -2,6 +2,7 @@ import { openTunnel } from "@hongminhee/localtunnel";
 import { getLogger } from "@logtape/logtape";
 import { serve } from "srvx";
 import type { TunnelService } from "./options.ts";
+import { TUNNEL_SERVICE_REGISTRY } from "./tunnelservice.ts";
 
 const logger = getLogger(["fedify", "cli", "tempserver"]);
 
@@ -84,6 +85,7 @@ export async function spawnTemporaryServer(
   logger.debug("Temporary server is listening on port {port}.", { port });
   const tun = await openTunnel({
     port: parseInt(port),
+    services: TUNNEL_SERVICE_REGISTRY,
     service: options.service,
   });
   logger.debug("Temporary server is tunneled to {url}.", { url: tun.url.href });

--- a/packages/cli/src/tunnel.test.ts
+++ b/packages/cli/src/tunnel.test.ts
@@ -1,10 +1,10 @@
-import type { Tunnel, TunnelOptions } from "@hongminhee/localtunnel";
+import type { Tunnel } from "@hongminhee/localtunnel";
 import { runSync } from "@optique/run";
 import { deepEqual, rejects } from "node:assert/strict";
 import test from "node:test";
 import { runCli } from "./runner.ts";
 import type { Ora } from "ora";
-import { runTunnel, tunnelCommand } from "./tunnel.ts";
+import { runTunnel, tunnelCommand, type TunnelDeps } from "./tunnel.ts";
 
 test("tunnel command structure", () => {
   const testCommandWithOptions = runSync(tunnelCommand, {
@@ -73,6 +73,14 @@ test("relay runner accepts tunnel options without a tunnel service", async () =>
   deepEqual((result as { tunnelService?: unknown }).tunnelService, undefined);
 });
 
+interface RuntimeTunnelOptions {
+  readonly port: number;
+  readonly services?: object;
+  readonly service?: string;
+  readonly exclude?: readonly string[];
+  readonly startupTimeout?: number;
+}
+
 test("tunnel successfully creates and manages tunnel", async () => {
   const mockCommand = {
     command: "tunnel" as const,
@@ -98,15 +106,15 @@ test("tunnel successfully creates and manages tunnel", async () => {
   let openTunnelFailed = false;
   let spinnerMsg;
 
-  const mockDeps = {
-    openTunnel: (args: TunnelOptions) => {
+  const mockDeps: TunnelDeps = {
+    openTunnel(args: RuntimeTunnelOptions) {
       openTunnelCalled = true;
       openTunnelPort = args.port;
       openTunnelService = args.service;
       return Promise.resolve(mockTunnel);
     },
-    ora: () =>
-      ({
+    ora() {
+      return ({
         start() {
           spinnerCalled = true;
           return this;
@@ -121,8 +129,9 @@ test("tunnel successfully creates and manages tunnel", async () => {
           spinnerMsg = msg;
           return this;
         },
-      }) as unknown as Ora,
-    exit: (): never => {
+      }) as unknown as Ora;
+    },
+    exit(): never {
       throw new Error();
     },
   };
@@ -161,15 +170,15 @@ test("tunnel fails to create a secure tunnel and handles error", async () => {
   let openTunnelFailed = false;
   let spinnerMsg;
 
-  const mockDeps = {
-    openTunnel: (args: TunnelOptions) => {
+  const mockDeps: TunnelDeps = {
+    openTunnel(args: RuntimeTunnelOptions) {
       openTunnelCalled = true;
       openTunnelPort = args.port;
       openTunnelService = args.service;
       return Promise.reject();
     },
-    ora: () =>
-      ({
+    ora() {
+      return ({
         start() {
           spinnerCalled = true;
           return this;
@@ -184,8 +193,9 @@ test("tunnel fails to create a secure tunnel and handles error", async () => {
           spinnerMsg = msg;
           return this;
         },
-      }) as unknown as Ora,
-    exit: (): never => {
+      }) as unknown as Ora;
+    },
+    exit(): never {
       throw new Error("Process exit called");
     },
   };

--- a/packages/cli/src/tunnel.test.ts
+++ b/packages/cli/src/tunnel.test.ts
@@ -13,6 +13,9 @@ test("tunnel command structure", () => {
   const testCommandWithoutOptions = runSync(tunnelCommand, {
     args: ["tunnel", "3000"],
   });
+  const testCommandWithFedify = runSync(tunnelCommand, {
+    args: ["tunnel", "3002", "-s", "fedify.com.es"],
+  });
 
   deepEqual(testCommandWithOptions.command, "tunnel");
   deepEqual(testCommandWithOptions.port, 3001);
@@ -20,6 +23,9 @@ test("tunnel command structure", () => {
 
   deepEqual(testCommandWithoutOptions.port, 3000);
   deepEqual(testCommandWithoutOptions.service, undefined);
+
+  deepEqual(testCommandWithFedify.port, 3002);
+  deepEqual(testCommandWithFedify.service, "fedify.com.es");
 });
 
 test("tunnel runner accepts omitted tunnel service", async () => {
@@ -101,6 +107,7 @@ test("tunnel successfully creates and manages tunnel", async () => {
   let openTunnelCalled = false;
   let openTunnelPort;
   let openTunnelService;
+  let openTunnelServices: object | undefined;
   let spinnerCalled = false;
   let openTunnelSucceed = false;
   let openTunnelFailed = false;
@@ -111,6 +118,7 @@ test("tunnel successfully creates and manages tunnel", async () => {
       openTunnelCalled = true;
       openTunnelPort = args.port;
       openTunnelService = args.service;
+      openTunnelServices = args.services;
       return Promise.resolve(mockTunnel);
     },
     ora() {
@@ -142,6 +150,10 @@ test("tunnel successfully creates and manages tunnel", async () => {
     deepEqual(openTunnelCalled, true);
     deepEqual(openTunnelPort, 3001);
     deepEqual(openTunnelService, "pinggy.io");
+    deepEqual(
+      Object.keys(openTunnelServices ?? {}),
+      ["serveo.net", "pinggy.io", "fedify.com.es"],
+    );
     deepEqual(openTunnelSucceed, true);
     deepEqual(openTunnelFailed, false);
     deepEqual(spinnerCalled, true);
@@ -165,6 +177,7 @@ test("tunnel fails to create a secure tunnel and handles error", async () => {
   let openTunnelCalled = false;
   let openTunnelPort;
   let openTunnelService;
+  let openTunnelServices: object | undefined;
   let spinnerCalled = false;
   let openTunnelSucceed = false;
   let openTunnelFailed = false;
@@ -175,6 +188,7 @@ test("tunnel fails to create a secure tunnel and handles error", async () => {
       openTunnelCalled = true;
       openTunnelPort = args.port;
       openTunnelService = args.service;
+      openTunnelServices = args.services;
       return Promise.reject();
     },
     ora() {
@@ -210,6 +224,10 @@ test("tunnel fails to create a secure tunnel and handles error", async () => {
     deepEqual(openTunnelCalled, true);
     deepEqual(openTunnelPort, 3001);
     deepEqual(openTunnelService, undefined);
+    deepEqual(
+      Object.keys(openTunnelServices ?? {}),
+      ["serveo.net", "pinggy.io", "fedify.com.es"],
+    );
     deepEqual(openTunnelSucceed, false);
     deepEqual(openTunnelFailed, true);
     deepEqual(spinnerCalled, true);

--- a/packages/cli/src/tunnel.ts
+++ b/packages/cli/src/tunnel.ts
@@ -14,6 +14,7 @@ import process from "node:process";
 import ora from "ora";
 import { configureLogging } from "./log.ts";
 import { createTunnelServiceOption, type GlobalOptions } from "./options.ts";
+import { TUNNEL_SERVICE_REGISTRY } from "./tunnelservice.ts";
 
 export const tunnelOptions = merge(
   "Tunnel options",
@@ -71,6 +72,7 @@ export async function runTunnel(
   try {
     tunnel = await deps.openTunnel({
       port: command.port,
+      services: TUNNEL_SERVICE_REGISTRY,
       service: command.service,
     });
   } catch (error) {

--- a/packages/cli/src/tunnel.ts
+++ b/packages/cli/src/tunnel.ts
@@ -46,13 +46,15 @@ export const tunnelCommand = command(
   tunnelMetadata,
 );
 
+export interface TunnelDeps {
+  readonly openTunnel: typeof openTunnel;
+  readonly ora: typeof ora;
+  readonly exit: typeof process.exit;
+}
+
 export async function runTunnel(
   command: InferValue<typeof tunnelCommand> & GlobalOptions,
-  deps: {
-    openTunnel: typeof openTunnel;
-    ora: typeof ora;
-    exit: typeof process.exit;
-  } = {
+  deps: TunnelDeps = {
     openTunnel,
     ora,
     exit: process.exit,

--- a/packages/cli/src/tunnelservice.test.ts
+++ b/packages/cli/src/tunnelservice.test.ts
@@ -1,0 +1,71 @@
+import { SERVICES } from "@hongminhee/localtunnel";
+import { deepEqual, doesNotMatch, equal, match } from "node:assert/strict";
+import test from "node:test";
+import {
+  FEDIFY_TUNNEL_SERVICE,
+  TUNNEL_SERVICE_NAMES,
+  TUNNEL_SERVICE_REGISTRY,
+} from "./tunnelservice.ts";
+
+test("Fedify tunnel service uses the public HTTP endpoint", () => {
+  equal(FEDIFY_TUNNEL_SERVICE.host, "fedify.com.es:2222");
+  equal(FEDIFY_TUNNEL_SERVICE.port, 80);
+  deepEqual(FEDIFY_TUNNEL_SERVICE.extraOptions, [
+    "-o",
+    "PubkeyAuthentication=no",
+    "-o",
+    "PasswordAuthentication=no",
+    "-o",
+    "KbdInteractiveAuthentication=no",
+    "-o",
+    "ExitOnForwardFailure=yes",
+    "-o",
+    "ServerAliveInterval=30",
+    "-o",
+    "ServerAliveCountMax=3",
+  ]);
+  deepEqual(FEDIFY_TUNNEL_SERVICE.knownHosts, {
+    "[fedify.com.es]:2222": [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOepK/E2PANumZNFCicc/zv4EkyraFwqV8qveMtDC5b+",
+    ],
+  });
+});
+
+test("Fedify tunnel service accepts only allocated public URL hosts", () => {
+  match(
+    "https://0123456789abcdef.fedify.com.es",
+    FEDIFY_TUNNEL_SERVICE.urlPattern,
+  );
+  match(
+    "https://0123456789abcdef.fedify.com.es/",
+    FEDIFY_TUNNEL_SERVICE.urlPattern,
+  );
+  doesNotMatch(
+    "https://short.fedify.com.es",
+    FEDIFY_TUNNEL_SERVICE.urlPattern,
+  );
+  doesNotMatch(
+    "https://0123456789abcdef.fedify.com.es.example.com",
+    FEDIFY_TUNNEL_SERVICE.urlPattern,
+  );
+});
+
+test("Fedify CLI tunnel registry extends localtunnel services", () => {
+  equal(
+    TUNNEL_SERVICE_REGISTRY["serveo.net"],
+    SERVICES["serveo.net"],
+  );
+  equal(
+    TUNNEL_SERVICE_REGISTRY["pinggy.io"],
+    SERVICES["pinggy.io"],
+  );
+  equal(
+    TUNNEL_SERVICE_REGISTRY["fedify.com.es"],
+    FEDIFY_TUNNEL_SERVICE,
+  );
+  deepEqual(TUNNEL_SERVICE_NAMES, [
+    "serveo.net",
+    "pinggy.io",
+    "fedify.com.es",
+  ]);
+});

--- a/packages/cli/src/tunnelservice.ts
+++ b/packages/cli/src/tunnelservice.ts
@@ -1,0 +1,58 @@
+import {
+  type Service,
+  SERVICES as LOCALTUNNEL_SERVICES,
+} from "@hongminhee/localtunnel";
+
+/**
+ * The Fedify-operated public tunneling service.
+ */
+export const FEDIFY_TUNNEL_SERVICE = {
+  host: "fedify.com.es:2222",
+  port: 80,
+  urlPattern: /https:\/\/[a-z0-9]{16}\.fedify\.com\.es(?=[/\s]|$)/,
+  extraOptions: [
+    "-o",
+    "PubkeyAuthentication=no",
+    "-o",
+    "PasswordAuthentication=no",
+    "-o",
+    "KbdInteractiveAuthentication=no",
+    "-o",
+    "ExitOnForwardFailure=yes",
+    "-o",
+    "ServerAliveInterval=30",
+    "-o",
+    "ServerAliveCountMax=3",
+  ],
+  knownHosts: {
+    // Ed25519 SHA256:MS+vPYDnU2dceunPdykxErOjWoTKQG/Hcy0HFfQc6mg
+    // Verified on July 14, 2026.
+    "[fedify.com.es]:2222": [
+      "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIOepK/E2PANumZNFCicc/zv4EkyraFwqV8qveMtDC5b+",
+    ],
+  },
+} as const satisfies Service;
+
+/**
+ * Available tunneling services for exposing local servers to the public
+ * internet.
+ */
+export const TUNNEL_SERVICE_REGISTRY = {
+  ...LOCALTUNNEL_SERVICES,
+  "fedify.com.es": FEDIFY_TUNNEL_SERVICE,
+} as const;
+
+/**
+ * A valid tunneling service name.
+ */
+export type TunnelService = keyof typeof TUNNEL_SERVICE_REGISTRY;
+
+/**
+ * Available tunneling service names.
+ */
+export const TUNNEL_SERVICE_NAMES = Object.freeze(
+  Object.keys(TUNNEL_SERVICE_REGISTRY) as [
+    TunnelService,
+    ...TunnelService[],
+  ],
+);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -978,8 +978,8 @@ importers:
         specifier: 'catalog:'
         version: 1.20.0
       '@hongminhee/localtunnel':
-        specifier: ^0.3.0
-        version: 0.3.0
+        specifier: ^0.5.0
+        version: 0.5.0
       '@inquirer/prompts':
         specifier: ^7.8.4
         version: 7.10.1(@types/node@22.19.1)
@@ -2964,8 +2964,8 @@ packages:
   '@hackmd/markdown-it-task-lists@2.1.4':
     resolution: {integrity: sha512-njMloWVihC7a7N4zxczv547bgNxPVG3GBzh6Z6f2xnO8/92JaxTmQuMV7YvaKKkOyhh2RW4RT84uSgax8u4qfQ==}
 
-  '@hongminhee/localtunnel@0.3.0':
-    resolution: {integrity: sha512-GRn02MyJIal6DjgDiaLDQhaiTvYlqTLq97bpTNqp2qGnwy4c77pHm6kWPBdSOjmLGPCf2bb/USFKQBgUhafbuA==}
+  '@hongminhee/localtunnel@0.5.0':
+    resolution: {integrity: sha512-1UZvlLwQJQ2vMmVY5+VdzR+7XIg0uA0TDZDv6m+vTipBX5uG0mnCPW2wRc+ZdqjMW11AygbfLskuDC6IuTxQ0w==}
     engines: {bun: '>=1.2.0', deno: '>=2.3.0', node: '>=20.0.0'}
 
   '@hono/node-server@1.14.4':
@@ -14069,7 +14069,7 @@ snapshots:
 
   '@hackmd/markdown-it-task-lists@2.1.4': {}
 
-  '@hongminhee/localtunnel@0.3.0':
+  '@hongminhee/localtunnel@0.5.0':
     dependencies:
       '@logtape/logtape': 1.3.8
 


### PR DESCRIPTION
This pull request adds [fedify.com.es](https://fedify.com.es/) as a tunnel service in Fedify CLI.

fedify.com.es is a public tunneling service for local ActivityPub development. It gives a local HTTP server a temporary HTTPS URL under `*.fedify.com.es`, without requiring an account or a separate tunnel client. The route disappears when the CLI command stops. Its deployment configuration and operating documentation are available in the <https://github.com/fedify-dev/fedify.com.es> repository.

The change upgrades `@hongminhee/localtunnel` to 0.5.0 and defines the service in the CLI-owned tunnel registry. The service connects to the sish endpoint on port 2222 and pins its SSH host key through `Service.knownHosts`, so a mismatched server is rejected before a local port is exposed. The same registry is passed to `openTunnel()` for direct tunnels and temporary servers.

The CLI configuration, help text, tutorials, changelog, and tests have also been updated for the new service.