### PR TITLE
Cover Express not-found delegation

### DIFF
--- a/packages/express/src/index.test.ts
+++ b/packages/express/src/index.test.ts
@@ -1,0 +1,41 @@
+import type { Federation } from "@fedify/fedify";
+import type {
+  NextFunction,
+  Request as ERequest,
+  Response as EResponse,
+} from "express";
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import { integrateFederation } from "./index.ts";
+
+test("integrateFederation delegates not-found requests to Express", async () => {
+  let nextCalls = 0;
+  const federation = {
+    fetch: (
+      _request: Request,
+      options: { onNotFound: () => Response },
+    ) => {
+      options.onNotFound();
+      return new Response("unused", { status: 404 });
+    },
+  } as unknown as Federation<void>;
+
+  const request = {
+    protocol: "https",
+    host: "example.com",
+    url: "/not-a-federation-route",
+    method: "GET",
+    headers: {},
+  } as ERequest;
+  const response = {} as EResponse;
+  const next: NextFunction = () => {
+    nextCalls++;
+  };
+
+  const middleware = integrateFederation(federation, () => undefined);
+  middleware(request, response, next);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+
+  assert.equal(nextCalls, 1);
+});


### PR DESCRIPTION
## Summary
- Add focused `@fedify/express` regression coverage for not-found delegation.
- Assert Express `next()` is invoked when Fedify calls `onNotFound`.

Fixes https://github.com/fedify-dev/fedify/issues/857

## Validation
- `node --experimental-transform-types --test packages/express/src/index.test.ts`
- `deno fmt --check packages/express/src/index.test.ts`
- `deno lint --no-config packages/express/src/index.test.ts`

The repository-wide `mise run check-each express` was not completed in this checkout because the pinned clean-checkout bootstrap attempted uncached monorepo downloads; the focused regression, formatting, and lint checks pass.

AI disclosure: OpenAI Codex (GPT-5) assisted with the implementation and validation of this issue-scoped test.