### PR TITLE
Add response-handling tests for @fedify/h3

### DIFF
--- a/packages/h3/deno.json
+++ b/packages/h3/deno.json
@@ -16,6 +16,7 @@
     ]
   },
   "tasks": {
-    "check": "deno fmt --check && deno lint && deno check src/*.ts"
+    "check": "deno fmt --check && deno lint && deno check src/*.ts",
+    "test": "deno test --allow-all"
   }
 }

--- a/packages/h3/package.json
+++ b/packages/h3/package.json
@@ -44,6 +44,7 @@
     "package.json"
   ],
   "devDependencies": {
+    "@types/node": "catalog:",
     "tsdown": "catalog:",
     "typescript": "catalog:"
   },
@@ -55,6 +56,8 @@
     "build:self": "tsdown",
     "build": "pnpm --filter @fedify/h3... run build:self",
     "prepack": "pnpm build",
-    "prepublish": "pnpm build"
+    "prepublish": "pnpm build",
+    "test": "node --experimental-transform-types --test",
+    "test:bun": "bun test src/"
   }
 }

--- a/packages/h3/src/index.test.ts
+++ b/packages/h3/src/index.test.ts
@@ -45,4 +45,24 @@ describe("integrateFederation()", () => {
     assert.equal(respondWithCalls.length, 1);
     assert.equal(respondWithCalls[0], okResponse);
   });
+
+  test("does not respond and delegates to the next handler on 404 Not Found", async () => {
+    const mockFederation: MockFederation = {
+      fetch() {
+        return Promise.resolve(new Response(null, { status: 404 }));
+      },
+    };
+    const handler = integrateFederation(
+      mockFederation as unknown as Federation<void>,
+      () => undefined,
+    );
+    const { event, respondWithCalls } = createMockEvent(
+      new Request("https://example.com/"),
+    );
+
+    await handler(event);
+
+    assert.equal(respondWithCalls.length, 0);
+    assert.equal("__fedify_response__" in event.context, false);
+  });
 });

--- a/packages/h3/src/index.test.ts
+++ b/packages/h3/src/index.test.ts
@@ -1,0 +1,48 @@
+import type { Federation } from "@fedify/fedify";
+import type { H3Event } from "h3";
+import { strict as assert } from "node:assert";
+import { describe, test } from "node:test";
+import { integrateFederation } from "./index.ts";
+
+interface MockFederation {
+  fetch(request: Request, options: unknown): Promise<Response>;
+}
+
+function createMockEvent(request: Request): {
+  event: H3Event;
+  respondWithCalls: Response[];
+} {
+  const respondWithCalls: Response[] = [];
+  const event = {
+    web: { request },
+    context: {},
+    respondWith(response: Response) {
+      respondWithCalls.push(response);
+      return Promise.resolve();
+    },
+  };
+  return { event: event as unknown as H3Event, respondWithCalls };
+}
+
+describe("integrateFederation()", () => {
+  test("responds with the Fedify response when it is handled (e.g., 200 OK)", async () => {
+    const okResponse = new Response("Hello, world!", { status: 200 });
+    const mockFederation: MockFederation = {
+      fetch() {
+        return Promise.resolve(okResponse);
+      },
+    };
+    const handler = integrateFederation(
+      mockFederation as unknown as Federation<void>,
+      () => undefined,
+    );
+    const { event, respondWithCalls } = createMockEvent(
+      new Request("https://example.com/"),
+    );
+
+    await handler(event);
+
+    assert.equal(respondWithCalls.length, 1);
+    assert.equal(respondWithCalls[0], okResponse);
+  });
+});

--- a/packages/h3/src/index.test.ts
+++ b/packages/h3/src/index.test.ts
@@ -1,8 +1,8 @@
 import type { Federation } from "@fedify/fedify";
-import type { H3Event } from "h3";
+import type { H3Error, H3Event } from "h3";
 import { strict as assert } from "node:assert";
 import { describe, test } from "node:test";
-import { integrateFederation } from "./index.ts";
+import { integrateFederation, onError } from "./index.ts";
 
 interface MockFederation {
   fetch(request: Request, options: unknown): Promise<Response>;
@@ -85,5 +85,79 @@ describe("integrateFederation()", () => {
 
     assert.equal(respondWithCalls.length, 0);
     assert.equal(event.context["__fedify_response__"], notAcceptableResponse);
+  });
+
+  test("waits for an async contextDataFactory and passes the resolved value to federation.fetch()", async () => {
+    let resolveContextData!: (value: string) => void;
+    let fetchCalled = false;
+    let receivedContextData: unknown;
+    const mockFederation: MockFederation = {
+      fetch(_request, options) {
+        fetchCalled = true;
+        const { contextData } = options as { contextData: unknown };
+        receivedContextData = contextData;
+        return Promise.resolve(new Response(null, { status: 200 }));
+      },
+    };
+    const contextDataFactory = () =>
+      new Promise<string>((resolve) => {
+        resolveContextData = resolve;
+      });
+    const handler = integrateFederation(
+      mockFederation as unknown as Federation<string>,
+      contextDataFactory,
+    );
+    const { event } = createMockEvent(new Request("https://example.com/"));
+
+    const handlerPromise = handler(event);
+    await Promise.resolve();
+    assert.equal(fetchCalled, false);
+
+    resolveContextData("context data");
+    await handlerPromise;
+
+    assert.equal(fetchCalled, true);
+    assert.equal(receivedContextData, "context data");
+  });
+});
+
+describe("onError()", () => {
+  function createMockError(statusCode: number): H3Error {
+    return { statusCode } as unknown as H3Error;
+  }
+
+  test("responds with the stored 406 response when the handler later reports 404", async () => {
+    const notAcceptableResponse = new Response(null, { status: 406 });
+    const { event, respondWithCalls } = createMockEvent(
+      new Request("https://example.com/"),
+    );
+    event.context["__fedify_response__"] = notAcceptableResponse;
+
+    await onError(createMockError(404), event);
+
+    assert.equal(respondWithCalls.length, 1);
+    assert.equal(respondWithCalls[0], notAcceptableResponse);
+  });
+
+  test("does nothing when there is no stored 406 response", async () => {
+    const { event, respondWithCalls } = createMockEvent(
+      new Request("https://example.com/"),
+    );
+
+    await onError(createMockError(404), event);
+
+    assert.equal(respondWithCalls.length, 0);
+  });
+
+  test("does nothing when the error status is not 404", async () => {
+    const notAcceptableResponse = new Response(null, { status: 406 });
+    const { event, respondWithCalls } = createMockEvent(
+      new Request("https://example.com/"),
+    );
+    event.context["__fedify_response__"] = notAcceptableResponse;
+
+    await onError(createMockError(500), event);
+
+    assert.equal(respondWithCalls.length, 0);
   });
 });

--- a/packages/h3/src/index.test.ts
+++ b/packages/h3/src/index.test.ts
@@ -65,4 +65,25 @@ describe("integrateFederation()", () => {
     assert.equal(respondWithCalls.length, 0);
     assert.equal("__fedify_response__" in event.context, false);
   });
+
+  test("stores the response in the event context on 406 Not Acceptable", async () => {
+    const notAcceptableResponse = new Response(null, { status: 406 });
+    const mockFederation: MockFederation = {
+      fetch() {
+        return Promise.resolve(notAcceptableResponse);
+      },
+    };
+    const handler = integrateFederation(
+      mockFederation as unknown as Federation<void>,
+      () => undefined,
+    );
+    const { event, respondWithCalls } = createMockEvent(
+      new Request("https://example.com/"),
+    );
+
+    await handler(event);
+
+    assert.equal(respondWithCalls.length, 0);
+    assert.equal(event.context["__fedify_response__"], notAcceptableResponse);
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1400,6 +1400,9 @@ importers:
         specifier: 'catalog:'
         version: 1.15.11
     devDependencies:
+      '@types/node':
+        specifier: 'catalog:'
+        version: 22.19.1
       tsdown:
         specifier: 'catalog:'
         version: 0.22.0(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.34(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1))
@@ -24759,7 +24762,7 @@ snapshots:
       - react-native-b4a
       - supports-color
 
-  '@stackbit/cms-contentful@0.4.56(debug@4.4.1)(graphql@16.14.2)':
+  '@stackbit/cms-contentful@0.4.56(debug@4.4.1)':
     dependencies:
       '@contentful/rich-text-types': 15.15.1
       '@stackbit/cms-core': 2.0.1(@types/react@19.1.8)(debug@4.4.1)(graphql@16.14.2)
@@ -24773,7 +24776,6 @@ snapshots:
       - bare-buffer
       - debug
       - encoding
-      - graphql
       - react-native-b4a
       - supports-color
 
@@ -24849,33 +24851,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@stackbit/cms-git@0.4.18(@types/react@19.1.8)(debug@4.4.1)(graphql@16.14.2)':
-    dependencies:
-      '@stackbit/artisanal-names': 1.0.1
-      '@stackbit/cms-core': 2.0.1(@types/react@19.1.8)(debug@4.4.1)(graphql@16.14.2)
-      '@stackbit/sdk': 2.0.1
-      '@stackbit/types': 1.0.1
-      '@stackbit/utils': 0.4.19
-      axios: 0.24.0(debug@4.4.1)
-      fs-extra: 11.3.6
-      git-url-parse: 13.1.1
-      lodash: 4.18.1
-      micromatch: 4.0.8
-      slugify: 1.6.9
-    transitivePeerDependencies:
-      - '@types/react'
-      - bare-abort-controller
-      - bare-buffer
-      - bufferutil
-      - canvas
-      - debug
-      - encoding
-      - graphql
-      - react-native-b4a
-      - supports-color
-      - utf-8-validate
-
-  '@stackbit/cms-git@0.4.18(@types/react@19.1.8)(graphql@16.14.2)':
+  '@stackbit/cms-git@0.4.18':
     dependencies:
       '@stackbit/artisanal-names': 1.0.1
       '@stackbit/cms-core': 2.0.1(@types/react@19.1.8)(graphql@16.14.2)
@@ -24889,17 +24865,33 @@ snapshots:
       micromatch: 4.0.8
       slugify: 1.6.9
     transitivePeerDependencies:
-      - '@types/react'
       - bare-abort-controller
       - bare-buffer
-      - bufferutil
-      - canvas
       - debug
       - encoding
-      - graphql
       - react-native-b4a
       - supports-color
-      - utf-8-validate
+
+  '@stackbit/cms-git@0.4.18(debug@4.4.1)':
+    dependencies:
+      '@stackbit/artisanal-names': 1.0.1
+      '@stackbit/cms-core': 2.0.1(@types/react@19.1.8)(debug@4.4.1)(graphql@16.14.2)
+      '@stackbit/sdk': 2.0.1
+      '@stackbit/types': 1.0.1
+      '@stackbit/utils': 0.4.19
+      axios: 0.24.0(debug@4.4.1)
+      fs-extra: 11.3.6
+      git-url-parse: 13.1.1
+      lodash: 4.18.1
+      micromatch: 4.0.8
+      slugify: 1.6.9
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - debug
+      - encoding
+      - react-native-b4a
+      - supports-color
 
   '@stackbit/cms-sanity@0.2.56(@types/react@19.1.8)':
     dependencies:
@@ -24928,7 +24920,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@stackbit/cms-sanity@0.2.56(@types/react@19.1.8)(debug@4.4.1)(graphql@16.14.2)':
+  '@stackbit/cms-sanity@0.2.56(@types/react@19.1.8)(debug@4.4.1)':
     dependencies:
       '@sanity/block-tools': 2.36.6
       '@sanity/client': 3.4.1
@@ -24951,7 +24943,6 @@ snapshots:
       - canvas
       - debug
       - encoding
-      - graphql
       - react-native-b4a
       - supports-color
       - utf-8-validate
@@ -24962,7 +24953,7 @@ snapshots:
       '@stackbit/artisanal-names': 1.0.1
       '@stackbit/cms-contentful': 0.4.56
       '@stackbit/cms-core': 2.0.1(@types/react@19.1.8)(graphql@16.14.2)
-      '@stackbit/cms-git': 0.4.18(@types/react@19.1.8)(graphql@16.14.2)
+      '@stackbit/cms-git': 0.4.18
       '@stackbit/cms-sanity': 0.2.56(@types/react@19.1.8)
       '@stackbit/sdk': 2.0.1
       '@stackbit/types': 1.0.1
@@ -24996,14 +24987,14 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@stackbit/dev-common@0.5.51(@types/react@19.1.8)(debug@4.4.1)(graphql@16.14.2)':
+  '@stackbit/dev-common@0.5.51(@types/react@19.1.8)(debug@4.4.1)':
     dependencies:
       '@iarna/toml': 2.2.5
       '@stackbit/artisanal-names': 1.0.1
-      '@stackbit/cms-contentful': 0.4.56(debug@4.4.1)(graphql@16.14.2)
+      '@stackbit/cms-contentful': 0.4.56(debug@4.4.1)
       '@stackbit/cms-core': 2.0.1(@types/react@19.1.8)(debug@4.4.1)(graphql@16.14.2)
-      '@stackbit/cms-git': 0.4.18(@types/react@19.1.8)(debug@4.4.1)(graphql@16.14.2)
-      '@stackbit/cms-sanity': 0.2.56(@types/react@19.1.8)(debug@4.4.1)(graphql@16.14.2)
+      '@stackbit/cms-git': 0.4.18(debug@4.4.1)
+      '@stackbit/cms-sanity': 0.2.56(@types/react@19.1.8)(debug@4.4.1)
       '@stackbit/sdk': 2.0.1
       '@stackbit/types': 1.0.1
       '@stackbit/utils': 0.4.19
@@ -25032,7 +25023,6 @@ snapshots:
       - canvas
       - debug
       - encoding
-      - graphql
       - react-native-b4a
       - supports-color
       - utf-8-validate
@@ -25040,8 +25030,8 @@ snapshots:
   '@stackbit/dev@1.0.35(@types/react@19.1.8)(debug@4.4.1)(graphql@16.14.2)':
     dependencies:
       '@stackbit/cms-core': 2.0.1(@types/react@19.1.8)(debug@4.4.1)(graphql@16.14.2)
-      '@stackbit/cms-git': 0.4.18(@types/react@19.1.8)(debug@4.4.1)(graphql@16.14.2)
-      '@stackbit/dev-common': 0.5.51(@types/react@19.1.8)(debug@4.4.1)(graphql@16.14.2)
+      '@stackbit/cms-git': 0.4.18(debug@4.4.1)
+      '@stackbit/dev-common': 0.5.51(@types/react@19.1.8)(debug@4.4.1)
       '@stackbit/sdk': 2.0.1
       axios: 0.25.0(debug@4.4.1)
       chalk: 4.1.2
@@ -25075,7 +25065,7 @@ snapshots:
   '@stackbit/dev@1.0.35(@types/react@19.1.8)(graphql@16.14.2)':
     dependencies:
       '@stackbit/cms-core': 2.0.1(@types/react@19.1.8)(graphql@16.14.2)
-      '@stackbit/cms-git': 0.4.18(@types/react@19.1.8)(graphql@16.14.2)
+      '@stackbit/cms-git': 0.4.18
       '@stackbit/dev-common': 0.5.51(@types/react@19.1.8)
       '@stackbit/sdk': 2.0.1
       axios: 0.25.0


### PR DESCRIPTION
Closes #859, Closes #860, Closes #861, Closes #862

## Background

`@fedify/h3` provides middleware integration between Fedify and h3. `integrateFederation()` and `onError()` had no test coverage at all, and the package itself had no way to run its test suite under `mise run test:node` / `test:bun` / `test-each`.

## Changes

- Add a `test` task to *packages/h3/deno.json* and `test` / `test:bun` scripts to *packages/h3/package.json* so the suite actually runs.
- Add unit tests in *packages/h3/src/index.test.ts*:
    - `integrateFederation()`: Verify it calls `event.respondWith()` when Fedify handles a request (#859).
    - `integrateFederation()`: Verify it does not respond and lets the next handler run on a 404 (#860).
    - `integrateFederation()`: Verify it stores the response on `event.context` on a 406 instead of responding immediately (#861).
    - `integrateFederation()`: Verify it awaits an async `contextDataFactory` before calling `federation.fetch()`, mirroring the ordering check added for `@fedify/express` in #985.
    - `onError()`: Verify it responds with the stored 406 response only when the handler later reports 404, and does nothing otherwise (#862).

## Testing

- `mise run check-each h3`
- `mise run test-each h3` (Deno, Node.js, and Bun all pass)

## AI disclosure

This change was written with assistance from Claude Code (`claude-sonnet-5`), reviewed and verified by me.