### PR TITLE
Enforce example registration in `test-examples`

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -39,6 +39,7 @@
     "./examples/lint/oxlint",
     "./examples/monitoring",
     "./examples/rfc-9421-test",
+    "./examples/test-examples",
     "./test/smoke/harness"
   ],
   "imports": {

--- a/examples/test-examples/deno.json
+++ b/examples/test-examples/deno.json
@@ -1,0 +1,6 @@
+{
+  "tasks": {
+    "test": "deno test --allow-all .",
+    "start": "deno run --allow-all mod.ts"
+  }
+}

--- a/examples/test-examples/mod.test.ts
+++ b/examples/test-examples/mod.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Registry-consistency tests for the example test runner.
+ *
+ * Every example directory under examples/ must be registered in exactly one
+ * of the registries in mod.ts (SERVER_EXAMPLES, SCRIPT_EXAMPLES,
+ * MULTI_HANDLE_EXAMPLES, or SKIPPED_EXAMPLES).  These tests fail when a new
+ * example is added without being registered, so it cannot silently miss
+ * automated checks.
+ *
+ * Usage (from repository root):
+ *   deno test --allow-all examples/test-examples
+ */
+import { fromFileUrl } from "@std/path";
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getRegisteredExampleNames, scanUnregisteredExamples } from "./mod.ts";
+
+const EXAMPLES_DIR = fromFileUrl(new URL("../", import.meta.url));
+
+test("Every example in the examples/ directory is registered in test-examples", async () => {
+  const unregistered = await scanUnregisteredExamples();
+  assert.deepEqual(
+    unregistered,
+    [],
+    `Unregistered example directories found: ${unregistered.join(", ")}`,
+  );
+});
+
+test("Every registered example has a matching examples/ directory", async () => {
+  const directories = new Set<string>();
+  for await (const entry of Deno.readDir(EXAMPLES_DIR)) {
+    if (entry.isDirectory) directories.add(entry.name);
+  }
+  const unmatchedExamples = [...getRegisteredExampleNames()]
+    .filter((name) => !directories.has(name))
+    .sort();
+
+  assert.deepEqual(
+    unmatchedExamples,
+    [],
+    `Registered examples without a matching directory found: ${
+      unmatchedExamples.join(", ")
+    }`,
+  );
+});

--- a/examples/test-examples/mod.ts
+++ b/examples/test-examples/mod.ts
@@ -294,6 +294,19 @@ const SERVER_EXAMPLES: ServerExample[] = [
     readyUrl: "http://localhost:3000/",
     readyTimeout: 30_000,
   },
+  {
+    // SolidStart sample using @fedify/solidstart; actor path is
+    // /users/{identifier}.  Built with vinxi build; served with vinxi start
+    // on port 3000.
+    name: "solidstart",
+    dir: "solidstart",
+    buildCmd: ["pnpm", "build"],
+    startCmd: ["pnpm", "start"],
+    port: 3000,
+    actor: "demo",
+    readyUrl: "http://localhost:3000/",
+    readyTimeout: 30_000,
+  },
 ];
 
 const SCRIPT_EXAMPLES: ScriptExample[] = [
@@ -349,6 +362,32 @@ const SKIPPED_EXAMPLES: SkippedExample[] = [
       "Requires live interaction with external fediverse servers (Bonfire, Mastodon)",
   },
 ];
+
+export function getRegisteredExampleNames(): Set<string> {
+  return new Set([
+    ...SERVER_EXAMPLES.map((e) => e.name),
+    ...SCRIPT_EXAMPLES.map((e) => e.name),
+    ...MULTI_HANDLE_EXAMPLES.map((e) => e.name),
+    ...SKIPPED_EXAMPLES.map((e) => e.name),
+  ]);
+}
+
+/**
+ * Scans the examples/ directory and returns the names of sub-directories
+ * that are not registered in any of the registries above.
+ */
+export async function scanUnregisteredExamples(): Promise<string[]> {
+  const registeredNames = getRegisteredExampleNames();
+  const unregistered: string[] = [];
+  for await (const entry of Deno.readDir(EXAMPLES_DIR)) {
+    if (!entry.isDirectory) continue;
+    if (entry.name === "test-examples") continue;
+    if (!registeredNames.has(entry.name)) {
+      unregistered.push(entry.name);
+    }
+  }
+  return unregistered;
+}
 
 // ─── ANSI Colors ──────────────────────────────────────────────────────────────
 
@@ -805,24 +844,8 @@ async function main(): Promise<void> {
   }
 
   // ── Unregistered examples ────────────────────────────────────────────────
-  // Collect every example name that appears in any registry.
-  const registeredNames = new Set([
-    ...SERVER_EXAMPLES.map((e) => e.name),
-    ...SCRIPT_EXAMPLES.map((e) => e.name),
-    ...MULTI_HANDLE_EXAMPLES.map((e) => e.name),
-    ...SKIPPED_EXAMPLES.map((e) => e.name),
-  ]);
-
   // Scan the examples/ directory for sub-directories that are not registered.
-  const unregistered: string[] = [];
-  for await (const entry of Deno.readDir(EXAMPLES_DIR)) {
-    if (!entry.isDirectory) continue;
-    // The test-examples directory is the test runner itself—skip it.
-    if (entry.name === "test-examples") continue;
-    if (!registeredNames.has(entry.name)) {
-      unregistered.push(entry.name);
-    }
-  }
+  const unregistered = await scanUnregisteredExamples();
 
   // ── Summary ──────────────────────────────────────────────────────────────
   const passed = results.filter((r) => r.status === "pass");
@@ -871,4 +894,8 @@ async function main(): Promise<void> {
   Deno.exit(0);
 }
 
-await main();
+// Run the test runner only when this module is executed directly, so that
+// mod.test.ts can import the registry helpers above without side effects.
+if (import.meta.main) {
+  await main();
+}

--- a/examples/test-examples/mod.ts
+++ b/examples/test-examples/mod.ts
@@ -365,11 +365,11 @@ const SKIPPED_EXAMPLES: SkippedExample[] = [
 
 export function getRegisteredExampleNames(): Set<string> {
   return new Set([
-    ...SERVER_EXAMPLES.map((e) => e.name),
-    ...SCRIPT_EXAMPLES.map((e) => e.name),
-    ...MULTI_HANDLE_EXAMPLES.map((e) => e.name),
-    ...SKIPPED_EXAMPLES.map((e) => e.name),
-  ]);
+    ...SERVER_EXAMPLES,
+    ...SCRIPT_EXAMPLES,
+    ...MULTI_HANDLE_EXAMPLES,
+    ...SKIPPED_EXAMPLES,
+  ].map((e) => e.name));
 }
 
 /**

--- a/examples/test-examples/mod.ts
+++ b/examples/test-examples/mod.ts
@@ -108,7 +108,7 @@ interface MultiHandleExample {
   name: string;
   dir: string;
   /** Command prefix—the handle is appended as the final argument. */
-  cmdPrefix?: string[];
+  cmd: string[];
   /** Handles to try, in order.  Pass if any succeeds. */
   handles: string[];
   description: string;


### PR DESCRIPTION
Closes #886

## Summary
- Add registry-consistency tests that fail when an example in the *examples/* directory is unregistered or a registered example has no matching directory.
- Make *examples/test-examples/* a root Deno workspace member so that CI picks up the added tests.
- Register the previously missing solidstart example, and restore the `cmd` field of `MultiHandleExample` that a formatting sweep (74d18f0e) accidentally renamed.

## Test plan
- Tested with `deno test --allow-all examples/test-examples` and `mise test`
- `mkdir examples/zz-fake && deno test --allow-all examples/test-examples` fails, naming the unregistered directory

## Test Screenshots

1. When an example in the *examples/* directory is unregistered
<img width="916" height="590" alt="스크린샷 2026-07-16 오전 2 00 12" src="https://github.com/user-attachments/assets/539d1f88-0793-4ef6-876c-9c5e1f4eb2e1" />

2. When a registered example has no matching directory
<img width="902" height="868" alt="스크린샷 2026-07-16 오전 2 03 33" src="https://github.com/user-attachments/assets/d5c377b5-9044-4582-96a2-30187e10fc33" />

AI assistance disclosure: Claude Code (claude-fable-5) helped implement and verify the change.