### PR TITLE
Add delegation tests for `@fedify/elysia`

### DIFF
--- a/packages/elysia/src/index.test.ts
+++ b/packages/elysia/src/index.test.ts
@@ -77,4 +77,37 @@ describe("[elysia] fedify() plugin", () => {
       "body must come from Elysia",
     );
   });
+
+  test("fedify() falls through to Elysia routes when federation declines the request via onNotAcceptable", async () => {
+    const elysia = new Elysia().get(
+      "/users/alice",
+      ({ set, status }) => {
+        set.headers["X-Custom-Header"] = "custom-value";
+        return status(200, "Hello Alice");
+      },
+    );
+    // Register the actor route so the request matches, but ask for text/html
+    // so federation declines via onNotAcceptable instead of handling it.
+    const federation = createFederation<void>({ kv: new MemoryKvStore() });
+    federation.setActorDispatcher("/users/{identifier}", () => null);
+
+    elysia.use(fedify(federation, () => undefined));
+    const response = await elysia.handle(
+      new Request("http://localhost/users/alice", {
+        headers: { Accept: "text/html" },
+      }),
+    );
+
+    assert.strictEqual(response.status, 200, "status must come from Elysia");
+    assert.strictEqual(
+      response.headers.get("X-Custom-Header"),
+      "custom-value",
+      "header must come from Elysia",
+    );
+    assert.strictEqual(
+      await response.text(),
+      "Hello Alice",
+      "body must come from Elysia",
+    );
+  });
 });

--- a/packages/elysia/src/index.test.ts
+++ b/packages/elysia/src/index.test.ts
@@ -1,3 +1,4 @@
+import { createFederation, MemoryKvStore } from "@fedify/fedify";
 import { Elysia } from "elysia";
 import { strict as assert } from "node:assert";
 import { describe, test } from "node:test";
@@ -44,6 +45,36 @@ describe("[elysia] fedify() plugin", () => {
       actual,
       "Hello World",
       "federation.fetch() must receive the context data returned by the factory",
+    );
+  });
+
+  test("fedify() falls through to Elysia routes when federation reports not-found via onNotFound", async () => {
+    const elysia = new Elysia().get(
+      "/hello-world",
+      ({ set, status }) => {
+        set.headers["X-Custom-Header"] = "custom-value";
+        return status(201, "Hello World");
+      },
+    );
+    const federationWithoutDispatcher = createFederation<void>({
+      kv: new MemoryKvStore(),
+    });
+
+    elysia.use(fedify(federationWithoutDispatcher, () => undefined));
+    const response = await elysia.handle(
+      new Request("http://localhost/hello-world"),
+    );
+
+    assert.strictEqual(response.status, 201, "status must come from Elysia");
+    assert.strictEqual(
+      response.headers.get("X-Custom-Header"),
+      "custom-value",
+      "header must come from Elysia",
+    );
+    assert.strictEqual(
+      await response.text(),
+      "Hello World",
+      "body must come from Elysia",
     );
   });
 });


### PR DESCRIPTION
Closes #854

## Summary

Adds two tests to `packages/elysia/src/index.test.ts` that verify the `fedify()` plugin does not return a Fedify response when federation delegates the request back to the app.

### 1) Not-found delegation test

A federation with no dispatcher registered reports not-found via `onNotFound`,
and the status, headers, and body all come from the app's own Elysia route.

### 2) Not-acceptable delegation test

A request matches the actor route while `Accept: text/html` rules out JSON-LD,
so federation declines via `onNotAcceptable` and the app's own Elysia route serves the response.

## Test Plan

Tested with the commands below, and all of them passed.

- `mise run check-each elysia`
- `mise run test-each elysia`
- `deno test --allow-all ./packages/elysia`
- `bun test ./packages/elysia`
- `mise run test`

AI assistance disclosure: Claude Code (claude-fable-5) helped write the tests, verify them across runtimes, and draft the commit messages and this description.