### PR TITLE
Avoid duplicate response headers on Elysia 1.4.18 and earlier

### DIFF
--- a/.hongdown.toml
+++ b/.hongdown.toml
@@ -7,6 +7,7 @@ exclude = [
   ".github/copilot-instructions.md",
   "AGENT.md",
   "CLAUDE.md",
+  "changes.d/**",
   "GEMINI.md",
   "WARP.md",
   "packages/fedify/src/cfworkers/**",

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@ To be released.
  -  Fixed duplicate response headers on Elysia 1.4.18 and earlier, which
     append both `set.headers` and the returned `Response`'s own headers
     without deduplication.  The `fedify()` plugin no longer sets the headers
-    in both places.  [[#970], [#972]]
+    in both places.  [[#970], [#972] by dktsudgg]
 
 [#970]: https://github.com/fedify-dev/fedify/issues/970
 [#972]: https://github.com/fedify-dev/fedify/pull/972

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,16 @@ Version 1.8.16
 
 To be released.
 
+### @fedify/elysia
+
+ -  Fixed duplicate response headers on Elysia 1.4.18 and earlier, which
+    append both `set.headers` and the returned `Response`'s own headers
+    without deduplication.  The `fedify()` plugin no longer sets the headers
+    in both places.  [[#970], [#972]]
+
+[#970]: https://github.com/fedify-dev/fedify/issues/970
+[#972]: https://github.com/fedify-dev/fedify/pull/972
+
 
 Version 1.8.15
 --------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@ To be released.
  -  Fixed duplicate response headers on Elysia 1.4.18 and earlier, which
     append both `set.headers` and the returned `Response`'s own headers
     without deduplication.  The `fedify()` plugin no longer sets the headers
-    in both places.  [[#970], [#972] by dktsudgg\]
+    in both places.  [[#970], [#972] by Kyujin Lim\]
 
 [#970]: https://github.com/fedify-dev/fedify/issues/970
 [#972]: https://github.com/fedify-dev/fedify/pull/972

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@ To be released.
     in both places.  [[#970], [#972] by dktsudgg\]
 
 [#970]: https://github.com/fedify-dev/fedify/issues/970
-[#972]: https://github.com/fedify-dev/fedify/issues/972
+[#972]: https://github.com/fedify-dev/fedify/pull/972
 
 
 Version 2.0.24

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,16 @@ Version 2.0.25
 
 To be released.
 
+### @fedify/elysia
+
+ -  Fixed duplicate response headers on Elysia 1.4.18 and earlier, which
+    append both `set.headers` and the returned `Response`'s own headers
+    without deduplication.  The `fedify()` plugin no longer sets the headers
+    in both places.  [[#970], [#972] by dktsudgg\]
+
+[#970]: https://github.com/fedify-dev/fedify/issues/970
+[#972]: https://github.com/fedify-dev/fedify/issues/972
+
 
 Version 2.0.24
 --------------

--- a/changes.d/elysia/duplicate-response-headers.md
+++ b/changes.d/elysia/duplicate-response-headers.md
@@ -1,4 +1,4 @@
  -  Fixed duplicate response headers on Elysia 1.4.18 and earlier, which
     append both `set.headers` and the returned `Response`'s own headers
     without deduplication.  The `fedify()` plugin no longer sets the headers
-    in both places.  [[#970], [#972] by dktsudgg]
+    in both places.  [[#970], [#972] by Kyujin Lim]

--- a/changes.d/elysia/duplicate-response-headers.md
+++ b/changes.d/elysia/duplicate-response-headers.md
@@ -1,0 +1,4 @@
+ -  Fixed duplicate response headers on Elysia 1.4.18 and earlier, which
+    append both `set.headers` and the returned `Response`'s own headers
+    without deduplication.  The `fedify()` plugin no longer sets the headers
+    in both places.  [[#970], [#972] by dktsudgg]

--- a/changes.d/elysia/duplicate-response-headers.md
+++ b/changes.d/elysia/duplicate-response-headers.md
@@ -1,3 +1,8 @@
+---
+links:
+  '#970': https://github.com/fedify-dev/fedify/issues/970
+  '#972': https://github.com/fedify-dev/fedify/pull/972
+---
  -  Fixed duplicate response headers on Elysia 1.4.18 and earlier, which
     append both `set.headers` and the returned `Response`'s own headers
     without deduplication.  The `fedify()` plugin no longer sets the headers

--- a/packages/elysia/src/index.ts
+++ b/packages/elysia/src/index.ts
@@ -42,14 +42,14 @@ export const fedify = <TContextData = unknown>(
         if (!notFound && !notAcceptable) {
           set.status = response.status;
 
-          response.headers.forEach((value, key) => {
-            set.headers[key] = value;
-          });
-
           // Return response body if it exists
           if (response.body) {
             return response;
           }
+
+          response.headers.forEach((value, key) => {
+            set.headers[key] = value;
+          });
 
           // Return empty response for successful requests without body
           return new Response(null, { status: response.status });


### PR DESCRIPTION
Fixes #970.

`@fedify/elysia`'s `fedify()` plugin copies the federation response headers into `set.headers` and then returns the same `Response` object.

When the response has a body, that `Response` already carries its own headers,
so on Elysia 1.4.18 and earlier(where Elysia merges `set.headers` into the returned response by appending unconditionally) every response header ends up duplicated.
(for example : `Content-Type: application/activity+json, application/activity+json`)

Elysia 1.4.19 changed the merge to skip headers the response already has, which masks the bug, but the package still supports Elysia `^1.3.6`, so users on 1.4.18 and earlier receive malformed federation responses that a strict ActivityPub peer can reject.

This change moves the early `return response` (the case where the response has a body) above the header copy,
so the copy only runs on the bodyless path where a fresh `new Response(null, …)` needs the headers.
When there is a body the `Response` is returned untouched, so there is nothing for Elysia to merge back in, and the headers are no longer duplicated on any Elysia version.

See #970 for the details.

Assisted-by: Claude Code:claude-fable-5