### PR TITLE
Cover the ordering lock release in cfworkers

### DIFF
--- a/packages/cfworkers/src/mod.test.ts
+++ b/packages/cfworkers/src/mod.test.ts
@@ -64,12 +64,9 @@ class MockKvNamespace implements WorkersKvNamespaceLike {
     type: "json",
   ): Promise<ExpectedValue | null>;
   get(key: string, type?: "json") {
-    if (type !== "json") {
-      throw new Error("MockKvNamespace only uses the JSON mode of get().");
-    }
-
     const entry = this.entries.get(key);
     if (entry == null) return Promise.resolve(null);
+    if (type !== "json") return Promise.resolve(entry.value);
     return Promise.resolve(JSON.parse(entry.value));
   }
 
@@ -325,5 +322,33 @@ describe("WorkersMessageQueue", () => {
       "WorkersMessageQueue does not support listen().  " +
         "Use Federation.processQueuedTask() method instead.",
     );
+  });
+
+  it("processMessage() - release() frees the ordering lock", async () => {
+    const orderingKv = new MockKvNamespace();
+    const queue = new WorkersMessageQueue(mockQueue, { orderingKv });
+
+    const first = await queue.processMessage({
+      __fedify_ordering_key__: "actor-1",
+      __fedify_payload__: { id: "first" },
+    });
+
+    expect(first.shouldProcess).toBe(true);
+    expect(first.message).toEqual({ id: "first" });
+    expect(orderingKv.entries.has("__fedify_ordering_actor-1")).toBe(true);
+
+    await first.release?.();
+
+    expect(orderingKv.entries.has("__fedify_ordering_actor-1")).toBe(false);
+
+    // Releasing is only meaningful if it lets the next message through, so
+    // check the queue actually moves rather than just that the key is gone.
+    const second = await queue.processMessage({
+      __fedify_ordering_key__: "actor-1",
+      __fedify_payload__: { id: "second" },
+    });
+
+    expect(second.shouldProcess).toBe(true);
+    expect(second.message).toEqual({ id: "second" });
   });
 });


### PR DESCRIPTION
Closes #880.

`processMessage()` hands back a `release()` callback once it takes an ordering
key lock, and nothing in the suite checked that calling it actually deletes the
lock.  A `release()` that quietly stopped deleting would stall every ordered
queue and no test would notice.

The test takes the lock through `processMessage()`, asserts the KV entry exists,
calls `release()`, then asserts it is gone.  It also pushes a second message
through the same ordering key afterwards and expects it to be processed —
asserting that a key vanished from a mock felt like thin evidence on its own,
and "the next message can run" is the behaviour that actually matters here.

One supporting change: `MockKvNamespace.get()` threw unless it was called in
JSON mode, but `processMessage()` reads the lock as a plain string.  It now
returns the raw value for an untyped `get()` and parses only when
`type === "json"`, which leaves the existing `WorkersKvStore` tests untouched.

## Checks

- `mise run check-each cfworkers` — passes
- `mise run test-each cfworkers` — 42 tests pass across 3 files
- Confirmed the test is not vacuous: stubbing `release()` into a no-op makes it
  fail with `expected true to be false`, and it passes again once reverted.

No changelog fragment, since this is test-only work; the commit carries
`Changelog: none`.

## AI disclosure

Per *AI_POLICY.md*: this was written with Claude Code (claude-opus-5).  It
drafted the test and ran the checks listed above.  The commit carries the
`Assisted-by: Claude Code:claude-opus-5` trailer.

That verification is done: the diff has been reviewed, `test-each` and
`check-each` re-run on this branch, and the mutation check above repeated to
confirm the test fails when `release()` stops deleting the lock.

Also: CONTRIBUTING asks contributors to comment on an issue and wait to be
assigned.  I have opened this as a draft rather than commented, so if you would
rather hand #880 to someone else, say the word and I will close it.

