### PR TITLE
Test the 406 fallback in @fedify/express

### DIFF
--- a/packages/express/src/index.test.ts
+++ b/packages/express/src/index.test.ts
@@ -92,4 +92,27 @@ describe("integrateFederation()", () => {
     assert.strictEqual(nextCalled, false);
     assert.strictEqual(getBody(), "Hello World");
   });
+
+  test("responds with 406 when onNotAcceptable is used and no route matches", async () => {
+    const mockFederation: MockFederation = {
+      fetch(_request, options) {
+        const { onNotAcceptable } = options as {
+          onNotAcceptable: () => Response;
+        };
+        return Promise.resolve(onNotAcceptable());
+      },
+    };
+
+    const middleware = integrateFederation(
+      mockFederation as never,
+      () => undefined,
+    );
+
+    const req = createMockRequest();
+    const { response, ended } = createMockResponse();
+
+    middleware(req, response, () => {});
+    await ended;
+    assert.strictEqual(response.statusCode, 406);
+  });
 });


### PR DESCRIPTION
Resolves #858.

## Summary

*@fedify/express* uses `onNotAcceptable` to let Express try HTML routes before falling back to a 406, which is what keeps an actor and its HTML profile page shareable on one URL.  The fallback branch—no route matched, so the middleware sends the 406 itself—had no test.

This adds a test in *packages/express/src/index.test.ts* that drives `integrateFederation()` with a mock federation calling `onNotAcceptable()`, and asserts the response status is 406.


## Tests

 -  `mise run test:deno packages/express/src/index.test.ts`
 -  `mise run check-each express`


## AI disclosure

Assisted-by: Claude Code:claude-opus 4.8

This change was written with assistance from Claude Code (`claude-opus-4-8`), reviewed and verified by me.