### PR TITLE
Add integration tests for packages/fresh/src/mod.ts (#863, #864, #865)

### DIFF
--- a/packages/fresh/deno.json
+++ b/packages/fresh/deno.json
@@ -19,6 +19,7 @@
     ]
   },
   "tasks": {
-    "check": "deno fmt --check && deno lint && deno check src/*.ts"
+    "check": "deno fmt --check && deno lint && deno check src/*.ts",
+    "test": "deno test --allow-all src/mod.test.ts"
   }
 }

--- a/packages/fresh/src/mod.test.ts
+++ b/packages/fresh/src/mod.test.ts
@@ -29,7 +29,8 @@ Deno.test("integrateFetchOptions() - onNotFound delegates to ctx.next with corre
   const options = integrateFetchOptions(mockCtx);
   const request = new Request("https://example.com/some-page");
 
-  const response = await options.onNotFound!(request);
+  assertExists(options.onNotFound);
+  const response = await options.onNotFound(request);
 
   assertStrictEquals(capturedThis, mockCtx);
   assertStrictEquals(passedRequest, request);
@@ -45,8 +46,8 @@ Deno.test("onNotAcceptable() returns Fresh response when not 404", async () => {
   assertExists(options.onNotAcceptable);
   const response = await options.onNotAcceptable(ctx.req);
 
-  assertEquals(response.status, 200);
-  assertEquals(await response.text(), "ok");
+  assertStrictEquals(response.status, 200);
+  assertStrictEquals(await response.text(), "ok");
 });
 
 Deno.test("onNotAcceptable() returns 406 when Fresh returns 404", async () => {
@@ -58,9 +59,9 @@ Deno.test("onNotAcceptable() returns 406 when Fresh returns 404", async () => {
   assertExists(options.onNotAcceptable);
   const response = await options.onNotAcceptable(ctx.req);
 
-  assertEquals(response.status, 406);
-  assertEquals(response.headers.get("Vary"), "Accept");
-  assertEquals(response.headers.get("Content-Type"), "text/plain");
+  assertStrictEquals(response.status, 406);
+  assertStrictEquals(response.headers.get("Vary"), "Accept");
+  assertStrictEquals(response.headers.get("Content-Type"), "text/plain");
 });
 
 Deno.test("integrateHandler() calls createContextData and passes result to federation.fetch()", async () => {
@@ -85,7 +86,7 @@ Deno.test("integrateHandler() calls createContextData and passes result to feder
   const handler = integrateHandler(mockFederation, createContextData);
   const response = await handler(ctx);
 
-  assertEquals(receivedContextData, expectedContextData);
+  assertStrictEquals(receivedContextData, expectedContextData);
   assertStrictEquals(receivedRequest, ctx.req);
   assertEquals(await response.text(), "ok");
 });
@@ -107,5 +108,5 @@ Deno.test("integrateHandler() supports an async createContextData factory", asyn
   const handler = integrateHandler(mockFederation, createContextData);
   await handler(ctx);
 
-  assertEquals(receivedContextData, expectedContextData);
+  assertStrictEquals(receivedContextData, expectedContextData);
 });

--- a/packages/fresh/src/mod.test.ts
+++ b/packages/fresh/src/mod.test.ts
@@ -1,6 +1,6 @@
 import type { Federation } from "@fedify/fedify";
 import { integrateFetchOptions, integrateHandler } from "@fedify/fresh";
-import { assertEquals, assertExists, assertStrictEquals } from "@std/assert";
+import { assertExists, assertStrictEquals } from "@std/assert";
 import type { Context } from "fresh";
 
 function createMockContext<TState>(
@@ -88,7 +88,7 @@ Deno.test("integrateHandler() calls createContextData and passes result to feder
 
   assertStrictEquals(receivedContextData, expectedContextData);
   assertStrictEquals(receivedRequest, ctx.req);
-  assertEquals(await response.text(), "ok");
+  assertStrictEquals(await response.text(), "ok");
 });
 
 Deno.test("integrateHandler() supports an async createContextData factory", async () => {

--- a/packages/fresh/src/mod.test.ts
+++ b/packages/fresh/src/mod.test.ts
@@ -1,0 +1,30 @@
+import { integrateFetchOptions } from "@fedify/fresh";
+import { assertEquals, assertExists } from "@std/assert";
+import type { Context } from "fresh";
+
+function createMockContext<TState>(
+  overrides: Partial<Context<TState>> = {},
+): Context<TState> {
+  return {
+    req: new Request("https://example.com/"),
+    next: () => Promise.resolve(new Response(null, { status: 404 })),
+    ...overrides,
+  } as Context<TState>;
+}
+
+Deno.test("integrateFetchOptions() wires onNotFound to ctx.next()", async () => {
+  let nextCalled = false;
+  const ctx = createMockContext({
+    next: () => {
+      nextCalled = true;
+      return Promise.resolve(new Response("fresh page"));
+    },
+  });
+
+  const options = integrateFetchOptions(ctx);
+  assertExists(options.onNotFound);
+  const response = await options.onNotFound(ctx.req);
+
+  assertEquals(nextCalled, true);
+  assertEquals(await response.text(), "fresh page");
+});

--- a/packages/fresh/src/mod.test.ts
+++ b/packages/fresh/src/mod.test.ts
@@ -35,8 +35,8 @@ Deno.test("integrateFetchOptions() - onNotFound delegates to ctx.next with corre
   // 1. this(receiver)가 mockCtx 자신인지 검증 (this 바인딩 유지 여부)
   assertStrictEquals(capturedThis, mockCtx);
   // 2. Request 전달 및 응답 검증
-  assertEquals(passedRequest, request);
-  assertEquals(response.status, 404);
+  assertStrictEquals(passedRequest, request);
+  assertStrictEquals(response, notFoundResponse);
 });
 
 Deno.test("onNotAcceptable() returns Fresh response when not 404", async () => {

--- a/packages/fresh/src/mod.test.ts
+++ b/packages/fresh/src/mod.test.ts
@@ -1,5 +1,6 @@
-import { integrateFetchOptions } from "@fedify/fresh";
-import { assertEquals, assertExists } from "@std/assert";
+import type { Federation } from "@fedify/fedify";
+import { integrateFetchOptions, integrateHandler } from "@fedify/fresh";
+import { assertEquals, assertExists, assertStrictEquals } from "@std/assert";
 import type { Context } from "fresh";
 
 function createMockContext<TState>(
@@ -54,4 +55,51 @@ Deno.test("onNotAcceptable() returns 406 when Fresh returns 404", async () => {
   assertEquals(response.status, 406);
   assertEquals(response.headers.get("Vary"), "Accept");
   assertEquals(response.headers.get("Content-Type"), "text/plain");
+});
+
+Deno.test("integrateHandler() calls createContextData and passes result to federation.fetch()", async () => {
+  const expectedContextData = { userId: "test-user" };
+  let receivedContextData: unknown;
+  let receivedRequest: Request | undefined;
+
+  const mockFederation = {
+    fetch: (req: Request, opts: { contextData: unknown }) => {
+      receivedRequest = req;
+      receivedContextData = opts.contextData;
+      return Promise.resolve(new Response("ok"));
+    },
+  } as unknown as Federation<unknown>;
+
+  const ctx = createMockContext();
+  const createContextData = (c: Context<unknown>) => {
+    assertStrictEquals(c, ctx);
+    return expectedContextData;
+  };
+
+  const handler = integrateHandler(mockFederation, createContextData);
+  const response = await handler(ctx);
+
+  assertEquals(receivedContextData, expectedContextData);
+  assertStrictEquals(receivedRequest, ctx.req);
+  assertEquals(await response.text(), "ok");
+});
+
+Deno.test("integrateHandler() supports an async createContextData factory", async () => {
+  const expectedContextData = { userId: "async-user" };
+  let receivedContextData: unknown;
+
+  const mockFederation = {
+    fetch: (_req: Request, opts: { contextData: unknown }) => {
+      receivedContextData = opts.contextData;
+      return Promise.resolve(new Response("ok"));
+    },
+  } as unknown as Federation<unknown>;
+
+  const createContextData = () => Promise.resolve(expectedContextData);
+
+  const ctx = createMockContext();
+  const handler = integrateHandler(mockFederation, createContextData);
+  await handler(ctx);
+
+  assertEquals(receivedContextData, expectedContextData);
 });

--- a/packages/fresh/src/mod.test.ts
+++ b/packages/fresh/src/mod.test.ts
@@ -18,10 +18,9 @@ Deno.test("integrateFetchOptions() - onNotFound delegates to ctx.next with corre
   let passedRequest: Request | undefined;
   let capturedThis: unknown;
 
-  // 화살표 함수 대신 일반 function을 사용하여 this 바인딩을 검증
   const mockCtx = {
     next(req?: Request) {
-      capturedThis = this; // 실행 시점의 this(receiver)를 기록
+      capturedThis = this;
       passedRequest = req;
       return Promise.resolve(notFoundResponse);
     },
@@ -32,9 +31,7 @@ Deno.test("integrateFetchOptions() - onNotFound delegates to ctx.next with corre
 
   const response = await options.onNotFound!(request);
 
-  // 1. this(receiver)가 mockCtx 자신인지 검증 (this 바인딩 유지 여부)
   assertStrictEquals(capturedThis, mockCtx);
-  // 2. Request 전달 및 응답 검증
   assertStrictEquals(passedRequest, request);
   assertStrictEquals(response, notFoundResponse);
 });

--- a/packages/fresh/src/mod.test.ts
+++ b/packages/fresh/src/mod.test.ts
@@ -13,21 +13,30 @@ function createMockContext<TState>(
   } as Context<TState>;
 }
 
-Deno.test("integrateFetchOptions() wires onNotFound to ctx.next()", async () => {
-  let nextCalled = false;
-  const ctx = createMockContext({
-    next: () => {
-      nextCalled = true;
-      return Promise.resolve(new Response("fresh page"));
+Deno.test("integrateFetchOptions() - onNotFound delegates to ctx.next with correct receiver", async () => {
+  const notFoundResponse = new Response("Not Found", { status: 404 });
+  let passedRequest: Request | undefined;
+  let capturedThis: unknown;
+
+  // 화살표 함수 대신 일반 function을 사용하여 this 바인딩을 검증
+  const mockCtx = {
+    next(req?: Request) {
+      capturedThis = this; // 실행 시점의 this(receiver)를 기록
+      passedRequest = req;
+      return Promise.resolve(notFoundResponse);
     },
-  });
+  } as unknown as Context<unknown>;
 
-  const options = integrateFetchOptions(ctx);
-  assertExists(options.onNotFound);
-  const response = await options.onNotFound(ctx.req);
+  const options = integrateFetchOptions(mockCtx);
+  const request = new Request("https://example.com/some-page");
 
-  assertEquals(nextCalled, true);
-  assertEquals(await response.text(), "fresh page");
+  const response = await options.onNotFound!(request);
+
+  // 1. this(receiver)가 mockCtx 자신인지 검증 (this 바인딩 유지 여부)
+  assertStrictEquals(capturedThis, mockCtx);
+  // 2. Request 전달 및 응답 검증
+  assertEquals(passedRequest, request);
+  assertEquals(response.status, 404);
 });
 
 Deno.test("onNotAcceptable() returns Fresh response when not 404", async () => {

--- a/packages/fresh/src/mod.test.ts
+++ b/packages/fresh/src/mod.test.ts
@@ -28,3 +28,30 @@ Deno.test("integrateFetchOptions() wires onNotFound to ctx.next()", async () => 
   assertEquals(nextCalled, true);
   assertEquals(await response.text(), "fresh page");
 });
+
+Deno.test("onNotAcceptable() returns Fresh response when not 404", async () => {
+  const ctx = createMockContext({
+    next: () => Promise.resolve(new Response("ok", { status: 200 })),
+  });
+
+  const options = integrateFetchOptions(ctx);
+  assertExists(options.onNotAcceptable);
+  const response = await options.onNotAcceptable(ctx.req);
+
+  assertEquals(response.status, 200);
+  assertEquals(await response.text(), "ok");
+});
+
+Deno.test("onNotAcceptable() returns 406 when Fresh returns 404", async () => {
+  const ctx = createMockContext({
+    next: () => Promise.resolve(new Response(null, { status: 404 })),
+  });
+
+  const options = integrateFetchOptions(ctx);
+  assertExists(options.onNotAcceptable);
+  const response = await options.onNotAcceptable(ctx.req);
+
+  assertEquals(response.status, 406);
+  assertEquals(response.headers.get("Vary"), "Accept");
+  assertEquals(response.headers.get("Content-Type"), "text/plain");
+});


### PR DESCRIPTION
Closes #863, Closes #864, Closes #865


Background
----------

`@fedify/fresh` provides middleware integration between Fedify and Fresh. To protect the baseline coexistence of standard Fresh pages and Fedify federation endpoints, dedicated regression tests were added for core integration behaviors:

 1. **Not Found Delegation (#863)**: Ensures unhandled routes fall back to Fresh's `ctx.next()`.
 2. **Not Acceptable Fallback (#864)**: Ensures browser HTML requests render via Fresh first, returning `406` only when Fresh returns `404`.
 3. **Context Data Flow (#865)**: Ensures application state in Fresh context flows into `federation.fetch()` via `createContextData`.


Changes
-------

 - Add unit tests in `packages/fresh/src/mod.test.ts`:
   - `integrateFetchOptions()`: Verify `onNotFound` delegates to `ctx.next()`.
   - `integrateFetchOptions()`: Verify `onNotAcceptable` returns Fresh response for non-404 results and returns `406` when Fresh returns `404`.
   - `integrateHandler()`: Verify `createContextData` is called with Fresh context and the result is forwarded to `federation.fetch()`.


Testing
-------

 - `mise run check-each fresh`
 - `deno test --allow-all src/mod.test.ts` (5 passed, 0 failed)


AI assistance
-------------

This PR description and test implementations were drafted with AI assistance (Gemini) and finalized after human review and testing.