### PR TITLE
Consolidate relay protocol handling

### DIFF
--- a/packages/relay/src/base.ts
+++ b/packages/relay/src/base.ts
@@ -1,12 +1,39 @@
-import type { Context, Federation, FederationBuilder } from "@fedify/fedify";
-import { isActor, Object as APObject } from "@fedify/vocab";
+import type {
+  Context,
+  Federation,
+  FederationBuilder,
+  InboxContext,
+  InboxListenerSetters,
+} from "@fedify/fedify";
+import {
+  type Actor,
+  Announce,
+  Create,
+  Delete,
+  Follow,
+  isActor,
+  Move,
+  Object as APObject,
+  Undo,
+  Update,
+} from "@fedify/vocab";
+import type { Logger } from "@logtape/logtape";
+import {
+  handleUndoFollow,
+  sendFollowResponse,
+  validateFollowActivity,
+} from "./follow.ts";
 import {
   isRelayFollowerData,
   type Relay,
   RELAY_SERVER_ACTOR,
   type RelayFollower,
+  type RelayFollowerState,
   type RelayOptions,
 } from "./types.ts";
+
+/** @internal */
+export type RelayableActivity = Create | Delete | Move | Update | Announce;
 
 /**
  * Abstract base class for relay implementations.
@@ -18,6 +45,9 @@ export abstract class BaseRelay implements Relay {
   protected federationBuilder: FederationBuilder<RelayOptions>;
   protected options: RelayOptions;
   protected federation?: Federation<RelayOptions>;
+
+  protected abstract readonly initialFollowerState: RelayFollowerState;
+  protected abstract readonly logger: Logger;
 
   constructor(
     options: RelayOptions,
@@ -126,11 +156,97 @@ export abstract class BaseRelay implements Relay {
     return await this.parseFollowerData(actorId, followerData);
   }
 
-  /**
-   * Set up inbox listeners for handling ActivityPub activities.
-   * Each relay type implements this method with protocol-specific logic.
-   */
-  protected abstract setupInboxListeners(): void;
+  protected shouldSkipFollow(
+    _ctx: InboxContext<RelayOptions>,
+    _follower: Actor,
+  ): Promise<boolean> {
+    return Promise.resolve(false);
+  }
+
+  protected afterFollowApproved(
+    _ctx: InboxContext<RelayOptions>,
+    _follower: Actor,
+  ): Promise<void> {
+    return Promise.resolve();
+  }
+
+  protected abstract deliverActivity(
+    ctx: InboxContext<RelayOptions>,
+    activity: RelayableActivity,
+    excludeBaseUris: URL[],
+  ): Promise<void>;
+
+  async #handleFollow(
+    ctx: InboxContext<RelayOptions>,
+    follow: Follow,
+  ): Promise<void> {
+    const follower = await validateFollowActivity(ctx, follow);
+    if (follower?.id == null || await this.shouldSkipFollow(ctx, follower)) {
+      return;
+    }
+
+    const approved = await this.options.subscriptionHandler(ctx, follower);
+    if (approved) {
+      await ctx.data.kv.set(
+        ["follower", follower.id.href],
+        {
+          actor: await follower.toJsonLd(),
+          state: this.initialFollowerState,
+        },
+      );
+    }
+
+    await sendFollowResponse(ctx, follow, follower, approved);
+    if (approved) await this.afterFollowApproved(ctx, follower);
+  }
+
+  async #relayActivity(
+    ctx: InboxContext<RelayOptions>,
+    activity: RelayableActivity,
+  ): Promise<void> {
+    const sender = await activity.getActor(ctx);
+    const excludeBaseUris = sender?.id == null ? [] : [new URL(sender.id)];
+    await this.deliverActivity(ctx, activity, excludeBaseUris);
+  }
+
+  protected setupInboxListeners(): InboxListenerSetters<RelayOptions> {
+    if (this.federation == null) {
+      throw new Error("Federation must be initialized before inbox listeners");
+    }
+
+    const listeners = this.federation.setInboxListeners(
+      "/users/{identifier}/inbox",
+      "/inbox",
+    );
+    listeners
+      .on(Follow, async (ctx, follow) => await this.#handleFollow(ctx, follow))
+      .on(
+        Undo,
+        async (ctx, undo) => await handleUndoFollow(ctx, undo, this.logger),
+      )
+      .on(
+        Create,
+        async (ctx, create) => await this.#relayActivity(ctx, create),
+      )
+      .on(
+        Delete,
+        async (ctx, deleteActivity) =>
+          await this.#relayActivity(ctx, deleteActivity),
+      )
+      .on(
+        Move,
+        async (ctx, move) => await this.#relayActivity(ctx, move),
+      )
+      .on(
+        Update,
+        async (ctx, update) => await this.#relayActivity(ctx, update),
+      )
+      .on(
+        Announce,
+        async (ctx, announce) => await this.#relayActivity(ctx, announce),
+      );
+    return listeners;
+  }
 
   async #getFederation(): Promise<Federation<RelayOptions>> {
     if (this.federation == null) {

--- a/packages/relay/src/base.ts
+++ b/packages/relay/src/base.ts
@@ -11,9 +11,7 @@ import {
   Create,
   Delete,
   Follow,
-  isActor,
   Move,
-  Object as APObject,
   Undo,
   Update,
 } from "@fedify/vocab";
@@ -24,7 +22,7 @@ import {
   validateFollowActivity,
 } from "./follow.ts";
 import {
-  isRelayFollowerData,
+  parseRelayFollowerData,
   type Relay,
   RELAY_SERVER_ACTOR,
   type RelayFollower,
@@ -64,31 +62,6 @@ export abstract class BaseRelay implements Relay {
   }
 
   /**
-   * Helper method to parse and validate follower data from storage.
-   * Deserializes JSON-LD actor data and validates it.
-   *
-   * @param actorId The actor ID of the follower
-   * @param data Raw data from KV store
-   * @returns RelayFollower object if valid, null otherwise
-   * @internal
-   */
-  private async parseFollowerData(
-    actorId: string,
-    data: unknown,
-  ): Promise<RelayFollower | null> {
-    if (!isRelayFollowerData(data)) return null;
-
-    const actor = await APObject.fromJsonLd(data.actor);
-    if (!isActor(actor)) return null;
-
-    return {
-      actorId,
-      actor,
-      state: data.state,
-    };
-  }
-
-  /**
    * Lists all followers of the relay.
    *
    * @returns An async iterator of follower entries
@@ -118,7 +91,7 @@ export abstract class BaseRelay implements Relay {
       const actorId = entry.key[1];
       if (typeof actorId !== "string") continue;
 
-      const follower = await this.parseFollowerData(actorId, entry.value);
+      const follower = await parseRelayFollowerData(actorId, entry.value);
       if (follower) yield follower;
     }
   }
@@ -153,7 +126,7 @@ export abstract class BaseRelay implements Relay {
    */
   async getFollower(actorId: string): Promise<RelayFollower | null> {
     const followerData = await this.options.kv.get(["follower", actorId]);
-    return await this.parseFollowerData(actorId, followerData);
+    return await parseRelayFollowerData(actorId, followerData);
   }
 
   protected shouldSkipFollow(

--- a/packages/relay/src/base.ts
+++ b/packages/relay/src/base.ts
@@ -204,8 +204,8 @@ export abstract class BaseRelay implements Relay {
     ctx: InboxContext<RelayOptions>,
     activity: RelayableActivity,
   ): Promise<void> {
-    const sender = await activity.getActor(ctx);
-    const excludeBaseUris = sender?.id == null ? [] : [new URL(sender.id)];
+    const senderId = activity.actorId;
+    const excludeBaseUris = senderId == null ? [] : [senderId];
     await this.deliverActivity(ctx, activity, excludeBaseUris);
   }
 

--- a/packages/relay/src/builder.ts
+++ b/packages/relay/src/builder.ts
@@ -7,9 +7,9 @@ import {
   importJwk,
 } from "@fedify/fedify";
 import type { Actor } from "@fedify/vocab";
-import { Application, isActor, Object } from "@fedify/vocab";
+import { Application } from "@fedify/vocab";
 import {
-  isRelayFollowerData,
+  parseRelayFollowerData,
   RELAY_SERVER_ACTOR,
   type RelayOptions,
 } from "./types.ts";
@@ -78,12 +78,12 @@ async function getFollowerActors(
 ): Promise<Actor[]> {
   const actors: Actor[] = [];
 
-  for await (const { value } of ctx.data.kv.list(["follower"])) {
-    if (!isRelayFollowerData(value)) continue;
-    if (value.state !== "accepted") continue;
-    const actor = await Object.fromJsonLd(value.actor);
-    if (!isActor(actor)) continue;
-    actors.push(actor);
+  for await (const { key, value } of ctx.data.kv.list(["follower"])) {
+    const actorId = key[1];
+    if (typeof actorId !== "string") continue;
+    const follower = await parseRelayFollowerData(actorId, value);
+    if (follower?.state !== "accepted") continue;
+    actors.push(follower.actor);
   }
 
   return actors;

--- a/packages/relay/src/litepub.test.ts
+++ b/packages/relay/src/litepub.test.ts
@@ -583,64 +583,64 @@ describe("LitePubRelay", () => {
     strictEqual(followerData.state, "accepted");
   });
 
-  test("handles Undo Follow activity", async () => {
-    const kv = new MemoryKvStore();
+  for (const state of ["pending", "accepted"] as const) {
+    test(`handles Undo Follow activity for ${state} follower`, async () => {
+      const kv = new MemoryKvStore();
 
-    // Pre-populate with an accepted follower
-    const followerId = "https://remote.example.com/users/alice";
-    const follower = new Person({
-      id: new URL(followerId),
-      preferredUsername: "alice",
-      inbox: new URL("https://remote.example.com/users/alice/inbox"),
+      const followerId = "https://remote.example.com/users/alice";
+      const follower = new Person({
+        id: new URL(followerId),
+        preferredUsername: "alice",
+        inbox: new URL("https://remote.example.com/users/alice/inbox"),
+      });
+
+      await kv.set(
+        ["follower", followerId],
+        { actor: await follower.toJsonLd(), state },
+      );
+
+      const relay = createRelay("litepub", {
+        kv,
+        origin: "https://relay.example.com",
+        documentLoaderFactory: () => mockDocumentLoader,
+        authenticatedDocumentLoaderFactory: () => mockDocumentLoader,
+        subscriptionHandler: () => Promise.resolve(true),
+      });
+
+      const originalFollow = new Follow({
+        id: new URL("https://remote.example.com/activities/follow/1"),
+        actor: new URL(followerId),
+        object: new URL("https://relay.example.com/users/relay"),
+      });
+
+      const undoActivity = new Undo({
+        id: new URL("https://remote.example.com/activities/undo/1"),
+        actor: new URL(followerId),
+        object: originalFollow,
+      });
+
+      let request = new Request("https://relay.example.com/inbox", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/activity+json",
+        },
+        body: JSON.stringify(
+          await undoActivity.toJsonLd({ contextLoader: mockDocumentLoader }),
+        ),
+      });
+
+      request = await signRequest(
+        request,
+        rsaKeyPair.privateKey,
+        rsaPublicKey.id,
+      );
+
+      await relay.fetch(request);
+
+      const followerData = await kv.get(["follower", followerId]);
+      strictEqual(followerData, undefined);
     });
-
-    await kv.set(
-      ["follower", followerId],
-      { actor: await follower.toJsonLd(), state: "accepted" },
-    );
-
-    const relay = createRelay("litepub", {
-      kv,
-      origin: "https://relay.example.com",
-      documentLoaderFactory: () => mockDocumentLoader,
-      authenticatedDocumentLoaderFactory: () => mockDocumentLoader,
-      subscriptionHandler: () => Promise.resolve(true),
-    });
-
-    const originalFollow = new Follow({
-      id: new URL("https://remote.example.com/activities/follow/1"),
-      actor: new URL(followerId),
-      object: new URL("https://relay.example.com/users/relay"),
-    });
-
-    const undoActivity = new Undo({
-      id: new URL("https://remote.example.com/activities/undo/1"),
-      actor: new URL(followerId),
-      object: originalFollow,
-    });
-
-    let request = new Request("https://relay.example.com/inbox", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/activity+json",
-      },
-      body: JSON.stringify(
-        await undoActivity.toJsonLd({ contextLoader: mockDocumentLoader }),
-      ),
-    });
-
-    request = await signRequest(
-      request,
-      rsaKeyPair.privateKey,
-      rsaPublicKey.id,
-    );
-
-    await relay.fetch(request);
-
-    // Verify follower was removed
-    const followerData = await kv.get(["follower", followerId]);
-    strictEqual(followerData, undefined);
-  });
+  }
 
   test("handles Create activity with Announce forwarding", async () => {
     const kv = new MemoryKvStore();

--- a/packages/relay/src/litepub.test.ts
+++ b/packages/relay/src/litepub.test.ts
@@ -467,47 +467,60 @@ describe("LitePubRelay", () => {
   });
 
   test("replaces malformed follower data on Follow", async () => {
-    const kv = new MemoryKvStore();
     const followerId = "https://remote.example.com/users/alice";
-    await kv.set(["follower", followerId], { state: "pending" });
-    let handlerCallCount = 0;
-
-    const relay = createRelay("litepub", {
-      kv,
-      origin: "https://relay.example.com",
-      documentLoaderFactory: () => mockDocumentLoader,
-      authenticatedDocumentLoaderFactory: () => mockDocumentLoader,
-      subscriptionHandler: () => {
-        handlerCallCount++;
-        return Promise.resolve(true);
-      },
+    const mismatchedActor = new Person({
+      id: new URL("https://remote.example.com/users/bob"),
     });
+    const malformedRows = [
+      { state: "pending" },
+      { actor: null, state: "pending" },
+      { actor: {}, state: "pending" },
+      { actor: await mismatchedActor.toJsonLd(), state: "pending" },
+    ];
 
-    const followActivity = new Follow({
-      id: new URL("https://remote.example.com/activities/follow/1"),
-      actor: new URL(followerId),
-      object: new URL("https://relay.example.com/users/relay"),
-    });
-    let request = new Request("https://relay.example.com/inbox", {
-      method: "POST",
-      headers: { "Content-Type": "application/activity+json" },
-      body: JSON.stringify(
-        await followActivity.toJsonLd({ contextLoader: mockDocumentLoader }),
-      ),
-    });
-    request = await signRequest(
-      request,
-      rsaKeyPair.privateKey,
-      rsaPublicKey.id,
-    );
+    for (const malformedRow of malformedRows) {
+      const kv = new MemoryKvStore();
+      await kv.set(["follower", followerId], malformedRow);
+      let handlerCallCount = 0;
 
-    await relay.fetch(request);
+      const relay = createRelay("litepub", {
+        kv,
+        origin: "https://relay.example.com",
+        documentLoaderFactory: () => mockDocumentLoader,
+        authenticatedDocumentLoaderFactory: () => mockDocumentLoader,
+        subscriptionHandler: () => {
+          handlerCallCount++;
+          return Promise.resolve(true);
+        },
+      });
+      strictEqual(await relay.getFollower(followerId), null);
 
-    strictEqual(handlerCallCount, 1);
-    const follower = await relay.getFollower(followerId);
-    ok(follower);
-    strictEqual(follower.state, "pending");
-    strictEqual(follower.actor.id?.href, followerId);
+      const followActivity = new Follow({
+        id: new URL("https://remote.example.com/activities/follow/1"),
+        actor: new URL(followerId),
+        object: new URL("https://relay.example.com/users/relay"),
+      });
+      let request = new Request("https://relay.example.com/inbox", {
+        method: "POST",
+        headers: { "Content-Type": "application/activity+json" },
+        body: JSON.stringify(
+          await followActivity.toJsonLd({ contextLoader: mockDocumentLoader }),
+        ),
+      });
+      request = await signRequest(
+        request,
+        rsaKeyPair.privateKey,
+        rsaPublicKey.id,
+      );
+
+      await relay.fetch(request);
+
+      strictEqual(handlerCallCount, 1);
+      const follower = await relay.getFollower(followerId);
+      ok(follower);
+      strictEqual(follower.state, "pending");
+      strictEqual(follower.actor.id?.href, followerId);
+    }
   });
 
   for (const state of ["pending", "accepted"] as const) {
@@ -632,52 +645,59 @@ describe("LitePubRelay", () => {
   });
 
   test("ignores Accept activity for invalid follower data", async () => {
-    const kv = new MemoryKvStore();
     const followerId = "https://remote.example.com/users/alice";
-    const invalidFollowerData = { state: "pending" };
-
-    await kv.set(["follower", followerId], invalidFollowerData);
-
-    const relay = createRelay("litepub", {
-      kv,
-      origin: "https://relay.example.com",
-      documentLoaderFactory: () => mockDocumentLoader,
-      authenticatedDocumentLoaderFactory: () => mockDocumentLoader,
-      subscriptionHandler: () => Promise.resolve(true),
+    const mismatchedActor = new Person({
+      id: new URL("https://remote.example.com/users/bob"),
     });
+    const invalidRows = [
+      { state: "pending" },
+      { actor: null, state: "pending" },
+      { actor: {}, state: "pending" },
+      { actor: await mismatchedActor.toJsonLd(), state: "pending" },
+    ];
 
-    const relayFollow = new Follow({
-      id: new URL("https://relay.example.com/activities/follow/1"),
-      actor: new URL("https://relay.example.com/users/relay"),
-      object: new URL(followerId),
-    });
-    const acceptActivity = new Accept({
-      id: new URL("https://remote.example.com/activities/accept/1"),
-      actor: new URL(followerId),
-      object: relayFollow,
-    });
+    for (const invalidRow of invalidRows) {
+      const kv = new MemoryKvStore();
+      await kv.set(["follower", followerId], invalidRow);
 
-    let request = new Request("https://relay.example.com/inbox", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/activity+json",
-      },
-      body: JSON.stringify(
-        await acceptActivity.toJsonLd({ contextLoader: mockDocumentLoader }),
-      ),
-    });
-    request = await signRequest(
-      request,
-      rsaKeyPair.privateKey,
-      rsaPublicKey.id,
-    );
+      const relay = createRelay("litepub", {
+        kv,
+        origin: "https://relay.example.com",
+        documentLoaderFactory: () => mockDocumentLoader,
+        authenticatedDocumentLoaderFactory: () => mockDocumentLoader,
+        subscriptionHandler: () => Promise.resolve(true),
+      });
 
-    await relay.fetch(request);
+      const relayFollow = new Follow({
+        id: new URL("https://relay.example.com/activities/follow/1"),
+        actor: new URL("https://relay.example.com/users/relay"),
+        object: new URL(followerId),
+      });
+      const acceptActivity = new Accept({
+        id: new URL("https://remote.example.com/activities/accept/1"),
+        actor: new URL(followerId),
+        object: relayFollow,
+      });
 
-    deepStrictEqual(
-      await kv.get(["follower", followerId]),
-      invalidFollowerData,
-    );
+      let request = new Request("https://relay.example.com/inbox", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/activity+json",
+        },
+        body: JSON.stringify(
+          await acceptActivity.toJsonLd({ contextLoader: mockDocumentLoader }),
+        ),
+      });
+      request = await signRequest(
+        request,
+        rsaKeyPair.privateKey,
+        rsaPublicKey.id,
+      );
+
+      await relay.fetch(request);
+
+      deepStrictEqual(await kv.get(["follower", followerId]), invalidRow);
+    }
   });
 
   for (const state of ["pending", "accepted"] as const) {

--- a/packages/relay/src/litepub.test.ts
+++ b/packages/relay/src/litepub.test.ts
@@ -466,6 +466,50 @@ describe("LitePubRelay", () => {
     strictEqual(followerData, undefined);
   });
 
+  test("replaces malformed follower data on Follow", async () => {
+    const kv = new MemoryKvStore();
+    const followerId = "https://remote.example.com/users/alice";
+    await kv.set(["follower", followerId], { state: "pending" });
+    let handlerCallCount = 0;
+
+    const relay = createRelay("litepub", {
+      kv,
+      origin: "https://relay.example.com",
+      documentLoaderFactory: () => mockDocumentLoader,
+      authenticatedDocumentLoaderFactory: () => mockDocumentLoader,
+      subscriptionHandler: () => {
+        handlerCallCount++;
+        return Promise.resolve(true);
+      },
+    });
+
+    const followActivity = new Follow({
+      id: new URL("https://remote.example.com/activities/follow/1"),
+      actor: new URL(followerId),
+      object: new URL("https://relay.example.com/users/relay"),
+    });
+    let request = new Request("https://relay.example.com/inbox", {
+      method: "POST",
+      headers: { "Content-Type": "application/activity+json" },
+      body: JSON.stringify(
+        await followActivity.toJsonLd({ contextLoader: mockDocumentLoader }),
+      ),
+    });
+    request = await signRequest(
+      request,
+      rsaKeyPair.privateKey,
+      rsaPublicKey.id,
+    );
+
+    await relay.fetch(request);
+
+    strictEqual(handlerCallCount, 1);
+    const follower = await relay.getFollower(followerId);
+    ok(follower);
+    strictEqual(follower.state, "pending");
+    strictEqual(follower.actor.id?.href, followerId);
+  });
+
   for (const state of ["pending", "accepted"] as const) {
     test(`ignores duplicate Follow activity from ${state} follower`, async () => {
       const kv = new MemoryKvStore();

--- a/packages/relay/src/litepub.test.ts
+++ b/packages/relay/src/litepub.test.ts
@@ -466,60 +466,64 @@ describe("LitePubRelay", () => {
     strictEqual(followerData, undefined);
   });
 
-  test("ignores duplicate Follow activity from pending follower", async () => {
-    const kv = new MemoryKvStore();
-    let handlerCallCount = 0;
+  for (const state of ["pending", "accepted"] as const) {
+    test(`ignores duplicate Follow activity from ${state} follower`, async () => {
+      const kv = new MemoryKvStore();
+      let handlerCallCount = 0;
 
-    const relay = createRelay("litepub", {
-      kv,
-      origin: "https://relay.example.com",
-      documentLoaderFactory: () => mockDocumentLoader,
-      authenticatedDocumentLoaderFactory: () => mockDocumentLoader,
-      subscriptionHandler: async (_ctx, _actor) => {
-        handlerCallCount++;
-        return await Promise.resolve(true);
-      },
+      const relay = createRelay("litepub", {
+        kv,
+        origin: "https://relay.example.com",
+        documentLoaderFactory: () => mockDocumentLoader,
+        authenticatedDocumentLoaderFactory: () => mockDocumentLoader,
+        subscriptionHandler: async (_ctx, _actor) => {
+          handlerCallCount++;
+          return await Promise.resolve(true);
+        },
+      });
+
+      const follower = new Person({
+        id: new URL("https://remote.example.com/users/alice"),
+        preferredUsername: "alice",
+        inbox: new URL("https://remote.example.com/users/alice/inbox"),
+      });
+      await kv.set(
+        ["follower", "https://remote.example.com/users/alice"],
+        { actor: await follower.toJsonLd(), state },
+      );
+
+      const followActivity = new Follow({
+        id: new URL("https://remote.example.com/activities/follow/1"),
+        actor: follower.id,
+        object: new URL("https://relay.example.com/users/relay"),
+      });
+
+      let request = new Request("https://relay.example.com/inbox", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/activity+json",
+        },
+        body: JSON.stringify(
+          await followActivity.toJsonLd({ contextLoader: mockDocumentLoader }),
+        ),
+      });
+      request = await signRequest(
+        request,
+        rsaKeyPair.privateKey,
+        rsaPublicKey.id,
+      );
+
+      await relay.fetch(request);
+
+      strictEqual(handlerCallCount, 0);
+      const followerData = await kv.get([
+        "follower",
+        "https://remote.example.com/users/alice",
+      ]);
+      ok(isRelayFollowerData(followerData));
+      strictEqual(followerData.state, state);
     });
-
-    const follower = new Person({
-      id: new URL("https://remote.example.com/users/alice"),
-      preferredUsername: "alice",
-      inbox: new URL("https://remote.example.com/users/alice/inbox"),
-    });
-
-    // Pre-populate with pending follower
-    await kv.set(
-      ["follower", "https://remote.example.com/users/alice"],
-      { actor: await follower.toJsonLd(), state: "pending" },
-    );
-
-    const followActivity = new Follow({
-      id: new URL("https://remote.example.com/activities/follow/1"),
-      actor: follower.id,
-      object: new URL("https://relay.example.com/users/relay"),
-    });
-
-    let request = new Request("https://relay.example.com/inbox", {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/activity+json",
-      },
-      body: JSON.stringify(
-        await followActivity.toJsonLd({ contextLoader: mockDocumentLoader }),
-      ),
-    });
-
-    request = await signRequest(
-      request,
-      rsaKeyPair.privateKey,
-      rsaPublicKey.id,
-    );
-
-    await relay.fetch(request);
-
-    // Verify handler was NOT called (duplicate follow ignored)
-    strictEqual(handlerCallCount, 0);
-  });
+  }
 
   test("handles Accept activity completing reciprocal follow", async () => {
     const kv = new MemoryKvStore();

--- a/packages/relay/src/litepub.test.ts
+++ b/packages/relay/src/litepub.test.ts
@@ -18,7 +18,7 @@ import {
   getDocumentLoader,
   type RemoteDocument,
 } from "@fedify/vocab-runtime";
-import { ok, strictEqual } from "node:assert";
+import { deepStrictEqual, ok, strictEqual } from "node:assert";
 import test, { describe } from "node:test";
 import { isRelayFollowerData } from "./types.ts";
 
@@ -581,6 +581,55 @@ describe("LitePubRelay", () => {
     ]);
     ok(isRelayFollowerData(followerData));
     strictEqual(followerData.state, "accepted");
+  });
+
+  test("ignores Accept activity for invalid follower data", async () => {
+    const kv = new MemoryKvStore();
+    const followerId = "https://remote.example.com/users/alice";
+    const invalidFollowerData = { state: "pending" };
+
+    await kv.set(["follower", followerId], invalidFollowerData);
+
+    const relay = createRelay("litepub", {
+      kv,
+      origin: "https://relay.example.com",
+      documentLoaderFactory: () => mockDocumentLoader,
+      authenticatedDocumentLoaderFactory: () => mockDocumentLoader,
+      subscriptionHandler: () => Promise.resolve(true),
+    });
+
+    const relayFollow = new Follow({
+      id: new URL("https://relay.example.com/activities/follow/1"),
+      actor: new URL("https://relay.example.com/users/relay"),
+      object: new URL(followerId),
+    });
+    const acceptActivity = new Accept({
+      id: new URL("https://remote.example.com/activities/accept/1"),
+      actor: new URL(followerId),
+      object: relayFollow,
+    });
+
+    let request = new Request("https://relay.example.com/inbox", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/activity+json",
+      },
+      body: JSON.stringify(
+        await acceptActivity.toJsonLd({ contextLoader: mockDocumentLoader }),
+      ),
+    });
+    request = await signRequest(
+      request,
+      rsaKeyPair.privateKey,
+      rsaPublicKey.id,
+    );
+
+    await relay.fetch(request);
+
+    deepStrictEqual(
+      await kv.get(["follower", followerId]),
+      invalidFollowerData,
+    );
   });
 
   for (const state of ["pending", "accepted"] as const) {

--- a/packages/relay/src/litepub.ts
+++ b/packages/relay/src/litepub.ts
@@ -1,23 +1,14 @@
-import type { InboxContext } from "@fedify/fedify";
+import type { InboxContext, InboxListenerSetters } from "@fedify/fedify";
 import {
   Accept,
+  type Actor,
   Announce,
-  Create,
-  Delete,
   Follow,
   isActor,
-  Move,
   PUBLIC_COLLECTION,
-  Undo,
-  Update,
 } from "@fedify/vocab";
 import { getLogger } from "@logtape/logtape";
-import { BaseRelay } from "./base.ts";
-import {
-  handleUndoFollow,
-  sendFollowResponse,
-  validateFollowActivity,
-} from "./follow.ts";
+import { BaseRelay, type RelayableActivity } from "./base.ts";
 import {
   RELAY_SERVER_ACTOR,
   type RelayFollowerData,
@@ -34,13 +25,43 @@ const logger = getLogger(["fedify", "relay", "litepub"]);
  * @since 2.0.0
  */
 export class LitePubRelay extends BaseRelay {
-  async #announceToFollowers(
-    ctx: InboxContext<RelayOptions>,
-    activity: Create | Delete | Move | Update | Announce,
-  ): Promise<void> {
-    const sender = await activity.getActor(ctx);
-    const excludeBaseUris = sender?.id ? [new URL(sender.id)] : [];
+  protected readonly initialFollowerState = "pending";
+  protected readonly logger = logger;
 
+  protected override async shouldSkipFollow(
+    ctx: InboxContext<RelayOptions>,
+    follower: Actor,
+  ): Promise<boolean> {
+    if (follower.id == null) return true;
+    const existingFollow = await ctx.data.kv.get<RelayFollowerData>([
+      "follower",
+      follower.id.href,
+    ]);
+    return existingFollow?.state === "pending";
+  }
+
+  protected override async afterFollowApproved(
+    ctx: InboxContext<RelayOptions>,
+    follower: Actor,
+  ): Promise<void> {
+    if (follower.id == null) return;
+    const relayActorUri = ctx.getActorUri(RELAY_SERVER_ACTOR);
+    await ctx.sendActivity(
+      { identifier: RELAY_SERVER_ACTOR },
+      follower,
+      new Follow({
+        actor: relayActorUri,
+        object: follower.id,
+        to: follower.id,
+      }),
+    );
+  }
+
+  protected async deliverActivity(
+    ctx: InboxContext<RelayOptions>,
+    activity: RelayableActivity,
+    excludeBaseUris: URL[],
+  ): Promise<void> {
     const announce = new Announce({
       id: new URL(`/announce#${crypto.randomUUID()}`, ctx.origin),
       actor: ctx.getActorUri(RELAY_SERVER_ACTOR),
@@ -60,105 +81,36 @@ export class LitePubRelay extends BaseRelay {
     );
   }
 
-  protected setupInboxListeners(): void {
-    if (this.federation != null) {
-      this.federation.setInboxListeners("/users/{identifier}/inbox", "/inbox")
-        .on(Follow, async (ctx, follow) => {
-          const follower = await validateFollowActivity(ctx, follow);
-          if (!follower || !follower.id) return;
+  protected override setupInboxListeners(): InboxListenerSetters<RelayOptions> {
+    return super.setupInboxListeners().on(Accept, async (ctx, accept) => {
+      // Validate follow activity from accept activity
+      const follow = await accept.getObject({
+        crossOrigin: "trust",
+        ...ctx,
+      });
+      if (!(follow instanceof Follow)) return;
+      const relayActorId = follow.actorId;
+      if (relayActorId == null) return;
 
-          // Litepub-specific: check if already in pending state
-          const existingFollow = await ctx.data.kv.get<RelayFollowerData>([
-            "follower",
-            follower.id.href,
-          ]);
-          if (existingFollow?.state === "pending") return;
+      // Validate follower actor - accept activity sender
+      const followerActor = await accept.getActor();
+      if (!isActor(followerActor) || !followerActor.id) return;
+      const parsed = ctx.parseUri(relayActorId);
+      if (parsed == null || parsed.type !== "actor") return;
 
-          const approved = await this.options.subscriptionHandler(
-            ctx,
-            follower,
-          );
+      // Get follower from kv store
+      const followerData = await ctx.data.kv.get([
+        "follower",
+        followerActor.id.href,
+      ]);
+      if (followerData == null) return;
 
-          if (approved) {
-            // Litepub-specific: save with "pending" state
-            await ctx.data.kv.set(
-              ["follower", follower.id.href],
-              { actor: await follower.toJsonLd(), state: "pending" },
-            );
-
-            await sendFollowResponse(ctx, follow, follower, approved);
-
-            // Litepub-specific: send reciprocal follow
-            const relayActorUri = ctx.getActorUri(RELAY_SERVER_ACTOR);
-            await ctx.sendActivity(
-              { identifier: RELAY_SERVER_ACTOR },
-              follower,
-              new Follow({
-                actor: relayActorUri,
-                object: follower.id,
-                to: follower.id,
-              }),
-            );
-          } else {
-            await sendFollowResponse(ctx, follow, follower, approved);
-          }
-        })
-        .on(Accept, async (ctx, accept) => {
-          // Validate follow activity from accept activity
-          const follow = await accept.getObject({
-            crossOrigin: "trust",
-            ...ctx,
-          });
-          if (!(follow instanceof Follow)) return;
-          const relayActorId = follow.actorId;
-          if (relayActorId == null) return;
-
-          // Validate follower actor - accept activity sender
-          const followerActor = await accept.getActor();
-          if (!isActor(followerActor) || !followerActor.id) return;
-          const parsed = ctx.parseUri(relayActorId);
-          if (parsed == null || parsed.type !== "actor") return;
-
-          // Get follower from kv store
-          const followerData = await ctx.data.kv.get([
-            "follower",
-            followerActor.id.href,
-          ]);
-          if (followerData == null) return;
-
-          // Update follower state to accepted
-          const updatedFollowerData = { ...followerData, state: "accepted" };
-          await ctx.data.kv.set(
-            ["follower", followerActor.id.href],
-            updatedFollowerData,
-          );
-        })
-        .on(
-          Undo,
-          async (ctx, undo) => await handleUndoFollow(ctx, undo, logger),
-        )
-        .on(
-          Create,
-          async (ctx, create) => await this.#announceToFollowers(ctx, create),
-        )
-        .on(
-          Update,
-          async (ctx, update) => await this.#announceToFollowers(ctx, update),
-        )
-        .on(
-          Move,
-          async (ctx, move) => await this.#announceToFollowers(ctx, move),
-        )
-        .on(
-          Delete,
-          async (ctx, deleteActivity) =>
-            await this.#announceToFollowers(ctx, deleteActivity),
-        )
-        .on(
-          Announce,
-          async (ctx, announce) =>
-            await this.#announceToFollowers(ctx, announce),
-        );
-    }
+      // Update follower state to accepted
+      const updatedFollowerData = { ...followerData, state: "accepted" };
+      await ctx.data.kv.set(
+        ["follower", followerActor.id.href],
+        updatedFollowerData,
+      );
+    });
   }
 }

--- a/packages/relay/src/litepub.ts
+++ b/packages/relay/src/litepub.ts
@@ -11,6 +11,7 @@ import { getLogger } from "@logtape/logtape";
 import { BaseRelay, type RelayableActivity } from "./base.ts";
 import {
   isRelayFollowerData,
+  parseRelayFollowerData,
   RELAY_SERVER_ACTOR,
   type RelayFollowerData,
   type RelayOptions,
@@ -38,7 +39,11 @@ export class LitePubRelay extends BaseRelay {
       "follower",
       follower.id.href,
     ]);
-    return isRelayFollowerData(existingFollow);
+    const storedFollower = await parseRelayFollowerData(
+      follower.id.href,
+      existingFollow,
+    );
+    return storedFollower != null;
   }
 
   protected override async afterFollowApproved(
@@ -105,6 +110,11 @@ export class LitePubRelay extends BaseRelay {
         followerActor.id.href,
       ]);
       if (!isRelayFollowerData(followerData)) return;
+      const storedFollower = await parseRelayFollowerData(
+        followerActor.id.href,
+        followerData,
+      );
+      if (storedFollower == null) return;
 
       // Update follower state to accepted
       const updatedFollowerData: RelayFollowerData = {

--- a/packages/relay/src/litepub.ts
+++ b/packages/relay/src/litepub.ts
@@ -93,7 +93,7 @@ export class LitePubRelay extends BaseRelay {
       if (relayActorId == null) return;
 
       // Validate follower actor - accept activity sender
-      const followerActor = await accept.getActor();
+      const followerActor = await accept.getActor(ctx);
       if (!isActor(followerActor) || !followerActor.id) return;
       const parsed = ctx.parseUri(relayActorId);
       if (parsed == null || parsed.type !== "actor") return;

--- a/packages/relay/src/litepub.ts
+++ b/packages/relay/src/litepub.ts
@@ -10,6 +10,7 @@ import {
 import { getLogger } from "@logtape/logtape";
 import { BaseRelay, type RelayableActivity } from "./base.ts";
 import {
+  isRelayFollowerData,
   RELAY_SERVER_ACTOR,
   type RelayFollowerData,
   type RelayOptions,
@@ -103,10 +104,13 @@ export class LitePubRelay extends BaseRelay {
         "follower",
         followerActor.id.href,
       ]);
-      if (followerData == null) return;
+      if (!isRelayFollowerData(followerData)) return;
 
       // Update follower state to accepted
-      const updatedFollowerData = { ...followerData, state: "accepted" };
+      const updatedFollowerData: RelayFollowerData = {
+        ...followerData,
+        state: "accepted",
+      };
       await ctx.data.kv.set(
         ["follower", followerActor.id.href],
         updatedFollowerData,

--- a/packages/relay/src/litepub.ts
+++ b/packages/relay/src/litepub.ts
@@ -38,7 +38,7 @@ export class LitePubRelay extends BaseRelay {
       "follower",
       follower.id.href,
     ]);
-    return existingFollow != null;
+    return isRelayFollowerData(existingFollow);
   }
 
   protected override async afterFollowApproved(

--- a/packages/relay/src/litepub.ts
+++ b/packages/relay/src/litepub.ts
@@ -34,11 +34,11 @@ export class LitePubRelay extends BaseRelay {
     follower: Actor,
   ): Promise<boolean> {
     if (follower.id == null) return true;
-    const existingFollow = await ctx.data.kv.get<RelayFollowerData>([
+    const existingFollow = await ctx.data.kv.get([
       "follower",
       follower.id.href,
     ]);
-    return existingFollow?.state === "pending";
+    return existingFollow != null;
   }
 
   protected override async afterFollowApproved(

--- a/packages/relay/src/mastodon.test.ts
+++ b/packages/relay/src/mastodon.test.ts
@@ -389,12 +389,13 @@ describe("MastodonRelay", () => {
     strictEqual(handlerCalled, true);
     ok(handlerActor);
 
-    // Verify follower was stored
+    // Verify follower was immediately accepted
     const followerData = await kv.get([
       "follower",
       "https://remote.example.com/users/alice",
     ]);
-    ok(followerData);
+    ok(isRelayFollowerData(followerData));
+    strictEqual(followerData.state, "accepted");
   });
 
   test("handles Follow activity with subscription rejection", async () => {

--- a/packages/relay/src/mastodon.test.ts
+++ b/packages/relay/src/mastodon.test.ts
@@ -2,6 +2,7 @@
 import { MemoryKvStore, signRequest } from "@fedify/fedify";
 import { createRelay, type RelayOptions } from "@fedify/relay";
 import {
+  Announce,
   Create,
   Delete,
   Follow,
@@ -674,6 +675,45 @@ describe("MastodonRelay", () => {
       },
       body: JSON.stringify(
         await moveActivity.toJsonLd({ contextLoader: mockDocumentLoader }),
+      ),
+    });
+
+    request = await signRequest(
+      request,
+      rsaKeyPair.privateKey,
+      rsaPublicKey.id,
+    );
+
+    const response = await relay.fetch(request);
+
+    // Verify the request was accepted
+    ok(response.status === 200 || response.status === 202);
+  });
+
+  test("handles Announce activity forwarding", async () => {
+    const kv = new MemoryKvStore();
+
+    const relay = createRelay("mastodon", {
+      kv,
+      origin: "https://relay.example.com",
+      documentLoaderFactory: () => mockDocumentLoader,
+      authenticatedDocumentLoaderFactory: () => mockDocumentLoader,
+      subscriptionHandler: () => Promise.resolve(true),
+    });
+
+    const announceActivity = new Announce({
+      id: new URL("https://remote.example.com/activities/announce/1"),
+      actor: new URL("https://remote.example.com/users/alice"),
+      object: new URL("https://remote.example.com/notes/1"),
+    });
+
+    let request = new Request("https://relay.example.com/inbox", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/activity+json",
+      },
+      body: JSON.stringify(
+        await announceActivity.toJsonLd({ contextLoader: mockDocumentLoader }),
       ),
     });
 

--- a/packages/relay/src/mastodon.test.ts
+++ b/packages/relay/src/mastodon.test.ts
@@ -1,5 +1,5 @@
 // deno-lint-ignore-file no-explicit-any
-import { MemoryKvStore, signRequest } from "@fedify/fedify";
+import { MemoryKvStore, signJsonLd, signRequest } from "@fedify/fedify";
 import { createRelay, type RelayOptions } from "@fedify/relay";
 import {
   Announce,
@@ -17,7 +17,7 @@ import {
   getDocumentLoader,
   type RemoteDocument,
 } from "@fedify/vocab-runtime";
-import { ok, strictEqual } from "node:assert";
+import { deepStrictEqual, ok, strictEqual } from "node:assert";
 import test, { describe } from "node:test";
 import { isRelayFollowerData } from "./types.ts";
 
@@ -692,6 +692,15 @@ describe("MastodonRelay", () => {
 
   test("handles Announce activity forwarding", async () => {
     const kv = new MemoryKvStore();
+    const follower = new Person({
+      id: new URL("https://follower.example.com/users/bob"),
+      preferredUsername: "bob",
+      inbox: new URL("https://follower.example.com/users/bob/inbox"),
+    });
+    await kv.set(
+      ["follower", follower.id!.href],
+      { actor: await follower.toJsonLd(), state: "accepted" },
+    );
 
     const relay = createRelay("mastodon", {
       kv,
@@ -706,15 +715,19 @@ describe("MastodonRelay", () => {
       actor: new URL("https://remote.example.com/users/alice"),
       object: new URL("https://remote.example.com/notes/1"),
     });
+    const signedAnnounce = await signJsonLd(
+      await announceActivity.toJsonLd({ contextLoader: mockDocumentLoader }),
+      rsaKeyPair.privateKey,
+      rsaPublicKey.id,
+      { contextLoader: mockDocumentLoader },
+    );
 
     let request = new Request("https://relay.example.com/inbox", {
       method: "POST",
       headers: {
         "Content-Type": "application/activity+json",
       },
-      body: JSON.stringify(
-        await announceActivity.toJsonLd({ contextLoader: mockDocumentLoader }),
-      ),
+      body: JSON.stringify(signedAnnounce),
     });
 
     request = await signRequest(
@@ -723,10 +736,40 @@ describe("MastodonRelay", () => {
       rsaPublicKey.id,
     );
 
-    const response = await relay.fetch(request);
+    const originalFetch = globalThis.fetch;
+    let deliveryMethod: string | undefined;
+    let deliveredActivity: unknown;
+    globalThis.fetch = (async (
+      input: URL | RequestInfo,
+      init?: RequestInit,
+    ) => {
+      const outboundRequest = input instanceof Request
+        ? input
+        : new Request(input, init);
+      if (
+        outboundRequest.url ===
+          "https://follower.example.com/users/bob/inbox"
+      ) {
+        deliveryMethod = outboundRequest.method;
+        deliveredActivity = await outboundRequest.json();
+        return new Response(null, { status: 202 });
+      }
+      return originalFetch(input, init);
+    }) as typeof fetch;
 
-    // Verify the request was accepted
-    ok(response.status === 200 || response.status === 202);
+    try {
+      const response = await relay.fetch(request);
+      ok(
+        response.status === 200 || response.status === 202,
+        `Unexpected inbox response status: ${response.status}`,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    ok(deliveredActivity, "Expected Announce delivery to the follower inbox");
+    strictEqual(deliveryMethod, "POST");
+    deepStrictEqual(deliveredActivity, signedAnnounce);
   });
 
   test("ignores Follow activity without required fields", async () => {

--- a/packages/relay/src/mastodon.ts
+++ b/packages/relay/src/mastodon.ts
@@ -1,20 +1,6 @@
 import type { InboxContext } from "@fedify/fedify";
-import {
-  Announce,
-  Create,
-  Delete,
-  Follow,
-  Move,
-  Undo,
-  Update,
-} from "@fedify/vocab";
 import { getLogger } from "@logtape/logtape";
-import { BaseRelay } from "./base.ts";
-import {
-  handleUndoFollow,
-  sendFollowResponse,
-  validateFollowActivity,
-} from "./follow.ts";
+import { BaseRelay, type RelayableActivity } from "./base.ts";
 import { RELAY_SERVER_ACTOR, type RelayOptions } from "./types.ts";
 
 const logger = getLogger(["fedify", "relay", "mastodon"]);
@@ -27,13 +13,14 @@ const logger = getLogger(["fedify", "relay", "mastodon"]);
  * @since 2.0.0
  */
 export class MastodonRelay extends BaseRelay {
-  async #forwardToFollowers(
-    ctx: InboxContext<RelayOptions>,
-    activity: Create | Delete | Move | Update | Announce,
-  ): Promise<void> {
-    const sender = await activity.getActor(ctx);
-    const excludeBaseUris = sender?.id ? [new URL(sender.id)] : [];
+  protected readonly initialFollowerState = "accepted";
+  protected readonly logger = logger;
 
+  protected async deliverActivity(
+    ctx: InboxContext<RelayOptions>,
+    _activity: RelayableActivity,
+    excludeBaseUris: URL[],
+  ): Promise<void> {
     await ctx.forwardActivity(
       { identifier: RELAY_SERVER_ACTOR },
       "followers",
@@ -43,56 +30,5 @@ export class MastodonRelay extends BaseRelay {
         preferSharedInbox: true,
       },
     );
-  }
-
-  protected setupInboxListeners(): void {
-    if (this.federation != null) {
-      this.federation.setInboxListeners("/users/{identifier}/inbox", "/inbox")
-        .on(Follow, async (ctx, follow) => {
-          const follower = await validateFollowActivity(ctx, follow);
-          if (!follower || !follower.id) return;
-
-          const approved = await this.options.subscriptionHandler(
-            ctx,
-            follower,
-          );
-
-          if (approved) {
-            // Mastodon-specific: immediately add to followers list with accepted state
-            await ctx.data.kv.set(
-              ["follower", follower.id.href],
-              { actor: await follower.toJsonLd(), state: "accepted" },
-            );
-          }
-
-          await sendFollowResponse(ctx, follow, follower, approved);
-        })
-        .on(
-          Undo,
-          async (ctx, undo) => await handleUndoFollow(ctx, undo, logger),
-        )
-        .on(
-          Create,
-          async (ctx, create) => await this.#forwardToFollowers(ctx, create),
-        )
-        .on(
-          Delete,
-          async (ctx, deleteActivity) =>
-            await this.#forwardToFollowers(ctx, deleteActivity),
-        )
-        .on(
-          Move,
-          async (ctx, move) => await this.#forwardToFollowers(ctx, move),
-        )
-        .on(
-          Update,
-          async (ctx, update) => await this.#forwardToFollowers(ctx, update),
-        )
-        .on(
-          Announce,
-          async (ctx, announce) =>
-            await this.#forwardToFollowers(ctx, announce),
-        );
-    }
   }
 }

--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -13,6 +13,13 @@ export const RELAY_SERVER_ACTOR = "relay";
 export type RelayType = "mastodon" | "litepub";
 
 /**
+ * A follower's subscription state.
+ *
+ * @internal
+ */
+export type RelayFollowerState = "pending" | "accepted";
+
+/**
  * Handler for subscription requests (Follow/Undo activities).
  */
 export type SubscriptionRequestHandler = (
@@ -79,7 +86,7 @@ export interface RelayFollowerData {
   /** The actor's JSON-LD representation (serialized for storage). */
   readonly actor: unknown;
   /** The follower's state. */
-  readonly state: "pending" | "accepted";
+  readonly state: RelayFollowerState;
 }
 
 /**
@@ -94,7 +101,7 @@ export interface RelayFollower {
   /** The validated Actor object. */
   readonly actor: Actor;
   /** The follower's state. */
-  readonly state: "pending" | "accepted";
+  readonly state: RelayFollowerState;
 }
 
 /**

--- a/packages/relay/src/types.ts
+++ b/packages/relay/src/types.ts
@@ -1,5 +1,5 @@
 import type { Context, KvStore, MessageQueue } from "@fedify/fedify";
-import type { Actor } from "@fedify/vocab";
+import { type Actor, isActor, Object as APObject } from "@fedify/vocab";
 import type {
   AuthenticatedDocumentLoaderFactory,
   DocumentLoaderFactory,
@@ -168,4 +168,27 @@ export function isRelayFollowerData(
     typeof obj.state === "string" &&
     (obj.state === "pending" || obj.state === "accepted")
   );
+}
+
+/**
+ * Parses and semantically validates follower data from storage.
+ *
+ * @param actorId The actor ID used as the follower's storage key.
+ * @param value The stored follower data.
+ * @returns The parsed follower, or `null` if the row is invalid.
+ * @internal
+ */
+export async function parseRelayFollowerData(
+  actorId: string,
+  value: unknown,
+): Promise<RelayFollower | null> {
+  if (!isRelayFollowerData(value)) return null;
+
+  try {
+    const actor = await APObject.fromJsonLd(value.actor);
+    if (!isActor(actor) || actor.id?.href !== actorId) return null;
+    return { actorId, actor, state: value.state };
+  } catch {
+    return null;
+  }
 }


### PR DESCRIPTION
This consolidates the behavior shared by the Mastodon and LitePub relay implementations while keeping their protocol differences explicit. Closes #905.


Background
----------

The relay implementations previously repeated their Follow, Undo, and activity listener chains. Shared behavior was split between the protocol classes and helper functions, which made the actual differences between Mastodon and LitePub harder to identify and test.


Changes
-------

 -  Move the shared Follow subscription flow, follower storage, Undo handling, activity listener registration, and sender exclusion into `BaseRelay`.
 -  Keep Mastodon's immediate accepted state and direct forwarding behavior in `MastodonRelay`.
 -  Keep LitePub's pending state, duplicate-pending check, reciprocal Follow, Accept transition, and Announce delivery in `LitePubRelay`.
 -  Add a shared follower-state type and explicit protocol initial states.
 -  Strengthen protocol-level state and Undo tests and cover Mastodon Announce forwarding.

This is an internal refactor. It does not change the public `createRelay()` API or the delivery semantics of either protocol.


Testing
-------

 -  `mise run fmt`
 -  `mise run check-each relay`
 -  `mise run test-each relay`
 -  `mise run test:deno packages/relay/src/mastodon.test.ts`
 -  `mise run test:deno packages/relay/src/litepub.test.ts`
 -  `sacho check --base upstream/main`


AI assistance
-------------

Codex (`gpt-5.6-sol`) assisted with code analysis, implementation, test planning, validation, and drafting this description. I reviewed the changes and test results.