### PR TITLE
Remove duplicate response from integration sequence diagram

### DIFF
--- a/docs/manual/integration.md
+++ b/docs/manual/integration.md
@@ -42,7 +42,6 @@ sequenceDiagram
   participant WF as Web framework
 
   Client ->> Fedify: GET /users/alice<br/>(Accept: application/activity+json)
-  Fedify -->> Client: 200 OK
   Fedify ->> AD: GET /users/alice
   AD -->> Fedify: 200 OK
   Fedify -->> Client: 200 OK


### PR DESCRIPTION
I found a duplicate 200 OK response in the sequence diagram in the [How it works](https://fedify.dev/manual/integration#how-it-works) section, so I removed the incorrect line.

# AS-IS

<img width="1017" height="754" alt="image" src="https://github.com/user-attachments/assets/f4382a1e-26e9-41a5-9461-30b96234e43e" />

# TO-BE

<img width="947" height="711" alt="image" src="https://github.com/user-attachments/assets/ce93b9e0-f933-4b8b-a4e8-3ebd9f9b228a" />
