### PR TITLE
Add `actor-preferred-username-required` lint rule

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -233,6 +233,12 @@ To be released.
         `endpoints.uploadMedia` is not built with
         `ctx.getMediaUploaderUri(identifier)`.
 
+ -  Added the `actor-preferred-username-required` lint rule, which warns
+    when an actor dispatcher's return value does not include a
+    `preferredUsername` property. [[#895]]
+
+[#895]: https://github.com/fedify-dev/fedify/issues/895
+
 ### @fedify/mysql
 
  -  Fixed the CommonJS MySQL adapter build so it no longer requires

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -235,9 +235,10 @@ To be released.
 
  -  Added the `actor-preferred-username-required` lint rule, which warns
     when an actor dispatcher's return value does not include a
-    `preferredUsername` property. [[#895]]
+    `preferredUsername` property. [[#895], [#1022] by Jae-Hyuk-Jang\]
 
 [#895]: https://github.com/fedify-dev/fedify/issues/895
+[#1022]: https://github.com/fedify-dev/fedify/pull/1022
 
 ### @fedify/mysql
 

--- a/changes.d/lint/actor-preferred-username-rule.md
+++ b/changes.d/lint/actor-preferred-username-rule.md
@@ -1,3 +1,8 @@
+---
+links:
+  '#1022': https://github.com/fedify-dev/fedify/pull/1022
+  '#895': https://github.com/fedify-dev/fedify/issues/895
+---
  -  Added the `actor-preferred-username-required` lint rule, which warns
     when an actor dispatcher's return value does not include a
-    `preferredUsername` property. [[#895]]
+    `preferredUsername` property. [[#895], [#1022] by Jae-Hyuk-Jang]

--- a/changes.d/lint/actor-preferred-username-rule.md
+++ b/changes.d/lint/actor-preferred-username-rule.md
@@ -1,0 +1,3 @@
+ -  Added the `actor-preferred-username-required` lint rule, which warns
+    when an actor dispatcher's return value does not include a
+    `preferredUsername` property. [[#895]]

--- a/docs/manual/lint.md
+++ b/docs/manual/lint.md
@@ -559,9 +559,9 @@ federation
 
 ### `actor-preferred-username-required`
 
-Ensures actors have a `preferredUsername` property.
-
 *This rule is introduced in Fedify 2.4.0.*
+
+Ensures actors have a `preferredUsername` property.
 
 **When this rule applies:**
 The actor dispatcher is configured with `setActorDispatcher()`, but the actor

--- a/docs/manual/lint.md
+++ b/docs/manual/lint.md
@@ -561,6 +561,8 @@ federation
 
 Ensures actors have a `preferredUsername` property.
 
+*This rule is introduced in Fedify 2.4.0.*
+
 **When this rule applies:**
 The actor dispatcher is configured with `setActorDispatcher()`, but the actor
 object doesn't include a `preferredUsername` property.

--- a/docs/manual/lint.md
+++ b/docs/manual/lint.md
@@ -557,6 +557,43 @@ federation
 
 [Object Integrity Proofs]: ./send.md#object-integrity-proofs
 
+### `actor-preferred-username-required`
+
+Ensures actors have a `preferredUsername` property.
+
+**When this rule applies:**
+The actor dispatcher is configured with `setActorDispatcher()`, but the actor
+object doesn't include a `preferredUsername` property.
+
+**Why it matters:**
+Most fediverse software expects actors to expose a stable
+`preferredUsername`.  Omitting it tends to make remote display, search, and
+profile rendering worse, even though Fedify itself doesn't require it.
+
+~~~~ typescript twoslash
+// @noErrors: 2345
+import { createFederation } from "@fedify/fedify";
+import { Person } from "@fedify/vocab";
+const federation = createFederation<void>({ kv: null as any });
+// ---cut-before---
+// ❌ Bad: Missing preferredUsername property
+federation.setActorDispatcher("/users/{identifier}", (ctx, identifier) => {
+  return new Person({
+    id: ctx.getActorUri(identifier),
+    name: "John Doe",  // No preferredUsername!
+  });
+});
+
+// ✅ Good: Include preferredUsername property
+federation.setActorDispatcher("/users/{identifier}", (ctx, identifier) => {
+  return new Person({
+    id: ctx.getActorUri(identifier),
+    preferredUsername: identifier,
+    name: "John Doe",
+  });
+});
+~~~~
+
 ### `actor-inbox-property-required`
 
 Ensures `inbox` is defined when `setInboxListeners()` is configured.

--- a/packages/lint/src/index.ts
+++ b/packages/lint/src/index.ts
@@ -55,6 +55,9 @@ import {
   eslint as actorOutboxPropertyRequired,
 } from "./rules/actor-outbox-property-required.ts";
 import {
+  eslint as actorPreferredUsernameRequired,
+} from "./rules/actor-preferred-username-required.ts";
+import {
   eslint as actorPublicKeyRequired,
 } from "./rules/actor-public-key-required.ts";
 import {
@@ -110,6 +113,7 @@ const rules: Record<
   [RULE_IDS.actorUploadMediaPropertyMismatch]: actorUploadMediaPropertyMismatch,
   [RULE_IDS.actorPublicKeyRequired]: actorPublicKeyRequired,
   [RULE_IDS.actorAssertionMethodRequired]: actorAssertionMethodRequired,
+  [RULE_IDS.actorPreferredUsernameRequired]: actorPreferredUsernameRequired,
   [RULE_IDS.collectionFilteringNotImplemented]: collectionFiltering,
   [RULE_IDS.outboxListenerDeliveryRequired]: outboxListenerDeliveryRequired,
   [RULE_IDS.mediaUploaderObjectUriRequired]: mediaUploaderObjectUriRequired,

--- a/packages/lint/src/lib/const.ts
+++ b/packages/lint/src/lib/const.ts
@@ -114,6 +114,12 @@ export const properties = {
     requiresIdentifier: true,
     isKeyProperty: true,
   },
+  preferredUsername: {
+    name: "preferredUsername",
+    path: ["preferredUsername"],
+    setter: "setActorDispatcher",
+    requiresIdentifier: false,
+  },
 } as const satisfies Record<string, PropertyConfig>;
 
 /**
@@ -133,6 +139,7 @@ export const RULE_IDS = {
   actorUploadMediaPropertyRequired: "actor-upload-media-property-required",
   actorPublicKeyRequired: "actor-public-key-required",
   actorAssertionMethodRequired: "actor-assertion-method-required",
+  actorPreferredUsernameRequired: "actor-preferred-username-required",
 
   // Mismatch rules
   actorIdMismatch: "actor-id-mismatch",

--- a/packages/lint/src/lib/const.ts
+++ b/packages/lint/src/lib/const.ts
@@ -119,6 +119,7 @@ export const properties = {
     path: ["preferredUsername"],
     setter: "setActorDispatcher",
     requiresIdentifier: false,
+    pluralName: "preferredUsernames",
   },
 } as const satisfies Record<string, PropertyConfig>;
 

--- a/packages/lint/src/lib/messages.ts
+++ b/packages/lint/src/lib/messages.ts
@@ -11,18 +11,24 @@ export const actorPropertyRequired = ({
   path,
   getter,
   requiresIdentifier = true,
-}: PropertyConfig): string =>
-  `When \`${setter}\` is configured, the \`${
-    path.join(".")
-  }\` property is recommended. Use \`${
-    getExpectedCall({
-      ctxName: "Context",
-      methodName: getter,
-      idName: "identifier",
-      path: path.join("."),
-      requiresIdentifier,
-    })
-  }\` for the \`${path.join(".")}\` property URI.`;
+}: PropertyConfig): string => {
+  const propertyPath = path.join(".");
+
+  const recommendation = getter == null
+    ? `Set the \`${propertyPath}\` property directly on the actor object.`
+    : `Use \`${
+      getExpectedCall({
+        ctxName: "Context",
+        methodName: getter,
+        idName: "identifier",
+        path: path.join("."),
+        requiresIdentifier,
+      })
+    }\` for the \`${propertyPath}\` property URI.`;
+
+  return `When \`${setter}\` is configured, the \`${propertyPath}\` ` +
+    `property is recommended. ${recommendation}`;
+};
 
 /**
  * Generates error message for *-mismatch rules.

--- a/packages/lint/src/lib/mismatch.ts
+++ b/packages/lint/src/lib/mismatch.ts
@@ -78,7 +78,7 @@ const getNameIfIdentifier = (node: Parameter): string | null =>
   node?.type === "Identifier" ? node.name : null;
 
 function createMismatchRule<Context = Deno.lint.RuleContext | Rule.RuleContext>(
-  config: PropertyConfig,
+  config: PropertyConfig & { getter: string },
   describe: (
     methodCallContext: MethodCallContext,
   ) => Context extends Deno.lint.RuleContext ? {
@@ -152,7 +152,7 @@ function createMismatchRule<Context = Deno.lint.RuleContext | Rule.RuleContext>(
  * @returns A Deno lint rule
  */
 export const createMismatchRuleDeno = (
-  config: PropertyConfig,
+  config: PropertyConfig & { getter: string },
 ): Deno.lint.Rule => ({
   create: createMismatchRule(
     config,
@@ -163,7 +163,7 @@ export const createMismatchRuleDeno = (
 });
 
 export const createMismatchRuleEslint = (
-  config: PropertyConfig,
+  config: PropertyConfig & { getter: string },
 ): Rule.RuleModule => ({
   meta: {
     type: "problem",

--- a/packages/lint/src/lib/property-checker.ts
+++ b/packages/lint/src/lib/property-checker.ts
@@ -224,6 +224,7 @@ export const createPropertySearcher = (propertyChecker: PropertyChecker) => {
         return checkAllReturnPaths(propertyChecker)(node);
 
       case "NewExpression":
+        if (isTombstoneExpression(node)) return true;
         return pipe(
           node,
           extractFirstObjectExpression,

--- a/packages/lint/src/lib/property-checker.ts
+++ b/packages/lint/src/lib/property-checker.ts
@@ -126,14 +126,23 @@ const unwrapTypeScriptExpression = (node: Expression): Expression => {
 const isNullLiteral = (node: Expression): boolean =>
   node.type === "Literal" && node.value === null;
 
+const isTombstoneExpression = (node: Expression): boolean =>
+  node.type === "NewExpression" &&
+  node.callee.type === "Identifier" &&
+  node.callee.name === "Tombstone";
+
 // Check if both branches have the property
 const checkBranchWith =
   (propertyChecker: PropertyChecker) => (branch: Expression): boolean => {
     const expression = unwrapTypeScriptExpression(branch);
 
     // A null return means that no actor was found, so there is no actor object
-    // whose properties need to be checked.
-    if (isNullLiteral(expression)) return true;
+    // whose properties need to be checked. A Tombstone return means the actor
+    // was deleted, which ActorDispatcher explicitly permits, so it likewise
+    // has no actor properties to check.
+    if (isNullLiteral(expression) || isTombstoneExpression(expression)) {
+      return true;
+    }
 
     return pipe(
       expression,

--- a/packages/lint/src/lib/required.ts
+++ b/packages/lint/src/lib/required.ts
@@ -77,7 +77,17 @@ function createRequiredRule<Context = Deno.lint.RuleContext | Rule.RuleContext>(
     const propertyChecker = createPropertyChecker(Boolean)(
       config.path,
     );
-    const propertySearcher = createPropertySearcher(propertyChecker);
+    const pluralPropertyChecker = config.pluralName == null ? null : (
+      createPropertyChecker(Boolean)([
+        ...config.path.slice(0, -1),
+        config.pluralName,
+      ])
+    );
+    const propertySearcher = createPropertySearcher(
+      pluralPropertyChecker == null
+        ? propertyChecker
+        : (node) => propertyChecker(node) || pluralPropertyChecker(node),
+    );
 
     return {
       VariableDeclarator: federationTracker.VariableDeclarator,

--- a/packages/lint/src/lib/test-templates.ts
+++ b/packages/lint/src/lib/test-templates.ts
@@ -543,6 +543,21 @@ export function createPreferredUsernameRequiredRuleTests(
       }),
       false,
     ],
+
+    // ✅ Good - concise-body dispatcher returning only a Tombstone
+    "concise-body dispatcher returning only a Tombstone": [
+      lintTest({
+        code: `
+federation.setActorDispatcher(
+  "/users/{identifier}",
+  (ctx, identifier) => new Tombstone({ id: ctx.getActorUri(identifier) }),
+);
+`,
+        rule,
+        ruleName,
+      }),
+      true,
+    ],
   };
 }
 

--- a/packages/lint/src/lib/test-templates.ts
+++ b/packages/lint/src/lib/test-templates.ts
@@ -8,6 +8,20 @@ import type { MethodCallContext, PropertyConfig } from "./types.ts";
 
 type PropertyKey = keyof typeof properties;
 
+/**
+ * Property keys whose config has a `getter` — the subset mismatch rules
+ * apply to (a property with no Context getter, like `preferredUsername`,
+ * cannot be "mismatched" against one).
+ */
+type PropertyKeyWithGetter = {
+  [K in PropertyKey]: (typeof properties)[K] extends { getter: string } ? K
+    : never;
+}[PropertyKey];
+
+/** Safely reads a property config's `getter`, if it has one. */
+const getterOf = (p: PropertyConfig): string | undefined =>
+  "getter" in p ? p.getter : undefined;
+
 interface TestConfig {
   rule: {
     deno: Deno.lint.Rule;
@@ -109,7 +123,7 @@ const createPropertyAssignment = (
   const idName = options.idName ?? "identifier";
   const requiresIdentifier = prop.requiresIdentifier ?? true;
 
-  const methodCall = createMethodCall(
+  const methodCall = getter == null ? `"example-value"` : createMethodCall(
     getter,
     requiresIdentifier,
     ctxName,
@@ -134,7 +148,7 @@ const createMethodCallContext = (
   path: prop.path.join("."),
   ctxName,
   idName,
-  methodName: prop.getter,
+  methodName: prop.getter!,
   requiresIdentifier: prop.requiresIdentifier ?? true,
 });
 
@@ -408,6 +422,117 @@ export function createIdRequiredRuleTests(config: TestConfig): TestSuite {
   };
 }
 
+/**
+ * Creates required rule tests for `preferredUsername`, which — like `id` —
+ * uses `setActorDispatcher` as its own setter, so the generic
+ * `createRequiredDispatcherRuleTests` (built for properties with a separate
+ * setter such as `setInboxListeners`) does not apply. Unlike `id`, it has no
+ * getter, so its "good" cases use a plain literal instead of a context call.
+ */
+export function createPreferredUsernameRequiredRuleTests(
+  config: TestConfig,
+): TestSuite {
+  const { rule, ruleName } = config;
+  const expectedError = actorPropertyRequired(properties.preferredUsername);
+
+  return {
+    // ✅ Good - non-Federation object
+    "non-federation object": [
+      lintTest({
+        code: createActorDispatcherCode(
+          `return new Person({ name: "John Doe" });`,
+        ),
+        rule,
+        ruleName,
+        federationSetup: `
+          const federation = { setActorDispatcher: () => {} };
+        `,
+      }),
+      true,
+    ],
+
+    // ✅ Good - with preferredUsername property
+    "with preferredUsername property": [
+      lintTest({
+        code: createActorDispatcherCode(`return new Person({
+          preferredUsername: identifier,
+          name: "John Doe",
+        });`),
+        rule,
+        ruleName,
+      }),
+      true,
+    ],
+
+    // ✅ Good - BlockStatement with preferredUsername
+    "block statement with preferredUsername": [
+      lintTest({
+        code: createActorDispatcherCode(`const name = "John Doe";
+        return new Person({
+          preferredUsername: identifier,
+          name,
+        });`),
+        rule,
+        ruleName,
+      }),
+      true,
+    ],
+
+    // ❌ Bad - without preferredUsername property
+    "without preferredUsername property": [
+      lintTest({
+        code: createActorDispatcherCode(
+          `return new Person({ name: "John Doe" });`,
+        ),
+        rule,
+        ruleName,
+        expectedError,
+      }),
+      false,
+    ],
+
+    // ❌ Bad - returning empty object
+    "returning empty object": [
+      lintTest({
+        code: createActorDispatcherCode(`return new Person({});`),
+        rule,
+        ruleName,
+        expectedError,
+      }),
+      false,
+    ],
+
+    // ✅ Good - multiple properties including preferredUsername
+    "multiple properties including preferredUsername": [
+      lintTest({
+        code: createActorDispatcherCode(`return new Person({
+          preferredUsername: identifier,
+          name: "John Doe",
+          inbox: ctx.getInboxUri(identifier),
+          outbox: ctx.getOutboxUri(identifier),
+        });`),
+        rule,
+        ruleName,
+      }),
+      true,
+    ],
+
+    // ❌ Bad - variable assignment without preferredUsername
+    "variable assignment without preferredUsername": [
+      lintTest({
+        code: createActorDispatcherCode(
+          `const actor = new Person({ name: "John Doe" });
+        return actor;`,
+        ),
+        rule,
+        ruleName,
+        expectedError,
+      }),
+      false,
+    ],
+  };
+}
+
 // =============================================================================
 // Mismatch Rule Tests
 // =============================================================================
@@ -416,7 +541,7 @@ export function createIdRequiredRuleTests(config: TestConfig): TestSuite {
  * Creates mismatch rule tests for standard properties
  */
 export function createMismatchRuleTests(
-  propertyKey: PropertyKey,
+  propertyKey: PropertyKeyWithGetter,
   config: TestConfig,
 ): TestSuite {
   const { rule, ruleName } = config;
@@ -427,8 +552,10 @@ export function createMismatchRuleTests(
 
   // Find a wrong getter for testing
   const wrongGetters = Object.values(properties)
-    .filter((p) => p.getter !== prop.getter)
-    .map((p) => p.getter);
+    .map(getterOf)
+    .filter((getter): getter is string =>
+      getter != null && getter !== prop.getter
+    );
   const wrongGetter = wrongGetters[0] || "getWrongUri";
   const wrongSetter = Object.values(properties)
     .filter((p) => p.setter !== prop.setter)
@@ -940,7 +1067,7 @@ return new Person({ ${ID_PROP} name: "C" });`,
  * Creates common edge case tests for mismatch rules
  */
 export function createMismatchEdgeCaseTests(
-  propertyKey: PropertyKey,
+  propertyKey: PropertyKeyWithGetter,
   config: TestConfig,
 ): TestSuite {
   const { rule, ruleName } = config;
@@ -951,8 +1078,10 @@ export function createMismatchEdgeCaseTests(
 
   // Find a wrong getter for testing
   const wrongGetters = Object.values(properties)
-    .filter((p) => p.getter !== prop.getter)
-    .map((p) => p.getter);
+    .map(getterOf)
+    .filter((getter): getter is string =>
+      getter != null && getter !== prop.getter
+    );
   const wrongGetter = wrongGetters[0] || "getWrongUri";
 
   const createLocalPropertyCode = (getter: string) =>

--- a/packages/lint/src/lib/test-templates.ts
+++ b/packages/lint/src/lib/test-templates.ts
@@ -464,6 +464,19 @@ export function createPreferredUsernameRequiredRuleTests(
       true,
     ],
 
+    // ✅ Good - with plural preferredUsernames property
+    "with preferredUsernames (plural) property": [
+      lintTest({
+        code: createActorDispatcherCode(`return new Person({
+          preferredUsernames: [identifier],
+          name: "John Doe",
+        });`),
+        rule,
+        ruleName,
+      }),
+      true,
+    ],
+
     // ✅ Good - BlockStatement with preferredUsername
     "block statement with preferredUsername": [
       lintTest({

--- a/packages/lint/src/lib/test-templates.ts
+++ b/packages/lint/src/lib/test-templates.ts
@@ -816,6 +816,34 @@ return new Person({ ${ID_PROP} name: "A" });`,
         true,
       ],
 
+      // ✅ Dispatcher returns only a Tombstone (e.g. a deleted actor)
+      "returns only a Tombstone": [
+        lintTest({
+          code: createDispatcherCode(
+            `return new Tombstone({ id: ctx.getActorUri(identifier) });`,
+            setter,
+          ),
+          rule,
+          ruleName,
+        }),
+        true,
+      ],
+
+      // ✅ Ternary with Tombstone and property in actor branch
+      "ternary with Tombstone and property in actor branch": [
+        lintTest({
+          code: createDispatcherCode(
+            `return condition
+    ? new Tombstone({ id: ctx.getActorUri(identifier) })
+    : new Person({ ${ID_PROP} ${propCode} name: "A" });`,
+            setter,
+          ),
+          rule,
+          ruleName,
+        }),
+        true,
+      ],
+
       // ✅ Ternary with property in both branches
       "ternary with property in both branches": [
         lintTest({

--- a/packages/lint/src/lib/types.ts
+++ b/packages/lint/src/lib/types.ts
@@ -87,7 +87,7 @@ export interface PropertyConfig {
    */
   path: readonly string[];
   /** Context method name to get the URI (e.g., "getActorUri", "getInboxUri") */
-  getter: string;
+  getter?: string;
   /**
    * Dispatcher/Listener method name
    * (e.g., "setActorDispatcher", "setInboxListeners")

--- a/packages/lint/src/lib/types.ts
+++ b/packages/lint/src/lib/types.ts
@@ -95,6 +95,13 @@ export interface PropertyConfig {
   setter: string;
   /** Whether the getter requires an identifier parameter (default: true) */
   requiresIdentifier: boolean;
+  /**
+   * Plural form of the property name that also satisfies this check
+   * (e.g., "preferredUsernames" for "preferredUsername"), for vocabulary
+   * properties whose constructors accept a plural initializer as sugar for
+   * the singular one.
+   */
+  pluralName?: string;
   /** Nested property configuration, if this property is nested inside another */
   nested?: NestedPropertyConfig;
   /** Whether this is a key-related property (uses getActorKeyPairs) */

--- a/packages/lint/src/mod.ts
+++ b/packages/lint/src/mod.ts
@@ -47,6 +47,9 @@ import {
   deno as actorOutboxPropertyRequired,
 } from "./rules/actor-outbox-property-required.ts";
 import {
+  deno as actorPreferredUsernameRequired,
+} from "./rules/actor-preferred-username-required.ts";
+import {
   deno as actorPublicKeyRequired,
 } from "./rules/actor-public-key-required.ts";
 import {
@@ -105,6 +108,7 @@ const plugin: Deno.lint.Plugin = {
       actorUploadMediaPropertyMismatch,
     [RULE_IDS.actorPublicKeyRequired]: actorPublicKeyRequired,
     [RULE_IDS.actorAssertionMethodRequired]: actorAssertionMethodRequired,
+    [RULE_IDS.actorPreferredUsernameRequired]: actorPreferredUsernameRequired,
     [RULE_IDS.collectionFilteringNotImplemented]: collectionFiltering,
     [RULE_IDS.outboxListenerDeliveryRequired]: outboxListenerDeliveryRequired,
     [RULE_IDS.mediaUploaderObjectUriRequired]: mediaUploaderObjectUriRequired,

--- a/packages/lint/src/oxlint.ts
+++ b/packages/lint/src/oxlint.ts
@@ -66,6 +66,9 @@ import {
   eslint as actorOutboxPropertyRequired,
 } from "./rules/actor-outbox-property-required.ts";
 import {
+  eslint as actorPreferredUsernameRequired,
+} from "./rules/actor-preferred-username-required.ts";
+import {
   eslint as actorPublicKeyRequired,
 } from "./rules/actor-public-key-required.ts";
 import {
@@ -121,6 +124,7 @@ const rules: Record<
   [RULE_IDS.actorUploadMediaPropertyMismatch]: actorUploadMediaPropertyMismatch,
   [RULE_IDS.actorPublicKeyRequired]: actorPublicKeyRequired,
   [RULE_IDS.actorAssertionMethodRequired]: actorAssertionMethodRequired,
+  [RULE_IDS.actorPreferredUsernameRequired]: actorPreferredUsernameRequired,
   [RULE_IDS.collectionFilteringNotImplemented]: collectionFiltering,
   [RULE_IDS.outboxListenerDeliveryRequired]: outboxListenerDeliveryRequired,
   [RULE_IDS.mediaUploaderObjectUriRequired]: mediaUploaderObjectUriRequired,

--- a/packages/lint/src/rules/actor-preferred-username-required.ts
+++ b/packages/lint/src/rules/actor-preferred-username-required.ts
@@ -1,0 +1,8 @@
+import { properties } from "../lib/const.ts";
+import {
+  createRequiredRuleDeno,
+  createRequiredRuleEslint,
+} from "../lib/required.ts";
+
+export const deno = createRequiredRuleDeno(properties.preferredUsername);
+export const eslint = createRequiredRuleEslint(properties.preferredUsername);

--- a/packages/lint/src/tests/actor-preferred-username-required.test.ts
+++ b/packages/lint/src/tests/actor-preferred-username-required.test.ts
@@ -1,0 +1,13 @@
+import { RULE_IDS } from "../lib/const.ts";
+import {
+  createPreferredUsernameRequiredRuleTests,
+  createRequiredEdgeCaseTests,
+  runTests,
+} from "../lib/test-templates.ts";
+import * as rule from "../rules/actor-preferred-username-required.ts";
+
+const ruleName = RULE_IDS.actorPreferredUsernameRequired;
+const config = { rule, ruleName };
+
+runTests(ruleName, createPreferredUsernameRequiredRuleTests(config));
+runTests(ruleName, createRequiredEdgeCaseTests("preferredUsername", config));

--- a/packages/lint/src/tests/integration.test.ts
+++ b/packages/lint/src/tests/integration.test.ts
@@ -146,6 +146,7 @@ federation
     return new Person({
       id: ctx.getActorUri(identifier),
       name: "John Doe",
+      preferredUsername: identifier,
       summary: "A test actor for comprehensive lint rule validation",
       inbox: ctx.getInboxUri(identifier),
       endpoints: new Endpoints({
@@ -372,6 +373,16 @@ test("Integration: ❌ actor-id-required - missing id property", () =>
       "// id: ctx.getActorUri(identifier), // REMOVED",
     ),
     assertHasError("actor-id-required"),
+  ));
+
+test("Integration: ❌ actor-preferred-username-required - missing preferred-username property", () =>
+  pipe(
+    COMPLETE_VALID_CODE,
+    replace(
+      "preferredUsername: identifier,",
+      "// preferredUsername: identifier, // REMOVED",
+    ),
+    assertHasError("actor-preferred-username-required"),
   ));
 
 test(


### PR DESCRIPTION
Closes #895

## Background

Most fediverse software expects actor objects to expose a stable `preferredUsername`. Fedify applications can omit it, but that tends to make remote display, search, and profile rendering worse. `@fedify/lint` already has rules that check other required actor properties (`id`, `inbox`, `publicKey`, etc.), but none of them cover `preferredUsername`.

## Changes

- Add the `actor-preferred-username-required` rule (*packages/lint/src/rules/actor-preferred-username-required.ts*), warning when an actor dispatcher's return value omits `preferredUsername`. Register it in Deno Lint, ESLint, and Oxlint (*mod.ts*, *index.ts*, *oxlint.ts*).
- `preferredUsername` has no corresponding `Context` getter method, unlike every other required-property rule, so `PropertyConfig.getter` is now optional (*lib/types.ts*) and `actorPropertyRequired()` (*lib/messages.ts*) falls back to a simpler message when it's absent.
- Generalize *lib/test-templates.ts*, which assumed every property has a getter in a couple of places (property-assignment code generation, and the mismatch tests' "wrong getter" picker), and add a dedicated test factory for `preferredUsername` since its setter (`setActorDispatcher`) is self-referential like `id`'s, unlike the generic `createRequiredDispatcherRuleTests` template.
- Add tests in *tests/actor-preferred-username-required.test.ts* and update *tests/integration.test.ts*'s baseline fixture and add a dedicated integration case.
- Document the rule in *docs/manual/lint.md*.
- Add a changelog fragment.

## Testing

- `mise run check-each lint`
- `node --experimental-transform-types --test 'src/tests/**/*.test.ts'` from *packages/lint* (610 tests pass, including oxlint's real-binary lane)

## AI disclosure

This was a mix of work I wrote myself and code Claude Code (`claude-sonnet-5`) wrote after we worked through the design together — in particular, it found and fixed two issues my first attempts missed: `test-templates.ts` generating invalid example code (`ctx.undefined(identifier)`) for a getter-less property, and a type error in the mismatch-test helpers caused by the same change. I reviewed and verified all of it.