### PR TITLE
Test 404 delegation in @fedify/solidstart

### DIFF
--- a/packages/solidstart/deno.json
+++ b/packages/solidstart/deno.json
@@ -16,6 +16,7 @@
     ]
   },
   "tasks": {
-    "check": "deno fmt --check && deno lint && deno check src/*.ts"
+    "check": "deno fmt --check && deno lint && deno check src/*.ts",
+    "test": "deno test --allow-all"
   }
 }

--- a/packages/solidstart/package.json
+++ b/packages/solidstart/package.json
@@ -49,7 +49,8 @@
     "build:self": "tsdown",
     "build": "pnpm --filter @fedify/solidstart... run build:self",
     "prepack": "pnpm build",
-    "prepublish": "pnpm build"
+    "prepublish": "pnpm build",
+    "test": "node --experimental-transform-types --test"
   },
   "peerDependencies": {
     "@fedify/fedify": "workspace:^",

--- a/packages/solidstart/src/handlers.ts
+++ b/packages/solidstart/src/handlers.ts
@@ -1,0 +1,88 @@
+import type { Federation } from "@fedify/fedify/federation";
+import type { FetchEvent } from "@solidjs/start/server";
+
+/**
+ * A factory function that creates the context data for the
+ * {@link Federation} object.
+ *
+ * @template TContextData The type of the context data.
+ * @param event The SolidStart {@link FetchEvent} for the current request.
+ * @returns The context data, or a promise resolving to the context data.
+ * @since 2.2.0
+ */
+export type ContextDataFactory<TContextData> = (
+  event: FetchEvent,
+) => TContextData | Promise<TContextData>;
+
+// Internal storage for 406 Not Acceptable responses across the
+// onRequest -> onBeforeResponse lifecycle, keyed by Request object.
+const notAcceptableResponses: WeakMap<Request, Response> = new WeakMap();
+
+/**
+ * Creates the `onRequest` handler wired into SolidStart by
+ * `fedifyMiddleware()`.
+ *
+ * @template TContextData A type of the context data for the
+ *                        {@link Federation} object.
+ * @param federation A {@link Federation} object to integrate with SolidStart.
+ * @param createContextData A function to create context data for the
+ *                          {@link Federation} object.
+ * @returns The `onRequest` handler.
+ */
+export function createOnRequestHandler<TContextData>(
+  federation: Federation<TContextData>,
+  createContextData: ContextDataFactory<TContextData>,
+): (event: FetchEvent) => Promise<Response | undefined> {
+  return async (event: FetchEvent) => {
+    const response = await federation.fetch(event.request, {
+      contextData: await createContextData(event),
+      onNotFound: () => new Response("Not Found", { status: 404 }),
+      onNotAcceptable: () =>
+        new Response("Not Acceptable", {
+          status: 406,
+          headers: { "Content-Type": "text/plain", Vary: "Accept" },
+        }),
+    });
+
+    // If Fedify does not handle this route, let SolidStart handle it:
+    if (response.status === 404) return;
+
+    // If content negotiation failed (client does not want JSON-LD),
+    // store the 406 response and let SolidStart try to serve HTML.
+    // If SolidStart also cannot handle it, onBeforeResponse will
+    // return the 406:
+    if (response.status === 406) {
+      notAcceptableResponses.set(event.request, response);
+      return;
+    }
+
+    // Fedify handled the request successfully:
+    return response;
+  };
+}
+
+/**
+ * Creates the `onBeforeResponse` handler wired into SolidStart by
+ * `fedifyMiddleware()`.
+ *
+ * @returns The `onBeforeResponse` handler.
+ */
+export function createOnBeforeResponseHandler(): (
+  event: FetchEvent,
+) => Response | undefined {
+  // Similar to onRequest, but slightly more tricky one.
+  // When the federation object finds a request not acceptable type-wise
+  // (i.e., a user-agent does not want JSON-LD), onRequest stores the 406
+  // response and lets SolidStart try to render HTML.  If SolidStart also
+  // has no page for this route (404), we return the stored 406 instead.
+  // This enables Fedify and SolidStart to share the same routes and do
+  // content negotiation depending on the Accept header:
+  return (event: FetchEvent) => {
+    const stored = notAcceptableResponses.get(event.request);
+    if (stored != null) {
+      notAcceptableResponses.delete(event.request);
+      const status = event.response.status ?? 200;
+      if (status === 404) return stored;
+    }
+  };
+}

--- a/packages/solidstart/src/index.test.ts
+++ b/packages/solidstart/src/index.test.ts
@@ -1,0 +1,42 @@
+import { createFederation, MemoryKvStore } from "@fedify/fedify";
+import type { FetchEvent } from "@solidjs/start/server";
+import { strict as assert } from "node:assert";
+import { describe, test } from "node:test";
+import { createOnRequestHandler } from "./handlers.ts";
+
+// The handlers are the SUT instead of fedifyMiddleware(): importing it
+// would load @solidjs/start's *.jsx* runtime modules, which need a bundler.
+describe("[solidstart] fedifyMiddleware()", () => {
+  test("returns no response when federation reports not-found via onNotFound", async () => {
+    // No dispatcher is registered, so federation.fetch() takes the
+    // onNotFound path for every request:
+    const federationWithoutDispatcher = createFederation<void>({
+      kv: new MemoryKvStore(),
+    });
+    let contextDataFactoryCalls = 0;
+    const onRequest = createOnRequestHandler(
+      federationWithoutDispatcher,
+      () => {
+        contextDataFactoryCalls++;
+      },
+    );
+
+    const event = {
+      request: new Request("http://localhost/hello-world"),
+      locals: {},
+    } as unknown as FetchEvent;
+    const response = await onRequest(event);
+
+    assert.strictEqual(
+      contextDataFactoryCalls,
+      1,
+      "the context data factory must be consulted for the request",
+    );
+    assert.strictEqual(
+      response,
+      undefined,
+      "onRequest must not return a response when Fedify reports not-found " +
+        "so that SolidStart can handle the request",
+    );
+  });
+});

--- a/packages/solidstart/src/index.ts
+++ b/packages/solidstart/src/index.ts
@@ -12,24 +12,13 @@
 
 import type { Federation } from "@fedify/fedify/federation";
 import { createMiddleware } from "@solidjs/start/middleware";
-import type { FetchEvent } from "@solidjs/start/server";
+import {
+  type ContextDataFactory,
+  createOnBeforeResponseHandler,
+  createOnRequestHandler,
+} from "./handlers.ts";
 
-/**
- * A factory function that creates the context data for the
- * {@link Federation} object.
- *
- * @template TContextData The type of the context data.
- * @param event The SolidStart {@link FetchEvent} for the current request.
- * @returns The context data, or a promise resolving to the context data.
- * @since 2.2.0
- */
-export type ContextDataFactory<TContextData> = (
-  event: FetchEvent,
-) => TContextData | Promise<TContextData>;
-
-// Internal storage for 406 Not Acceptable responses across the
-// onRequest -> onBeforeResponse lifecycle, keyed by Request object.
-const notAcceptableResponses: WeakMap<Request, Response> = new WeakMap();
+export type { ContextDataFactory } from "./handlers.ts";
 
 /**
  * Create a SolidStart middleware to integrate with the {@link Federation}
@@ -57,47 +46,7 @@ export function fedifyMiddleware<TContextData>(
     undefined as TContextData,
 ): ReturnType<typeof createMiddleware> {
   return createMiddleware({
-    onRequest: async (event: FetchEvent) => {
-      const response = await federation.fetch(event.request, {
-        contextData: await createContextData(event),
-        onNotFound: () => new Response("Not Found", { status: 404 }),
-        onNotAcceptable: () =>
-          new Response("Not Acceptable", {
-            status: 406,
-            headers: { "Content-Type": "text/plain", Vary: "Accept" },
-          }),
-      });
-
-      // If Fedify does not handle this route, let SolidStart handle it:
-      if (response.status === 404) return;
-
-      // If content negotiation failed (client does not want JSON-LD),
-      // store the 406 response and let SolidStart try to serve HTML.
-      // If SolidStart also cannot handle it, onBeforeResponse will
-      // return the 406:
-      if (response.status === 406) {
-        notAcceptableResponses.set(event.request, response);
-        return;
-      }
-
-      // Fedify handled the request successfully:
-      return response;
-    },
-
-    // Similar to onRequest, but slightly more tricky one.
-    // When the federation object finds a request not acceptable type-wise
-    // (i.e., a user-agent does not want JSON-LD), onRequest stores the 406
-    // response and lets SolidStart try to render HTML.  If SolidStart also
-    // has no page for this route (404), we return the stored 406 instead.
-    // This enables Fedify and SolidStart to share the same routes and do
-    // content negotiation depending on the Accept header:
-    onBeforeResponse: (event: FetchEvent) => {
-      const stored = notAcceptableResponses.get(event.request);
-      if (stored != null) {
-        notAcceptableResponses.delete(event.request);
-        const status = event.response.status ?? 200;
-        if (status === 404) return stored;
-      }
-    },
+    onRequest: createOnRequestHandler(federation, createContextData),
+    onBeforeResponse: createOnBeforeResponseHandler(),
   });
 }


### PR DESCRIPTION
Closes #872

## Summary

Adds a test that verifies the `onRequest` handler behind `fedifyMiddleware()` returns no response when `federation.fetch()` reports not-found via `onNotFound`, so SolidStart can handle the request with its own routes.

Taking `fedifyMiddleware()` itself as the SUT would require groundwork for loading the SolidStart framework into the test runtime, and no clean way to do that turned up.
so I judged that extracting the two callbacks that made up `fedifyMiddleware()` into `src/handlers.ts` and taking them as the SUT instead would still cover the behavior.

## Test plan

Tested with the commands below, and all of them passed.

 -  `mise run check-each solidstart`
 -  `mise run test-each solidstart`
 -  `deno test --allow-all ./packages/solidstart`
 -  `bun test ./packages/solidstart`
 -  `mise run test`

AI assistance disclosure: Claude Code (claude-fable-5) helped write the handler extraction, the test, the commit messages, and this description.