### PR TITLE
Add an async context data test for @fedify/express

### DIFF
--- a/packages/express/deno.json
+++ b/packages/express/deno.json
@@ -19,6 +19,7 @@
     ]
   },
   "tasks": {
-    "check": "deno fmt --check && deno lint && deno check *.ts"
+    "check": "deno fmt --check && deno lint && deno check *.ts",
+    "test": "deno test --allow-all"
   }
 }

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -58,6 +58,7 @@
     "build:self": "tsdown",
     "build": "pnpm --filter @fedify/express... run build:self",
     "prepack": "pnpm build",
-    "prepublish": "pnpm build"
+    "prepublish": "pnpm build",
+    "test": "node --experimental-transform-types --test"
   }
 }

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -59,6 +59,7 @@
     "build": "pnpm --filter @fedify/express... run build:self",
     "prepack": "pnpm build",
     "prepublish": "pnpm build",
-    "test": "node --experimental-transform-types --test"
+    "test": "node --experimental-transform-types --test",
+    "test:bun": "bun test src/"
   }
 }

--- a/packages/express/src/index.test.ts
+++ b/packages/express/src/index.test.ts
@@ -36,21 +36,12 @@ function createMockResponse(): {
     setHeader() {
       return response;
     },
-    removeHeader() {
-      return response;
-    },
     write(chunk: Buffer | string) {
       body += chunk.toString();
       return true;
     },
     end() {
       resolveEnded();
-      return response;
-    },
-    send() {
-      return response;
-    },
-    json() {
       return response;
     },
   };

--- a/packages/express/src/index.test.ts
+++ b/packages/express/src/index.test.ts
@@ -1,0 +1,90 @@
+import { strict as assert } from "node:assert";
+import { describe, test } from "node:test";
+import type { Request as ERequest, Response as EResponse } from "express";
+import { integrateFederation } from "./index.ts";
+
+interface MockFederation {
+  fetch(request: Request, options: unknown): Promise<Response>;
+}
+
+function createMockRequest(): ERequest {
+  return {
+    protocol: "http",
+    host: "localhost",
+    url: "/",
+    method: "GET",
+    headers: {},
+  } as unknown as ERequest;
+}
+
+function createMockResponse(): {
+  response: EResponse;
+  ended: Promise<void>;
+  getBody(): string;
+} {
+  let body = "";
+  let resolveEnded: () => void;
+  const ended = new Promise<void>((resolve) => {
+    resolveEnded = resolve;
+  });
+  const response = {
+    statusCode: 200,
+    status(code: number) {
+      response.statusCode = code;
+      return response;
+    },
+    setHeader() {
+      return response;
+    },
+    removeHeader() {
+      return response;
+    },
+    write(chunk: Buffer | string) {
+      body += chunk.toString();
+      return true;
+    },
+    end() {
+      resolveEnded();
+      return response;
+    },
+    send() {
+      return response;
+    },
+    json() {
+      return response;
+    },
+  };
+  return {
+    response: response as unknown as EResponse,
+    ended,
+    getBody: () => body,
+  };
+}
+
+describe("integrateFederation()", () => {
+  test("waits for an async contextDataFactory and passes the resolved value to federation.fetch()", async () => {
+    const mockFederation: MockFederation = {
+      fetch(_request, options) {
+        const { contextData } = options as { contextData: unknown };
+        return Promise.resolve(new Response(String(contextData)));
+      },
+    };
+    const contextDataFactory = () => Promise.resolve("Hello World");
+    const middleware = integrateFederation(
+      mockFederation as never,
+      contextDataFactory,
+    );
+
+    const req = createMockRequest();
+    const { response, ended, getBody } = createMockResponse();
+    let nextCalled = false;
+
+    middleware(req, response, () => {
+      nextCalled = true;
+    });
+    await ended;
+
+    assert.strictEqual(nextCalled, false);
+    assert.strictEqual(getBody(), "Hello World");
+  });
+});

--- a/packages/express/src/index.test.ts
+++ b/packages/express/src/index.test.ts
@@ -1,6 +1,6 @@
+import type { Request as ERequest, Response as EResponse } from "express";
 import { strict as assert } from "node:assert";
 import { describe, test } from "node:test";
-import type { Request as ERequest, Response as EResponse } from "express";
 import { integrateFederation } from "./index.ts";
 
 interface MockFederation {
@@ -63,13 +63,22 @@ function createMockResponse(): {
 
 describe("integrateFederation()", () => {
   test("waits for an async contextDataFactory and passes the resolved value to federation.fetch()", async () => {
+    let resolveContextData!: (value: string) => void;
+    let fetchCalled = false;
+
     const mockFederation: MockFederation = {
       fetch(_request, options) {
+        fetchCalled = true;
         const { contextData } = options as { contextData: unknown };
         return Promise.resolve(new Response(String(contextData)));
       },
     };
-    const contextDataFactory = () => Promise.resolve("Hello World");
+
+    const contextDataFactory = () =>
+      new Promise<string>((resolve) => {
+        resolveContextData = resolve;
+      });
+
     const middleware = integrateFederation(
       mockFederation as never,
       contextDataFactory,
@@ -82,6 +91,11 @@ describe("integrateFederation()", () => {
     middleware(req, response, () => {
       nextCalled = true;
     });
+
+    await Promise.resolve();
+    assert.strictEqual(fetchCalled, false);
+
+    resolveContextData("Hello World");
     await ended;
 
     assert.strictEqual(nextCalled, false);


### PR DESCRIPTION
## Summary

`integrateFederation()`'s `contextDataFactory` may return a plain value or a `Promise`, but only the synchronous path had test coverage. 
This adds a regression test for the async path, verifying the middleware waits for the factory to resolve and passes the resolved value to `federation.fetch()`.

Also adds the missing `test` script (*package.json*) and `test` task (*deno.json*) for `@fedify/express` so the suite actually runs under `mise run test:node` / `test-each`.

Fixes #855

## Test plan

- [x] `mise run check-each express`
- [x] `deno test --allow-all` (packages/express)
- [x] `node --experimental-transform-types --test` (packages/express)

## AI disclosure

This change was written with assistance from Claude Code (`claude-sonnet-5`), reviewed and verified by me.