### PR TITLE
Add a unit test for WorkersMessageQueue.listen()

### DIFF
--- a/packages/cfworkers/src/mod.test.ts
+++ b/packages/cfworkers/src/mod.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { type WorkersKvNamespaceLike, WorkersKvStore } from "./mod.ts";
+import {
+  type WorkersKvNamespaceLike,
+  WorkersKvStore,
+  WorkersMessageQueue,
+} from "./mod.ts";
 
 // Mock Temporal.Duration for testing in Cloudflare Workers environment
 const mockDuration = (seconds: number) => ({
@@ -307,5 +311,18 @@ describe("WorkersKvStore", () => {
     expect(entries).toContainEqual({ key: ["page", "e"], value: "value-e" });
 
     expect(namespace.listCalls).toBe(3);
+  });
+});
+
+describe("WorkersMessageQueue", () => {
+  // listen() throws before touching the queue, so no methods are needed.
+  const mockQueue = {} as unknown as Queue;
+
+  it("listen() throws TypeError", () => {
+    const queue = new WorkersMessageQueue(mockQueue);
+    expect(() => queue.listen(() => {})).toThrow(TypeError);
+    expect(() => queue.listen(() => {})).toThrow(
+      "WorkersMessageQueue does not support listen().",
+    );
   });
 });

--- a/packages/cfworkers/src/mod.test.ts
+++ b/packages/cfworkers/src/mod.test.ts
@@ -322,7 +322,8 @@ describe("WorkersMessageQueue", () => {
     const queue = new WorkersMessageQueue(mockQueue);
     expect(() => queue.listen(() => {})).toThrow(TypeError);
     expect(() => queue.listen(() => {})).toThrow(
-      "WorkersMessageQueue does not support listen().",
+      "WorkersMessageQueue does not support listen().  " +
+        "Use Federation.processQueuedTask() method instead.",
     );
   });
 });


### PR DESCRIPTION
## Summary

`WorkersMessageQueue` cannot implement `listen()` because the `queue()` handler is the only way to consume a queue inside a Worker, and Cloudflare invokes it rather than exposing anything the adapter can poll:

> A [consumer Worker][], which is push-based: the Worker is invoked when the queue has messages to deliver.

A pull-based [HTTP pull consumer][] does exist, but it runs "outside of Cloudflare Workers" and cannot coexist with a push-based consumer on the same queue, so it is not available here.  The adapter throws a `TypeError` instead, which is the behavior documented in *docs/manual/mq.md*.

[consumer Worker]: https://developers.cloudflare.com/queues/reference/how-queues-works/
[HTTP pull consumer]: https://developers.cloudflare.com/queues/configuration/pull-consumers/

This adds a `WorkersMessageQueue` block to that file, covering both the error type and the message that points users to `Federation.processQueuedTask()`.

The mock queue is an empty object cast to `Queue`, since `listen()` throws before touching the queue binding.  Unlike `WorkersKvStore`, which has `WorkersKvNamespaceLike` for this purpose, there is no equivalent interface for `Queue`.

Closes #881

## Test plan

- [x] `mise run check-each cfworkers` — the check suggested in the issue
- [x] `tsc -p test/typecheck/tsconfig.json --noEmit` (packages/cfworkers)
- [x] `vitest run` (packages/cfworkers) — 41 tests passed across 3 files
- [x] Confirmed the test fails when the behavior it pins is broken

Changing `TypeError` to `Error` fails only the type assertion, and altering the message fails only the message assertion:

~~~~
❯ src/mod.test.ts:323
    expect(() => queue.listen(() => {})).toThrow(TypeError);

Tests  1 failed | 14 passed (15)
~~~~

`mise run test-each cfworkers` could not be run locally: `@fedify/vocab-runtime` f's npm resolution does not place `typescript` in `rolldown-plugin-dts`'s dependency
tree, so the build resolves the wrong `tsdown` copy.  This looks unrelated to thisn the same commit.  The package's own `test` script steps were run directly instead.

## AI disclosure

Claude Code (`claude-opus-5`) assisted with this change: it located the existing tckage, drafted the test, and diagnosed type errors along the way.  I reviewed andedited the result, made the final decisions, and ran all verification myself.