### PR TITLE
Fix public audience interop

### DIFF
--- a/packages/fedify/src/compat/mod.ts
+++ b/packages/fedify/src/compat/mod.ts
@@ -1,2 +1,3 @@
 export * from "./transformers.ts";
 export * from "./types.ts";
+export * from "./public-audience.ts";

--- a/packages/fedify/src/compat/public-audience.ts
+++ b/packages/fedify/src/compat/public-audience.ts
@@ -3,6 +3,14 @@ import { PUBLIC_COLLECTION } from "@fedify/vocab";
 
 const logger = getLogger(["fedify", "compat", "public-audience"]);
 
+/**
+ * Rewrites the compact `as:Public` or `Public` CURIE in the `object` field of a
+ * serialized Follow activity to the full ActivityStreams Public collection URI.
+ *
+ * Some ActivityPub implementations compare the field as a plain URL
+ * without applying JSON-LD expansion, causing them to reject public-addressed
+ * Follow activities that use a compact IRI. This helper works around that gap.
+ */
 export function normalizePublicFollowObject(
   jsonLd: unknown,
 ): unknown {

--- a/packages/fedify/src/compat/public-audience.ts
+++ b/packages/fedify/src/compat/public-audience.ts
@@ -1,0 +1,36 @@
+import { getLogger } from "@logtape/logtape";
+import { PUBLIC_COLLECTION } from "@fedify/vocab";
+
+const logger = getLogger(["fedify", "compat", "public-audience"]);
+
+export function normalizePublicFollowObject(
+  jsonLd: unknown,
+): unknown {
+  if (typeof jsonLd !== "object" || jsonLd === null) {
+    return jsonLd;
+  }
+
+  try {
+    const record = jsonLd as Record<string, unknown>;
+    if (
+      record.type === "Follow" &&
+      (record.object === "as:Public" || record.object === "Public")
+    ) {
+      const normalized = {
+        ...record,
+        object: PUBLIC_COLLECTION.href,
+      };
+
+      return normalized;
+    }
+  } catch (error) {
+    logger.debug(
+      "Failed to normalize public follow object; sending the activity as is.\n{error}",
+      {
+        error,
+      },
+    );
+  }
+
+  return jsonLd;
+}

--- a/packages/fedify/src/federation/middleware.test.ts
+++ b/packages/fedify/src/federation/middleware.test.ts
@@ -1691,6 +1691,7 @@ test("FederationImpl.sendActivity()", async (t) => {
 
   let verified: ("http" | "ld" | "proof")[] | null = null;
   let request: Request | null = null;
+  let receivedJson: unknown = null;
   fetchMock.post("https://example.com/inbox", async (cl) => {
     verified = [];
     request = cl.request!.clone() as Request;
@@ -1699,6 +1700,7 @@ test("FederationImpl.sendActivity()", async (t) => {
       contextLoader: mockDocumentLoader,
     };
     let json = await cl.request!.json();
+    receivedJson = json;
     if (await verifyJsonLd(json, options)) verified.push("ld");
     json = detachSignature(json);
     let activity = await verifyObject(vocab.Activity, json, options);
@@ -1806,6 +1808,35 @@ test("FederationImpl.sendActivity()", async (t) => {
       request?.headers.get("Content-Type"),
       "application/activity+json",
     );
+  });
+
+  await t.step("normalizes a relay Follow object before sending", async () => {
+    const follow = new vocab.Follow({
+      id: new URL("https://example.com/activities/follow-relay"),
+      actor: new URL("https://example.com/person2"),
+      object: vocab.PUBLIC_COLLECTION,
+    });
+    const inboxes = {
+      "https://example.com/inbox": {
+        actorIds: ["https://example.com/recipient"],
+        sharedInbox: false,
+      },
+    };
+
+    verified = null;
+    receivedJson = null;
+    await federation.sendActivity(
+      [{ privateKey: ed25519PrivateKey, keyId: ed25519Multikey.id! }],
+      inboxes,
+      follow,
+      { context },
+    );
+
+    assertEquals(
+      (receivedJson as Record<string, unknown>).object,
+      vocab.PUBLIC_COLLECTION.href,
+    );
+    assertEquals(verified, ["proof"]);
   });
 
   fetchMock.hardReset();

--- a/packages/fedify/src/federation/middleware.ts
+++ b/packages/fedify/src/federation/middleware.ts
@@ -1346,6 +1346,7 @@ export class FederationImpl<TContextData>
       format: "compact",
       contextLoader,
     });
+    jsonLd = normalizePublicFollowObject(jsonLd);
     if (rsaKey == null) {
       logger.warn(
         "No supported key found to create a Linked Data signature for " +
@@ -1362,7 +1363,6 @@ export class FederationImpl<TContextData>
       );
     } else {
       try {
-        jsonLd = normalizePublicFollowObject(jsonLd);
         jsonLd = await signJsonLd(jsonLd, rsaKey.privateKey, rsaKey.keyId, {
           contextLoader,
           tracerProvider: this.tracerProvider,

--- a/packages/fedify/src/federation/middleware.ts
+++ b/packages/fedify/src/federation/middleware.ts
@@ -48,6 +48,7 @@ import {
 } from "@opentelemetry/semantic-conventions";
 import metadata from "../../deno.json" with { type: "json" };
 import { getDefaultActivityTransformers } from "../compat/transformers.ts";
+import { normalizePublicFollowObject } from "../compat/public-audience.ts";
 import type { ActivityTransformer } from "../compat/types.ts";
 import { getNodeInfo, type GetNodeInfoOptions } from "../nodeinfo/client.ts";
 import { handleNodeInfo, handleNodeInfoJrd } from "../nodeinfo/handler.ts";
@@ -1361,6 +1362,7 @@ export class FederationImpl<TContextData>
       );
     } else {
       try {
+        jsonLd = normalizePublicFollowObject(jsonLd);
         jsonLd = await signJsonLd(jsonLd, rsaKey.privateKey, rsaKey.keyId, {
           contextLoader,
           tracerProvider: this.tracerProvider,

--- a/packages/fedify/src/sig/proof.test.ts
+++ b/packages/fedify/src/sig/proof.test.ts
@@ -3,13 +3,16 @@ import {
   Create,
   type CryptographicKey,
   DataIntegrityProof,
+  Follow,
   Multikey,
   Note,
   Place,
+  PUBLIC_COLLECTION,
 } from "@fedify/vocab";
 import { decodeMultibase, importMultibaseKey } from "@fedify/vocab-runtime";
 import { assertEquals, assertInstanceOf, assertRejects } from "@std/assert";
 import { decodeHex, encodeHex } from "byte-encodings/hex";
+import { normalizePublicFollowObject } from "../compat/public-audience.ts";
 import {
   ed25519Multikey,
   ed25519PrivateKey,
@@ -263,6 +266,37 @@ test("signObject()", async () => {
       }),
     TypeError,
     "Unsupported algorithm",
+  );
+});
+
+test("signObject() signs a normalized relay Follow object", async () => {
+  const follow = new Follow({
+    id: new URL("https://example.com/activities/follow-relay"),
+    actor: new URL("https://example.com/person2"),
+    object: PUBLIC_COLLECTION,
+  });
+  const signed = await signObject(
+    follow,
+    ed25519PrivateKey,
+    ed25519Multikey.id!,
+    { contextLoader: mockDocumentLoader },
+  );
+  const compact = await signed.toJsonLd({
+    format: "compact",
+    contextLoader: mockDocumentLoader,
+  });
+  const normalized = normalizePublicFollowObject(compact) as Record<
+    string,
+    unknown
+  >;
+
+  assertEquals(normalized.object, PUBLIC_COLLECTION.href);
+  assertInstanceOf(
+    await verifyObject(Follow, normalized, {
+      documentLoader: mockDocumentLoader,
+      contextLoader: mockDocumentLoader,
+    }),
+    Follow,
   );
 });
 

--- a/packages/fedify/src/sig/proof.ts
+++ b/packages/fedify/src/sig/proof.ts
@@ -11,6 +11,7 @@ import { SpanStatusCode, trace, type TracerProvider } from "@opentelemetry/api";
 import { encodeHex } from "byte-encodings/hex";
 import serialize from "json-canon";
 import metadata from "../../deno.json" with { type: "json" };
+import { normalizePublicFollowObject } from "../compat/public-audience.ts";
 import {
   fetchKey,
   type FetchKeyResult,
@@ -66,11 +67,12 @@ export async function createProof(
     throw new TypeError("Unsupported algorithm: " + privateKey.algorithm.name);
   }
   const objectWithoutProofs = object.clone({ proofs: [] });
-  const compactMsg = await objectWithoutProofs.toJsonLd({
+  let compactMsg = await objectWithoutProofs.toJsonLd({
     format: "compact",
     contextLoader,
     context,
   });
+  compactMsg = normalizePublicFollowObject(compactMsg);
   const msgCanon = serialize(compactMsg);
   const encoder = new TextEncoder();
   const msgBytes = encoder.encode(msgCanon);


### PR DESCRIPTION
Closes #998 

It adds `normalizePublicFollowObject()` helper to rewrite the compact `as:Public` or `Public` in the `Follow.object` to the full ActivityStreams Public collection URI.  Some ActivityPub implementations, especially relays in this issue, compare the field as a plain URL without applying JSON-LD expansion. That causes them to reject public-addressed `Follow` activities that use a compact IRI. 

This fix follows the structure introduced in #710, but does not copy the entire `public-audience.ts` file because the `2.0-maintenance` branch predates the Threadiverse tutorial.