### PR TITLE
Test queue message wrapping in @fedify/cfworkers

### DIFF
--- a/packages/cfworkers/src/mod.test.ts
+++ b/packages/cfworkers/src/mod.test.ts
@@ -351,4 +351,26 @@ describe("WorkersMessageQueue", () => {
     expect(second.shouldProcess).toBe(true);
     expect(second.message).toEqual({ id: "second" });
   });
+
+  it("enqueue() sends __fedify_ordering_key__ and __fedify_payload__ to the queue binding", async () => {
+    let sentMessage: unknown;
+
+    const queueBinding = {
+      send: (message: unknown) => {
+        sentMessage = message;
+      },
+    } as unknown as Queue;
+
+    const queue = new WorkersMessageQueue(queueBinding);
+
+    await queue.enqueue(
+      { id: "test-message" },
+      { orderingKey: "actor-1" },
+    );
+
+    expect(sentMessage).toEqual({
+      __fedify_ordering_key__: "actor-1",
+      __fedify_payload__: { id: "test-message" },
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Add a test for `WorkersMessageQueue.enqueue()` to verify that the queue binding receives the message wrapped with `__fedify_ordering_key__` and `__fedify_payload__`.

Fixes #877 

## Test plan

* `mise run check-each cfworkers`

## AI disclosure

This change was written with assistance from Codex:gpt-5.6-luna, reviewed and verified by me.