### PR TITLE
Test expired KV entries in @fedify/cfworkers

### DIFF
--- a/packages/cfworkers/test/kv.test.ts
+++ b/packages/cfworkers/test/kv.test.ts
@@ -36,11 +36,23 @@ describe("WorkersKvStore", () => {
     await env.KV1.put(
       JSON.stringify(["expired", "test"]),
       JSON.stringify("stale-value"),
-      { expirationTtl: 60, metadata: { expires: Date.now() - 1000 } },
+      {expirationTtl: 60, metadata: {expires : Date.now() - 1000}},
     );
 
     expect(await store.get(["expired", "test"])).toBeUndefined();
   });
+
+  it("get() - includes unexpired entry", async () => {
+    const store = new WorkersKvStore(env.KV1);
+
+    await env.KV1.put(
+      JSON.stringify(["fresh", "test"]),
+      JSON.stringify("live-value"),
+      { expirationTtl: 60, metadata: { expires: Date.now() + 60_000 }},
+    );
+
+    expect(await store.get(["fresh", "test"])).toBe("live-value");
+  })
 
   it("delete()", async () => {
     const store = new WorkersKvStore(env.KV1);
@@ -72,6 +84,8 @@ describe("WorkersKvStore", () => {
     expect(entries.some((e) => e.key[1] === "b")).toBe(true);
     expect(entries.some((e) => e.key[1] === "nested")).toBe(true);
   });
+
+
 
   it("list() - single element key", async () => {
     const store = new WorkersKvStore(env.KV1);

--- a/packages/cfworkers/test/kv.test.ts
+++ b/packages/cfworkers/test/kv.test.ts
@@ -36,7 +36,7 @@ describe("WorkersKvStore", () => {
     await env.KV1.put(
       JSON.stringify(["expired", "test"]),
       JSON.stringify("stale-value"),
-      {expirationTtl: 60, metadata: {expires : Date.now() - 1000}},
+      { expirationTtl: 60, metadata: { expires: Date.now() - 1000 } },
     );
 
     expect(await store.get(["expired", "test"])).toBeUndefined();
@@ -48,11 +48,11 @@ describe("WorkersKvStore", () => {
     await env.KV1.put(
       JSON.stringify(["fresh", "test"]),
       JSON.stringify("live-value"),
-      { expirationTtl: 60, metadata: { expires: Date.now() + 60_000 }},
+      { expirationTtl: 60, metadata: { expires: Date.now() + 60_000 } },
     );
 
     expect(await store.get(["fresh", "test"])).toBe("live-value");
-  })
+  });
 
   it("delete()", async () => {
     const store = new WorkersKvStore(env.KV1);
@@ -85,7 +85,32 @@ describe("WorkersKvStore", () => {
     expect(entries.some((e) => e.key[1] === "nested")).toBe(true);
   });
 
+  it("list() - excludes expired entries", async () => {
+    const store = new WorkersKvStore(env.KV1);
 
+    await env.KV1.put(
+      JSON.stringify(["expired-list"]),
+      JSON.stringify("stale-root"),
+      { expirationTtl: 60, metadata: { expires: Date.now() - 1000 } },
+    );
+
+    await env.KV1.put(
+      JSON.stringify(["expired-list", "stale"]),
+      JSON.stringify("stale-child"),
+      { expirationTtl: 60, metadata: { expires: Date.now() - 1000 } },
+    );
+
+    await store.set(["expired-list", "fresh"], "fresh-child");
+
+    const entries: { key: readonly unknown[]; value: unknown }[] = [];
+    for await (const entry of store.list(["expired-list"])) {
+      entries.push({ key: entry.key, value: entry.value });
+    }
+
+    expect(entries).toEqual([
+      { key: ["expired-list", "fresh"], value: "fresh-child" },
+    ]);
+  });
 
   it("list() - single element key", async () => {
     const store = new WorkersKvStore(env.KV1);

--- a/packages/cfworkers/test/kv.test.ts
+++ b/packages/cfworkers/test/kv.test.ts
@@ -30,6 +30,18 @@ describe("WorkersKvStore", () => {
     expect(await store.get(["ttl", "test"])).toBe("ttl-value");
   });
 
+  it("get() - excludes expired entry", async () => {
+    const store = new WorkersKvStore(env.KV1);
+
+    await env.KV1.put(
+      JSON.stringify(["expired", "test"]),
+      JSON.stringify("stale-value"),
+      { expirationTtl: 60, metadata: { expires: Date.now() - 1000 } },
+    );
+
+    expect(await store.get(["expired", "test"])).toBeUndefined();
+  });
+
   it("delete()", async () => {
     const store = new WorkersKvStore(env.KV1);
 


### PR DESCRIPTION
Closes #876

## Background

`@fedify/cfworkers`'s `WorkersKvStore` applies its own expiry check via a `metadata.expires` field, independent of Workers KV's native TTL (Workers KV enforces a 60-second minimum TTL and doesn't expire entries immediately).
`src/mod.test.ts` already had unit tests for this against a hand-written mock namespace (added in #987), but the miniflare-backed integration suite in `test/kv.test.ts` — which exercises the real KV binding — only tested that `set()` with a TTL stores the metadata, not that an expired entry is actually excluded when read back.

## Changes

Add tests in *packages/cfworkers/test/kv.test.ts* that seed an already-expired entry directly via `env.KV1.put()` (bypassing `set()`'s 60-second TTL floor) and verify:

- `get()` excludes an expired entry.
- `get()` still returns an entry whose expiry is in the future.
- `list()` excludes expired entries, for both the exact-prefix key and matching children.

## Testing

- `pnpm --filter @fedify/cfworkers test` (all 47 tests pass, including the 3 new ones)

## AI disclosure

Tests were written by me. Claude Code (`claude-sonnet-5`) helped me find the gap between the mocked unit coverage and the real-binding integration suite, explained the pattern for seeding an already-expired entry via a direct `put()` call, and pointed out a couple of formatting issues and one test-assertion bug (comparing an array to a bare object) that I then fixed myself.