### PR TITLE
Add a test to prevent README framework list drift

### DIFF
--- a/docs/tutorial/astro-blog.md
+++ b/docs/tutorial/astro-blog.md
@@ -153,7 +153,7 @@ Select *Astro*, *bun*, *in-process*, and *in-memory* in order:
   Hono
   Nitro
   Next.js
-  ElysiaJS
+  Elysia
 ❯ Astro
   Express
 

--- a/docs/tutorial/microblog.md
+++ b/docs/tutorial/microblog.md
@@ -164,7 +164,7 @@ Select *Hono*, *npm*, *in-process*, and *in-memory* in order:
 ❯ Hono
   Nitro
   Next.js
-  ElysiaJS
+  Elysia
   Astro
   Express
   Nuxt

--- a/packages/init/src/types.ts
+++ b/packages/init/src/types.ts
@@ -113,7 +113,7 @@ export interface WebFrameworkInitializer {
 
 /**
  * Describes a web framework integration (Hono, Express, Nitro, Next.js,
- * ElysiaJS, Astro) and how to initialize a project with it.
+ * Elysia, Astro) and how to initialize a project with it.
  */
 export interface WebFrameworkDescription {
   /** Human-readable name of the framework (e.g., `"Hono"`, `"Next.js"`). */

--- a/packages/init/src/webframeworks.test.ts
+++ b/packages/init/src/webframeworks.test.ts
@@ -1,9 +1,12 @@
 import { equal, ok } from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
 import test from "node:test";
+import { fileURLToPath } from "node:url";
 import astroDescription from "./webframeworks/astro.ts";
+import webFrameworks from "./webframeworks/mod.ts";
 import nextDescription from "./webframeworks/next.ts";
 import nitroDescription from "./webframeworks/nitro.ts";
-import webFrameworks from "./webframeworks/mod.ts";
 import solidstartDescription from "./webframeworks/solidstart.ts";
 
 test("Nitro template loads LogTape during server startup", async () => {
@@ -160,5 +163,22 @@ test("Astro Node.js and Bun templates use Prettier for Astro files", async () =>
     equal(initializer.devDependencies?.["oxfmt"], undefined);
     equal(initializer.devDependencies?.["oxlint"] != null, true);
     equal(initializer.format?.tool, "prettier");
+  }
+});
+
+test("README.md's web framework list matches the framework registry", async () => {
+  const modList = Object.values(webFrameworks).map((f) => f.label);
+  const readmeFile = resolve(dirname(fileURLToPath(import.meta.url)), "..", "README.md");
+  const readme = await readFile(readmeFile, "utf-8");
+  const readmeWebframeworks = readme.match(/\*\*Web frameworks\*\*:\s*([\s\S]+?)(?=\n\s*-\s*\*\*)/);
+  ok(readmeWebframeworks);
+  const readmeList = readmeWebframeworks[1]
+    .split(/,\s*/)
+    .map((s) => s.trim().replace(/^\[|\]$/g, ""));
+  equal(modList.length, readmeList.length);
+  modList.sort();
+  readmeList.sort();
+  for (let i = 0; i < modList.length; i++){
+    equal(modList[i], readmeList[i]);
   }
 });

--- a/packages/init/src/webframeworks.test.ts
+++ b/packages/init/src/webframeworks.test.ts
@@ -168,9 +168,15 @@ test("Astro Node.js and Bun templates use Prettier for Astro files", async () =>
 
 test("README.md's web framework list matches the framework registry", async () => {
   const modList = Object.values(webFrameworks).map((f) => f.label);
-  const readmeFile = resolve(dirname(fileURLToPath(import.meta.url)), "..", "README.md");
+  const readmeFile = resolve(
+    dirname(fileURLToPath(import.meta.url)),
+    "..",
+    "README.md",
+  );
   const readme = await readFile(readmeFile, "utf-8");
-  const readmeWebframeworks = readme.match(/\*\*Web frameworks\*\*:\s*([\s\S]+?)(?=\n\s*-\s*\*\*)/);
+  const readmeWebframeworks = readme.match(
+    /\*\*Web frameworks\*\*:\s*([\s\S]+?)(?=\n\s*-\s*\*\*)/,
+  );
   ok(readmeWebframeworks);
   const readmeList = readmeWebframeworks[1]
     .split(/,\s*/)
@@ -178,7 +184,7 @@ test("README.md's web framework list matches the framework registry", async () =
   equal(modList.length, readmeList.length);
   modList.sort();
   readmeList.sort();
-  for (let i = 0; i < modList.length; i++){
+  for (let i = 0; i < modList.length; i++) {
     equal(modList[i], readmeList[i]);
   }
 });

--- a/packages/init/src/webframeworks.test.ts
+++ b/packages/init/src/webframeworks.test.ts
@@ -167,7 +167,7 @@ test("Astro Node.js and Bun templates use Prettier for Astro files", async () =>
 });
 
 test("README.md's web framework list matches the framework registry", async () => {
-  const modList = Object.values(webFrameworks).map((f) => f.label);
+  const modSet = new Set(Object.values(webFrameworks).map((f) => f.label));
   const readmeFile = resolve(
     dirname(fileURLToPath(import.meta.url)),
     "..",
@@ -178,13 +178,25 @@ test("README.md's web framework list matches the framework registry", async () =
     /\*\*Web frameworks\*\*:\s*([\s\S]+?)(?=\n\s*-\s*\*\*)/,
   );
   ok(readmeWebframeworks);
-  const readmeList = readmeWebframeworks[1]
-    .split(/,\s*/)
-    .map((s) => s.trim().replace(/^\[|\]$/g, ""));
-  equal(modList.length, readmeList.length);
-  modList.sort();
-  readmeList.sort();
-  for (let i = 0; i < modList.length; i++) {
-    equal(modList[i], readmeList[i]);
+  const readmeSet = new Set(
+    readmeWebframeworks[1]
+      .split(/,\s*/)
+      .map((s) => s.trim().replace(/^\[|\]$/g, "")),
+  );
+  const missingInReadme = modSet.difference(readmeSet);
+  const missingInMod = readmeSet.difference(modSet);
+  const errorMsg = [];
+  if (missingInReadme.size > 0) {
+    errorMsg.push(
+      `Missing from README.md: ${[...missingInReadme].join(", ")}`,
+    );
+  }
+  if (missingInMod.size > 0) {
+    errorMsg.push(
+      `Missing from the framework registry: ${[...missingInMod].join(", ")}`,
+    );
+  }
+  if (errorMsg.length > 0) {
+    throw new Error(errorMsg.join("\n"));
   }
 });

--- a/packages/init/src/webframeworks/elysia.ts
+++ b/packages/init/src/webframeworks/elysia.ts
@@ -6,7 +6,7 @@ import { defaultDenoDependencies, defaultDevDependencies } from "./const.ts";
 import { getInstruction, nodeBunDevToolTasks, pmToRt } from "./utils.ts";
 
 const elysiaDescription: WebFrameworkDescription = {
-  label: "ElysiaJS",
+  label: "Elysia",
   packageManagers: PACKAGE_MANAGER,
   defaultPort: 3000,
   init: async ({ projectName, packageManager: pm }) => ({


### PR DESCRIPTION
Related issue
-------------

#888


Summary
-------

`fedify init`'s web framework list lives in two places: the framework registry in *packages/init/src/webframeworks/mod.ts* and the list in *packages/init/README.md*.  The registry is source code, but the README is maintained by hand, so the two can drift apart without anyone noticing.

This PR adds a test to *webframeworks.test.ts* that extracts both lists — the registry's `label` values and the framework names in the README — sorts them, and compares them entry by entry.

While writing the test, the two lists did not match at first.  The only difference turned out to be `elysia`: its `label` was `"ElysiaJS"`, while the README and the rest of the documentation (*docs/cli.md*, *docs/manual/integration.md*) use `"Elysia"`, matching the framework's own homepage branding.  I fixed *webframeworks/elysia.ts* to use `"Elysia"` so the new test passes.

That label change makes two tutorial pages stale, since they embed a literal transcript of the `fedify init` prompt showing the old `"ElysiaJS"` text: I updated *docs/tutorial/astro-blog.md*, *docs/tutorial/microblog.md*, and, for consistency, a JSDoc example in *packages/init/src/types.ts*.

### Naming mismatch found

| `mod.ts` key | `label` before | `label` after | README.md    |
| ------------ | -------------- | ------------- | ------------ |
| `bare-bones` | `Bare-bones`   | —             | `Bare-bones` |
| `astro`      | `Astro`        | —             | `Astro`      |
| `elysia`     | `ElysiaJS`     | `Elysia`      | `Elysia`     |
| `express`    | `Express`      | —             | `Express`    |
| `hono`       | `Hono`         | —             | `Hono`       |
| `next`       | `Next.js`      | —             | `Next.js`    |
| `nitro`      | `Nitro`        | —             | `Nitro`      |
| `nuxt`       | `Nuxt`         | —             | `Nuxt`       |
| `solidstart` | `SolidStart`   | —             | `SolidStart` |
| `sveltekit`  | `SvelteKit`    | —             | `SvelteKit`  |

### Impact of the label change

I searched the codebase for other uses of `"ElysiaJS"` and of the `label` field.  `label` is only used for display text: the `fedify init` framework prompt, a package-manager compatibility message, and `test:init`'s console output.  No test or snapshot depends on the exact string, and the generated project files are unaffected.  I have ran `fedify init` interactively to see the new prompt, and checked it.


How I tested this
-----------------

 -  `mise run test:deno packages/init/src/webframeworks.test.ts`
 -  `mise run check-each init`


AI usage
--------

I used Claude (Sonnet 5) throughout this change: debugging the regex and `split()` logic in the test, explaining JavaScript/TypeScript syntax I was unfamiliar with (object shorthand properties, regex anchors, `Object.values` versus `Object.keys`), researching Elysia's official display name, spotting the two tutorial pages that went stale because of the label change, and reviewing the test for redundant assertions.  I wrote and understood the final test and fix myself, and ran the checks above to confirm the result.
