### PR TITLE
Message byte estimation and batching on @fedify/cfworkers

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,12 @@
 Fedify changelog
 ================
 
+Version 2.0.23
+--------------
+
+To be released.
+
+
 Version 2.0.22
 --------------
 

--- a/packages/amqp/deno.json
+++ b/packages/amqp/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/amqp",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts",

--- a/packages/amqp/package.json
+++ b/packages/amqp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/amqp",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "AMQP/RabbitMQ driver for Fedify",
   "keywords": [
     "fedify",

--- a/packages/cfworkers/deno.json
+++ b/packages/cfworkers/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/cfworkers",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "imports": {
     "@cloudflare/workers-types": "npm:@cloudflare/workers-types@^4.20250906.0"

--- a/packages/cfworkers/package.json
+++ b/packages/cfworkers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/cfworkers",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "Adapt Fedify with Cloudflare Workers",
   "keywords": [
     "Fedify",

--- a/packages/cfworkers/src/mod.ts
+++ b/packages/cfworkers/src/mod.ts
@@ -94,6 +94,13 @@ interface WrappedMessage {
 }
 
 /**
+ * enqueueMany Limit settings.
+ */
+const MAX_BATCH_MESSAGES = 100;
+const MAX_ESTIMATED_BATCH_BYTES = 240_000;
+const ESTIMATED_METADATA_BYTES_PER_MESSAGE = 128;
+
+/**
  * Result from {@link WorkersMessageQueue.processMessage}.
  * @since 2.0.0
  */
@@ -339,16 +346,57 @@ export class WorkersMessageQueue implements MessageQueue {
     messages: readonly any[],
     options?: MessageQueueEnqueueOptions,
   ): Promise<void> {
-    const requests: MessageSendRequest[] = messages.map((msg) => ({
-      body: {
+    const utf8Encoder = new TextEncoder();
+
+    const estimateMessageBytes = (body: WrappedMessage): number => {
+      const serialized = JSON.stringify(body);
+
+      if (serialized === undefined) {
+        throw new TypeError("Queue message must be JSON-serializable.");
+      }
+
+      return utf8Encoder.encode(serialized).byteLength +
+        ESTIMATED_METADATA_BYTES_PER_MESSAGE;
+    };
+
+    const delaySeconds = options?.delay?.total("seconds") ?? 0;
+
+    let batch: MessageSendRequest[] = [];
+    let estimatedBatchBytes = 0;
+
+    const flush = async (): Promise<void> => {
+      if (batch.length === 0) return;
+
+      await this.#queue.sendBatch(batch, { delaySeconds });
+
+      batch = [];
+      estimatedBatchBytes = 0;
+    };
+
+    for (const message of messages) {
+      const body = {
         __fedify_ordering_key__: options?.orderingKey,
-        __fedify_payload__: msg,
-      } satisfies WrappedMessage,
-      contentType: "json",
-    }));
-    await this.#queue.sendBatch(requests, {
-      delaySeconds: options?.delay?.total("seconds") ?? 0,
-    });
+        __fedify_payload__: message,
+      } satisfies WrappedMessage;
+
+      const request = {
+        body,
+        contentType: "json",
+      } satisfies MessageSendRequest;
+
+      const messageBytes = estimateMessageBytes(body);
+      const exceedsBatchLimit = batch.length >= MAX_BATCH_MESSAGES ||
+        estimatedBatchBytes + messageBytes > MAX_ESTIMATED_BATCH_BYTES;
+
+      if (batch.length > 0 && exceedsBatchLimit) {
+        await flush();
+      }
+
+      batch.push(request);
+      estimatedBatchBytes += messageBytes;
+    }
+
+    await flush();
   }
 
   /**

--- a/packages/cli/deno.json
+++ b/packages/cli/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/cli",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "exports": "./src/mod.ts",
   "imports": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/cli",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "type": "module",
   "files": [
     "README.md",

--- a/packages/create/package.json
+++ b/packages/create/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/create",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "Create a new Fedify application",
   "keywords": [
     "fedify",

--- a/packages/debugger/deno.json
+++ b/packages/debugger/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/debugger",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.tsx"

--- a/packages/debugger/package.json
+++ b/packages/debugger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/debugger",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "Embedded ActivityPub debug dashboard for Fedify",
   "type": "module",
   "main": "./dist/mod.cjs",

--- a/packages/denokv/deno.json
+++ b/packages/denokv/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/denokv",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "imports": {
     "@std/assert": "jsr:@std/assert@^1.0.13",

--- a/packages/elysia/deno.json
+++ b/packages/elysia/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/elysia",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts"

--- a/packages/elysia/package.json
+++ b/packages/elysia/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/elysia",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "Integrate Fedify with Elysia",
   "keywords": [
     "Fedify",

--- a/packages/express/deno.json
+++ b/packages/express/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/express",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts"

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/express",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "Integrate Fedify with Express",
   "keywords": [
     "Fedify",

--- a/packages/fastify/deno.json
+++ b/packages/fastify/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/fastify",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts"

--- a/packages/fastify/package.json
+++ b/packages/fastify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/fastify",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "Integrate Fedify with Fastify",
   "keywords": [
     "Fedify",

--- a/packages/fedify/deno.json
+++ b/packages/fedify/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/fedify",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts",

--- a/packages/fedify/package.json
+++ b/packages/fedify/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/fedify",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "An ActivityPub server framework",
   "keywords": [
     "ActivityPub",

--- a/packages/fixture/deno.json
+++ b/packages/fixture/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/fixture",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts"

--- a/packages/fresh/deno.json
+++ b/packages/fresh/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/fresh",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "imports": {
     "@fresh/core": "jsr:@fresh/core@^2.1.4",

--- a/packages/h3/deno.json
+++ b/packages/h3/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/h3",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts"

--- a/packages/h3/package.json
+++ b/packages/h3/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/h3",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "Integrate Fedify with h3",
   "keywords": [
     "Fedify",

--- a/packages/hono/deno.json
+++ b/packages/hono/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/hono",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "imports": {
     "@std/assert": "jsr:@std/assert@^1.0.13"

--- a/packages/hono/package.json
+++ b/packages/hono/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/hono",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "Integrate Fedify with Hono",
   "keywords": [
     "Fedify",

--- a/packages/init/deno.json
+++ b/packages/init/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/init",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "exports": "./src/mod.ts",
   "imports": {

--- a/packages/init/package.json
+++ b/packages/init/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/init",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "Project initializer for Fedify",
   "keywords": [
     "fedify",

--- a/packages/koa/deno.json
+++ b/packages/koa/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/koa",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "exports": {
     ".": "./src/index.ts"

--- a/packages/koa/package.json
+++ b/packages/koa/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/koa",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "Integrate Fedify with Koa",
   "keywords": [
     "Fedify",

--- a/packages/lint/deno.json
+++ b/packages/lint/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/lint",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts"

--- a/packages/lint/package.json
+++ b/packages/lint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/lint",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "Fedify linting rules and plugins",
   "keywords": [
     "Fedify",

--- a/packages/nestjs/package.json
+++ b/packages/nestjs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/nestjs",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "Integrate Fedify with Nest.js",
   "keywords": [
     "Fedify",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/next",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "Integrate Fedify with Next.js",
   "keywords": [
     "Fedify",

--- a/packages/postgres/deno.json
+++ b/packages/postgres/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/postgres",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts",

--- a/packages/postgres/package.json
+++ b/packages/postgres/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/postgres",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "PostgreSQL drivers for Fedify",
   "keywords": [
     "fedify",

--- a/packages/redis/deno.json
+++ b/packages/redis/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/redis",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts",

--- a/packages/redis/package.json
+++ b/packages/redis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/redis",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "Redis drivers for Fedify",
   "keywords": [
     "fedify",

--- a/packages/relay/deno.json
+++ b/packages/relay/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/relay",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "imports": {
     "@std/assert": "jsr:@std/assert@^1.0.13"

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/relay",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "ActivityPub relay support for Fedify",
   "keywords": [
     "Fedify",

--- a/packages/sqlite/deno.json
+++ b/packages/sqlite/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/sqlite",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts",

--- a/packages/sqlite/package.json
+++ b/packages/sqlite/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/sqlite",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "SQLite drivers for Fedify",
   "keywords": [
     "fedify",

--- a/packages/sveltekit/deno.json
+++ b/packages/sveltekit/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/sveltekit",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "imports": {
     "@std/assert": "jsr:@std/assert@^1.0.13",

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/sveltekit",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "Integrate Fedify with SvelteKit",
   "keywords": [
     "Fedify",

--- a/packages/testing/deno.json
+++ b/packages/testing/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/testing",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts"

--- a/packages/testing/package.json
+++ b/packages/testing/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/testing",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "Testing utilities for Fedify applications",
   "keywords": [
     "fedify",

--- a/packages/vocab-runtime/deno.json
+++ b/packages/vocab-runtime/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/vocab-runtime",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts",

--- a/packages/vocab-runtime/package.json
+++ b/packages/vocab-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/vocab-runtime",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "homepage": "https://fedify.dev/",
   "repository": {
     "type": "git",

--- a/packages/vocab-tools/deno.json
+++ b/packages/vocab-tools/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/vocab-tools",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts"

--- a/packages/vocab-tools/package.json
+++ b/packages/vocab-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/vocab-tools",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "description": "Code generator for Activity Vocabulary APIs",
   "homepage": "https://fedify.dev/",
   "repository": {

--- a/packages/vocab/deno.json
+++ b/packages/vocab/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/vocab",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts"

--- a/packages/vocab/package.json
+++ b/packages/vocab/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/vocab",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "homepage": "https://fedify.dev/",
   "repository": {
     "type": "git",

--- a/packages/webfinger/deno.json
+++ b/packages/webfinger/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/webfinger",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "license": "MIT",
   "exports": {
     ".": "./src/mod.ts"

--- a/packages/webfinger/package.json
+++ b/packages/webfinger/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fedify/webfinger",
-  "version": "2.0.22",
+  "version": "2.0.23",
   "homepage": "https://fedify.dev/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Summary
---
Fixed `WorkersMessageQueue.enqueueMany()` failing when the given messages exceeded Cloudflare Queues' batch limits of 100 messages or 256 KB per batch.
- Fixes #958 

Assisted-by: chatgpt codex-5.6-sol

Changes
---
- estimates the serialized size of each message
- splits the messages into multiple `sendBatch()` calls