### PR TITLE
Reject standalone keys with mismatched IDs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,14 @@ Version 2.0.25
 
 To be released.
 
+### @fedify/fedify
+
+ -  Standalone key documents whose `id` differs from the requested key URL are
+    now rejected instead of being cached under the wrong URL. [[#963]] by
+    ojspp41
+
+[#963]: https://github.com/fedify-dev/fedify/issues/963
+
 
 Version 2.0.24
 --------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,10 +11,11 @@ To be released.
 ### @fedify/fedify
 
  -  Standalone key documents whose `id` differs from the requested key URL are
-    now rejected instead of being cached under the wrong URL. [[#963]] by
-    ojspp41
+    now rejected instead of being cached under the wrong URL.
+    ([#963], [#980] by Junseok Oh)
 
 [#963]: https://github.com/fedify-dev/fedify/issues/963
+[#980]: https://github.com/fedify-dev/fedify/issues/980
 
 
 Version 2.0.24

--- a/changes.d/fedify/mismatched-key-id.md
+++ b/changes.d/fedify/mismatched-key-id.md
@@ -1,5 +1,6 @@
  -  Standalone key documents whose `id` differs from the requested key URL are
-    now rejected instead of being cached under the wrong URL. [[#963]] by
-    ojspp41
+    now rejected instead of being cached under the wrong URL.
+    ([#963], [#980] by Junseok Oh)
 
 [#963]: https://github.com/fedify-dev/fedify/issues/963
+[#980]: https://github.com/fedify-dev/fedify/issues/980

--- a/changes.d/fedify/mismatched-key-id.md
+++ b/changes.d/fedify/mismatched-key-id.md
@@ -1,0 +1,5 @@
+ -  Standalone key documents whose `id` differs from the requested key URL are
+    now rejected instead of being cached under the wrong URL. [[#963]] by
+    ojspp41
+
+[#963]: https://github.com/fedify-dev/fedify/issues/963

--- a/packages/fedify/src/sig/key.test.ts
+++ b/packages/fedify/src/sig/key.test.ts
@@ -352,6 +352,65 @@ test("fetchKey()", async () => {
   );
 });
 
+test("fetchKey() rejects standalone keys with a mismatched id", async () => {
+  for (
+    const { keyId, standaloneKey, fetch } of [
+      {
+        keyId: "https://example.com/key",
+        standaloneKey: rsaPublicKey1,
+        fetch: (keyId: string, options: FetchKeyOptions) =>
+          fetchKey(keyId, CryptographicKey, options),
+      },
+      {
+        keyId: "https://example.com/multikey",
+        standaloneKey: ed25519Multikey,
+        fetch: (keyId: string, options: FetchKeyOptions) =>
+          fetchKey(keyId, Multikey, options),
+      },
+    ]
+  ) {
+    const cache: Record<string, CryptographicKey | Multikey | null> = {};
+    const options: FetchKeyOptions = {
+      async documentLoader(resource) {
+        if (resource === keyId) {
+          const document = await standaloneKey.toJsonLd({
+            contextLoader: mockDocumentLoader,
+          });
+          return {
+            contextUrl: null,
+            documentUrl: resource,
+            document: {
+              ...document as Record<string, unknown>,
+              id: "https://example.com/different-key",
+            },
+          };
+        }
+        return await mockDocumentLoader(resource);
+      },
+      contextLoader: mockDocumentLoader,
+      keyCache: {
+        get(keyId) {
+          return Promise.resolve(cache[keyId.href]);
+        },
+        set(keyId, key) {
+          cache[keyId.href] = key;
+          return Promise.resolve();
+        },
+      } satisfies KeyCache,
+    };
+
+    assertEquals(await fetch(keyId, options), {
+      key: null,
+      cached: false,
+    });
+    assertEquals(cache, { [keyId]: null });
+    assertEquals(await fetch(keyId, options), {
+      key: null,
+      cached: true,
+    });
+  }
+});
+
 test("fetchKey() returns null for a malformed actor publicKey", async () => {
   const actorId = "https://example.com/malformed-public-key";
   const keyId = "https://example.com/malformed-public-key#main-key";

--- a/packages/fedify/src/sig/key.ts
+++ b/packages/fedify/src/sig/key.ts
@@ -323,7 +323,10 @@ async function fetchKeyInternal<T extends CryptographicKey | Multikey>(
     }
   }
   let key: T | null = null;
-  if (object instanceof cls) key = object;
+  if (
+    object instanceof cls &&
+    (object.id == null || object.id.href === keyId)
+  ) key = object;
   else if (isActor(object)) {
     // Treat malformed remote actor keys as missing keys.
     // @ts-ignore: cls is either CryptographicKey or Multikey


### PR DESCRIPTION
## Background

`fetchKey()` accepts either an actor document containing keys or a standalone `CryptographicKey`/`Multikey` document.

The actor branch already checks candidate key IDs against the requested `keyId`. The standalone branch previously accepted any object of the requested key class without checking its `id`. As a result, a document fetched from one URL could declare a different ID and still be returned and cached under the requested URL.

Although this does not let the key impersonate another actor—the owner/controller checks remain responsible for binding a key to an actor—it leaves the fetched key identity inconsistent with its lookup and cache key.

## Changes

- Accept a standalone key when it has no `id`, preserving the existing compatibility behavior.
- Accept a standalone key with an `id` only when its URL exactly matches the requested `keyId`.
- Reject and negatively cache standalone key documents whose present `id` differs from the requested URL.
- Keep actor key resolution unchanged, including the existing fragmentless single-key tolerance.
- Add a changelog fragment for `@fedify/fedify`.

## Regression coverage

The regression test supplies standalone key documents whose IDs differ from their requested URLs and verifies that:

- both `CryptographicKey` and `Multikey` documents are rejected;
- the first lookup returns `{ key: null, cached: false }`;
- the unavailable result is cached under the requested URL; and
- a repeated lookup returns the negative cache entry with `cached: true`.

I also confirmed that the new regression test fails against the previous standalone-key behavior and passes with this change.

## Existing cache entries

This change validates newly fetched standalone key documents. It does not retroactively validate or evict mismatched key objects that may already exist in a persistent `KeyCache` from before the upgrade.

I kept existing cache-entry handling out of scope because #963 specifically concerns resolving a fetched standalone document, and cache storage and retention are provided by the application. I am happy to add validation or stale-entry handling for cached keys in this PR if the maintainers prefer that behavior.

## Testing

The following checks passed locally:

- `mise exec -- deno test --check --doc --allow-all --unstable-kv --trace-leaks packages/fedify/src/sig/key.test.ts`
- `mise run check-each fedify`
- `mise run test-each fedify` (Deno, Node.js, and Bun)
- `mise run check`

Fixes #963.

## AI usage

Implementation, regression-test drafting, code review, and local verification were assisted by Codex (GPT-5.6 Sol; model ID: `gpt-5.6-sol`). I reviewed the resulting change and exercised it locally using the Deno, Node.js, and Bun workflows listed above.
