### PR TITLE
Preload the SWICG miscellany JSON-LD context

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,18 @@ Version 2.0.24
 
 To be released.
 
+### @fedify/vocab-runtime
+
+ -  Added <https://purl.archive.org/miscellany> (the
+    [SWICG ActivityPub Miscellaneous Terms] context, referenced by every Bridgy
+    Fed activity) to preloaded JSON-LD contexts.  The context is served through
+    purl.archive.org, which suffers recurring outages; during one, JSON-LD
+    expansion of any activity referencing this URL fails before application
+    handlers can run. [[#965] by Michael Barrett]
+
+[SWICG ActivityPub Miscellaneous Terms]: https://swicg.github.io/miscellany/
+[#965]: https://github.com/fedify-dev/fedify/issues/965
+
 
 Version 2.0.23
 --------------

--- a/packages/vocab-runtime/src/contexts.ts
+++ b/packages/vocab-runtime/src/contexts.ts
@@ -3,6 +3,7 @@
 // cSpell: disable
 
 import joinLemmyContext from "./contexts/join-lemmy.json" with { type: "json" };
+import miscellany from "./contexts/miscellany.json" with { type: "json" };
 
 const preloadedContexts: Record<string, unknown> = {
   "https://www.w3.org/ns/activitystreams": {
@@ -4363,6 +4364,18 @@ const preloadedContexts: Record<string, unknown> = {
       },
     },
   },
+
+  // The SWICG "ActivityPub Miscellaneous Terms" context.  Bridgy Fed (via
+  // granary) references this URL in the @context of every activity it sends,
+  // and other implementations use it as the recommended home for widely
+  // deployed extension terms like as:Hashtag and as:sensitive.  It is served
+  // through purl.archive.org (Internet Archive's PURL service), which suffers
+  // recurring outages; while it is unreachable, every activity referencing
+  // this URL fails JSON-LD expansion before application handlers run.  The
+  // document is a deliberately stable, versioned SWICG deliverable, so we
+  // ship a built-in copy.
+  // See: https://swicg.github.io/miscellany/
+  "https://purl.archive.org/miscellany": miscellany,
 };
 
 export default preloadedContexts;

--- a/packages/vocab-runtime/src/contexts/miscellany.json
+++ b/packages/vocab-runtime/src/contexts/miscellany.json
@@ -1,0 +1,19 @@
+{
+  "@context": {
+    "as": "https://www.w3.org/ns/activitystreams#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "Hashtag": "as:Hashtag",
+    "manuallyApprovesFollowers": {
+      "@id": "as:manuallyApprovesFollowers",
+      "@type": "xsd:boolean"
+    },
+    "movedTo": {
+      "@id": "as:movedTo",
+      "@type": "@id"
+    },
+    "sensitive": {
+      "@id": "as:sensitive",
+      "@type": "xsd:boolean"
+    }
+  }
+}


### PR DESCRIPTION
Fixes #965

Adds `https://purl.archive.org/miscellany` (the [SWICG "ActivityPub Miscellaneous Terms" context](https://swicg.github.io/miscellany/)) to the preloaded JSON-LD contexts in `@fedify/vocab-runtime`, following the same shape as the Lemmy context change (#714): bundled JSON asset + `preloadedContexts` entry

The bundled document is a byte-for-byte copy of the canonical context (the current version, immutable at <https://purl.archive.org/miscellany/1.0.0>)

See #965 for the full rationale: Bridgy Fed references this context in every activity it delivers, and `purl.archive.org` outages currently fail JSON-LD expansion of all those activities before application handlers run

Testing: `mise run check-each vocab-runtime` passes, and the vocab-runtime test suites pass on Deno and Node (the existing "preloaded contexts" test in `docloader.test.ts` covers the new entry automatically)

### AI disclosure

AI-assisted (`OpenCode` with `claude-fable-5`; `Assisted-by` trailer on the commit). The agent did the investigation, authored the change following the #714 precedent, and ran the checks; I reviewed and verified the work. The bundled JSON was fetched from the canonical URL, not generated