### PR TITLE
List the h3 example in the examples index

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -14,6 +14,8 @@ added in the future.[^1]
  -  [Fedi badge]
  -  [Ghost's ActivityPub server]
  -  [Hollo: a federated single-user microblogging software]
+ -  [H3 integration example](./h3/), which demonstrates serving a Fedify
+    federation through an H3 application
  -  [Hono integration sample](./hono-sample/)
  -  [Fastify integration example](./fastify/)
  -  [Fedify–Express integration example](./express/)


### PR DESCRIPTION
The h3 example was easy to miss because *examples/README.md* did not list it. This adds the existing example to the index with a short description of the H3 integration it demonstrates.

Closes #884

Verification
============

 -  `/tmp/hongdown --check examples/README.md`
 -  `git diff --check`
 -  Confirmed the link target contains the H3 application and Fedify integration source files

AI assistance
=============

OpenAI Codex (`gpt-5.6`) assisted with repository policy review, wording, and validation commands. I reviewed the final diff and ran the repository-pinned Hongdown 0.5.3 check locally.
