### PR TITLE
fix: update miscellany context to 1.0.1 to fix bug with re-compaction

### DIFF
--- a/changes.d/vocab-runtime/miscellany-context.md
+++ b/changes.d/vocab-runtime/miscellany-context.md
@@ -1,0 +1,8 @@
+---
+links:
+  '#1002': https://github.com/fedify-dev/fedify/issues/1002
+  '#1003': https://github.com/fedify-dev/fedify/pull/1003
+---
+ -  Changed `miscellany` context to match public version 1.0.1,
+    which fixes a bug with re-compacting Mastodon and similar content using
+    boolean flags (`manuallyApprovesFollowers`, `sensitive`). [[#1002], [#1003]]

--- a/packages/vocab-runtime/src/contexts/miscellany.json
+++ b/packages/vocab-runtime/src/contexts/miscellany.json
@@ -4,16 +4,14 @@
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "Hashtag": "as:Hashtag",
     "manuallyApprovesFollowers": {
-      "@id": "as:manuallyApprovesFollowers",
-      "@type": "xsd:boolean"
+      "@id": "as:manuallyApprovesFollowers"
     },
     "movedTo": {
       "@id": "as:movedTo",
       "@type": "@id"
     },
     "sensitive": {
-      "@id": "as:sensitive",
-      "@type": "xsd:boolean"
+      "@id": "as:sensitive"
     }
   }
 }


### PR DESCRIPTION
This PR updates the pre-cached miscellany context to track upstream version 1.0.1. The upstream version fixes a bug with re-compaction of Mastodon and similar content.