### PR TITLE
Fix public audience interop

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,17 @@ Version 2.2.11
 
 To be released.
 
+### @fedify/fedify
+
+ -  Fixed some public relay subscription requests being rejected by
+    implementations that compare `Follow.object` as a plain URL without JSON-LD
+    expansion.  The Public collection in relay `Follow` activities is now
+    serialized as its full ActivityStreams URI instead of a compact IRI.
+    [[#998], [#1008] by Jiwon Kwon\]
+
+[#998]: https://github.com/fedify-dev/fedify/issues/998
+[#1008]: https://github.com/fedify-dev/fedify/pull/1008
+
 
 Version 2.2.10
 --------------

--- a/changes.d/fedify/public-relay-follow.md
+++ b/changes.d/fedify/public-relay-follow.md
@@ -1,0 +1,10 @@
+---
+links:
+  '#1008': https://github.com/fedify-dev/fedify/pull/1008
+  '#998': https://github.com/fedify-dev/fedify/issues/998
+---
+ -  Fixed some public relay subscription requests being rejected by
+    implementations that compare `Follow.object` as a plain URL without JSON-LD
+    expansion.  The Public collection in relay `Follow` activities is now
+    serialized as its full ActivityStreams URI instead of a compact IRI.
+    [[#998], [#1008] by Jiwon Kwon\]

--- a/packages/fedify/src/compat/public-audience.test.ts
+++ b/packages/fedify/src/compat/public-audience.test.ts
@@ -1,5 +1,5 @@
 import { test } from "@fedify/fixture";
-import { Create, Note, PUBLIC_COLLECTION } from "@fedify/vocab";
+import { Create, Follow, Note, PUBLIC_COLLECTION } from "@fedify/vocab";
 import { getDocumentLoader, preloadedContexts } from "@fedify/vocab-runtime";
 import { assertEquals } from "@std/assert/assert-equals";
 import { assertNotEquals } from "@std/assert/assert-not-equals";
@@ -57,6 +57,25 @@ test("normalizePublicAudience() normalises activities serialized by @fedify/voca
   assertEquals(normalized.to, PUBLIC_URI);
   const nestedObject = normalized.object as Record<string, unknown>;
   assertEquals(nestedObject.to, PUBLIC_URI);
+});
+
+test("normalizePublicAudience() normalises a public relay Follow object", async () => {
+  const activity = new Follow({
+    id: new URL("https://example.com/activities/follow-relay"),
+    actor: new URL("https://example.com/alice"),
+    object: PUBLIC_COLLECTION,
+  });
+  const compact = await activity.toJsonLd({ format: "compact" }) as Record<
+    string,
+    unknown
+  >;
+  assertEquals(compact.object, "as:Public");
+
+  const normalized = await normalizePublicAudience(
+    compact,
+    getDocumentLoader(),
+  ) as Record<string, unknown>;
+  assertEquals(normalized.object, PUBLIC_URI);
 });
 
 test("normalizePublicAudience() is a no-op without the CURIE", async () => {

--- a/packages/fedify/src/compat/public-audience.ts
+++ b/packages/fedify/src/compat/public-audience.ts
@@ -55,6 +55,16 @@ function hasPublicCurieInAddressing(
   if (typeof value !== "object" || value == null) return false;
   const record = value as Record<string, unknown>;
   for (const key of Object.keys(record)) {
+    // Some relay implementations compare a subscription's Follow.object as a
+    // plain URL without expanding its Public CURIE.  Keep this type-specific
+    // instead of treating every `object` property as a public-addressing field.
+    if (
+      record.type === "Follow" &&
+      key === "object" &&
+      (record[key] === "as:Public" || record[key] === "Public")
+    ) {
+      return true;
+    }
     // `@context` holds term definitions, not addressing values; skip it so
     // we do not traverse potentially large inline context objects.
     if (key === "@context") continue;
@@ -101,9 +111,14 @@ function rewritePublicAudience(
   const normalized: Record<string, unknown> = Object.create(null);
   for (const key of Object.keys(record)) {
     // `@context` is never an addressing field, so skip the recursion and
-    // keep the reference intact.
+    // keep the reference intact.  Follow.object is handled separately because
+    // `object` is not a public-addressing field for other activity types.
     const rewritten = key === "@context"
       ? record[key]
+      : record.type === "Follow" &&
+          key === "object" &&
+          (record[key] === "as:Public" || record[key] === "Public")
+      ? PUBLIC_COLLECTION.href
       : rewritePublicAudience(record[key], key, depth + 1);
     if (rewritten !== record[key]) changed = true;
     normalized[key] = rewritten;


### PR DESCRIPTION
Closes #998 

This extends the public-audience normalisation to rewrite `as:Public` or `Public` in `Follow.object` to the full ActivityStreams Public collection URI. Some relay implementations compare `Follow.object` as a plain URL without applying JSON-LD expansion, so they reject otherwise valid relay subscription requests when the Public collection is represented as a compact IRI. The rewrites is limited to `Follow.object`, other `object` properties on other activity types remain unchanged. 

