### PR TITLE
Add a README for the SolidStart example

### DIFF
--- a/examples/solidstart/README.md
+++ b/examples/solidstart/README.md
@@ -1,0 +1,72 @@
+<!-- deno-fmt-ignore-file -->
+
+Fedify–SolidStart integration example application
+=================================================
+
+An example of building a federated server application using [Fedify] with
+[SolidStart].  It serves a single demo actor over ActivityPub, so it can be
+looked up and followed from other federated platforms such as [Mastodon] or
+[Misskey].
+
+Federation is wired up in *src/lib/federation.ts* and mounted through
+`fedifyMiddleware()` in *src/middleware/index.ts*.  Keys and follower
+relationships are kept in memory, so they are discarded whenever the server
+restarts.
+
+[Fedify]: https://fedify.dev
+[SolidStart]: https://start.solidjs.com/
+[Mastodon]: https://mastodon.social/
+[Misskey]: https://misskey.io/
+
+
+Running the example
+-------------------
+
+~~~~ sh
+pnpm install
+pnpm dev
+~~~~
+
+The server listens on <http://localhost:3000/>, which redirects to the demo
+actor's profile page.
+
+
+Looking up the actor
+--------------------
+
+The example exposes one actor, `demo`, at
+<http://localhost:3000/users/demo>:
+
+~~~~ sh
+curl -H "Accept: application/activity+json" http://localhost:3000/users/demo
+~~~~
+
+WebFinger and NodeInfo are served too:
+
+~~~~ sh
+curl "http://localhost:3000/.well-known/webfinger?resource=acct:demo@localhost:3000"
+curl http://localhost:3000/nodeinfo/2.1
+~~~~
+
+
+Communicate with other federated servers
+----------------------------------------
+
+1.  Tunnel your local server to the internet using `fedify tunnel`:
+
+    ~~~~ sh
+    fedify tunnel 3000
+    ~~~~
+
+2.  Open the tunneled URL in your browser and check that the server is running
+    properly.
+
+3.  Search for `@demo@<your tunneled host>` from another federated server and
+    follow it.  The example answers a `Follow` with an `Accept` and records the
+    follower, so the follower count on the profile page goes up.
+
+    > [!NOTE]
+    > [ActivityPub Academy] is a great resource to learn how to interact with
+    > other federated servers using the ActivityPub protocol.
+
+[ActivityPub Academy]: https://www.activitypub.academy/

--- a/examples/solidstart/app.config.ts
+++ b/examples/solidstart/app.config.ts
@@ -5,4 +5,7 @@ export default defineConfig({
   server: {
     preset: "node-server",
   },
+  vite: {
+    server: { allowedHosts: true },
+  },
 });


### PR DESCRIPTION
Closes #883.

*examples/solidstart* had a full app but no README, so the only way to find out
which actor it serves, or on which port, was to read the source tree.

The README covers the install and run commands, the demo actor URL, the
WebFinger and NodeInfo endpoints, and the `fedify tunnel` steps for following
the actor from another server.  I kept it close in shape to
*examples/nuxt/README.md* rather than the longer *sveltekit-sample* one, since
the issue asked for something short.

## A second commit, because the tunnel steps did not work

Writing the tunnel section and then actually running it turned up a bug in the
example itself.  Vite rejects any request whose Host header it does not
recognise, so every request through `fedify tunnel` came back as:

~~~~
Blocked request. This host ("...serveousercontent.com") is not allowed.
To allow this host, add "..." to `server.allowedHosts` in vite.config.js.
~~~~

That makes step 2 of the section impossible and the follow step unreachable.
The sibling examples had already hit this — nuxt, sveltekit-sample, astro and
netlify-astro all set `allowedHosts` in their configs — and *app.config.ts*
here was simply missing it, so the second commit adds the same three lines.

I would rather widen the diff slightly than land a README whose instructions
403.  Happy to split it into its own PR against a separate issue if you would
prefer to keep this one documentation-only.

## Checks

- `hongdown --check examples/solidstart/README.md` — passes
- `deno fmt --check` on *app.config.ts* — passes
- Ran `pnpm dev` and confirmed every URL in the README responds:
  - `GET /` → `302` to `/users/demo`
  - `GET /users/demo` with `Accept: application/activity+json` → `200`,
    `content-type: application/activity+json`
  - `GET /.well-known/webfinger?resource=acct:demo@localhost:3000` → `200`
  - `GET /nodeinfo/2.1` → `200`
  - port 3000 confirmed from the running server, not assumed
- Ran the tunnel section end to end.  With the fix, the tunnelled actor
  resolves over HTTPS with its `id` and `inbox` rewritten to the public host,
  WebFinger answers for `acct:demo@<tunnel host>`, and
  `fedify lookup @demo@<tunnel host>` completes discovery and reads back the
  keys and shared inbox — the sequence a remote server runs before it delivers
  a `Follow`.
- Ran the follow itself from a throwaway ActivityPub Academy account.  The
  handle resolved in Mastodon's search, the `Follow` reached the inbox, the
  example answered with an `Accept`, and the follower count on the profile page
  went from 0 to 1 with the remote actor recorded in
  `/users/demo/followers` — so every step of that section is confirmed working,
  not just the endpoints leading up to it.

I did not touch *examples/README.md*, since #885 covers the index entry.

## AI disclosure

Per *AI_POLICY.md*: this was written with Claude Code (claude-opus-5).  It
drafted the README, made the *app.config.ts* fix, and ran the checks listed
above.  Both commits carry the `Assisted-by: Claude Code:claude-opus-5`
trailer.


