### PR TITLE
Add readme for h3 example

### DIFF
--- a/examples/h3/README.md
+++ b/examples/h3/README.md
@@ -1,0 +1,41 @@
+Fedify–H3 integration example
+=============================
+
+This is a simple example of how to integrate Fedify into an [H3]
+application.
+
+[H3]: https://h3.unjs.io/
+
+
+Running the example
+-------------------
+
+1.  Clone the repository:
+
+    ~~~~ sh
+    git clone https://github.com/fedify-dev/fedify.git
+    ~~~~
+
+2.  Move to the example folder:
+
+    ~~~~ sh
+    cd examples/h3
+    ~~~~
+
+3.  Install dependencies:
+
+    ~~~~ sh
+    pnpm install
+    ~~~~
+
+4.  Start the server:
+
+    ~~~~ sh
+    deno serve -A index.ts
+    ~~~~
+
+5.  Look up the actor URL:
+
+    ~~~~
+    http://localhost:8000/users/{identifier}
+    ~~~~

--- a/examples/h3/README.md
+++ b/examples/h3/README.md
@@ -44,5 +44,5 @@ Running the example
 6.  Lookup an actor using `@fedify/cli`:
 
     ~~~~ sh
-    fedify lookup http://localhost:8000/users/{identifier}
+    mise run cli lookup http://localhost:8000/users/{identifier}
     ~~~~

--- a/examples/h3/README.md
+++ b/examples/h3/README.md
@@ -16,26 +16,33 @@ Running the example
     git clone https://github.com/fedify-dev/fedify.git
     ~~~~
 
-2.  Move to the example folder:
+2.  Go to the directory of the cloned repository:
+
+    ~~~~ sh
+    cd fedify
+    ~~~~
+
+3.  Trust and install dependencies using `mise`:
+
+    ~~~~ sh
+    mise trust
+    mise install
+    ~~~~
+
+4.  Go to the `h3` example directory:
 
     ~~~~ sh
     cd examples/h3
     ~~~~
 
-3.  Install dependencies:
-
-    ~~~~ sh
-    pnpm install
-    ~~~~
-
-4.  Start the server:
+5.  Open the server using Deno:
 
     ~~~~ sh
     deno serve -A index.ts
     ~~~~
 
-5.  Look up the actor URL:
+6.  Lookup an actor using `@fedify/cli`:
 
-    ~~~~
-    http://localhost:8000/users/{identifier}
+    ~~~~ sh
+    fedify lookup http://localhost:8000/users/{identifier}
     ~~~~


### PR DESCRIPTION
## Summary

- Add `examples/h3/README.md` to document the H3 example.

Fixes #882 

## Test plan

- `hongdown --check examples/h3/README.md`

## AI disclosure

This change was written with assistance from ChatGPT (GPT-5.5-mini), reviewed and verified by me.