### PR TITLE
Cover held ordering locks in cfworkers

### DIFF
--- a/packages/cfworkers/src/mod.test.ts
+++ b/packages/cfworkers/src/mod.test.ts
@@ -373,4 +373,26 @@ describe("WorkersMessageQueue", () => {
       __fedify_payload__: { id: "test-message" },
     });
   });
+
+  it("processMessage() - returns shouldProcess=false when lock exists", async () => {
+    const orderingKv = new MockKvNamespace();
+    const queue = new WorkersMessageQueue(mockQueue, { orderingKv });
+
+    const first = await queue.processMessage({
+      __fedify_ordering_key__: "key1",
+      __fedify_payload__: { id: "first" },
+    });
+
+    expect(first.shouldProcess).toBe(true);
+    expect(first.message).toEqual({ id: "first" });
+
+    const second = await queue.processMessage({
+      __fedify_ordering_key__: "key1",
+      __fedify_payload__: { id: "second" },
+    });
+
+    expect(second.shouldProcess).toBe(false);
+    expect(second.message).toBeUndefined();
+    expect(second.release).toBeUndefined();
+  });
 });


### PR DESCRIPTION
Closes #879.

`WorkersMessageQueue.processMessage()` returns `shouldProcess: false` when an ordering key lock is already held, which is what tells a queue handler to retry the message instead of running it out of order. `src/mod.test.ts` covered the lock being taken and released, but never the already-held case.

`test/mq.test.ts` already covers that branch, but it stubs `get()` to return a lock unconditionally, so the lock key itself is never exercised. This test takes the lock with a real `processMessage()` call and then sends a second message for the same ordering key without releasing it, which is the state a queue handler is in while the first message is still in flight. That also proves the key `processMessage()` writes is the one it later reads back.


Checks
------

 -  `mise run check-each cfworkers` — passes.
 -  `vitest run` — 44 tests pass across 3 files.
 -  Confirmed the test is not vacuous: replacing the lock check in `processMessage()` with `if (false)` makes it fail with `expected true to be false`, and it passes again once reverted.

Rebased onto `main` after #1016 touched the same file; both tests coexist.

No changelog fragment, since this is test-only work; the commit carries `Changelog: none`.


AI disclosure
-------------

Per *AI\_POLICY.md*: I wrote the test myself. Claude Code (claude-opus-5) helped diagnose why my first attempt asserted against the lock-acquire path instead of the lock-exists path, and ran the checks listed above. The commit carries the `Assisted-by: Claude Code:claude-opus-5` trailer.
