### PR TITLE
Add test `enqueueMany()` wrapped message shape  

### DIFF
--- a/packages/cfworkers/src/mod.test.ts
+++ b/packages/cfworkers/src/mod.test.ts
@@ -4,6 +4,7 @@ import {
   WorkersKvStore,
   WorkersMessageQueue,
 } from "./mod.ts";
+import type { Queue } from "@cloudflare/workers-types";
 
 // Mock Temporal.Duration for testing in Cloudflare Workers environment
 const mockDuration = (seconds: number) => ({
@@ -350,5 +351,99 @@ describe("WorkersMessageQueue", () => {
 
     expect(second.shouldProcess).toBe(true);
     expect(second.message).toEqual({ id: "second" });
+  });
+});
+
+interface MockWrappedMessage {
+  readonly __fedify_ordering_key__?: string;
+  readonly __fedify_payload__: unknown;
+}
+
+interface MockSendBatchOptions {
+  readonly delaySeconds?: number;
+}
+
+interface MockSendOptions {
+  readonly contentType?: string;
+  readonly delaySeconds?: number;
+}
+
+interface MockMessageSendRequest {
+  readonly body: MockWrappedMessage;
+  readonly contentType?: string;
+}
+
+class MockQueue {
+  sentSingles: {
+    wrapped: MockWrappedMessage;
+    options?: MockSendOptions;
+  }[] = [];
+  sentBatches: {
+    batch: MockMessageSendRequest[];
+    options?: MockSendBatchOptions;
+  }[] = [];
+
+  send(wrapped: MockWrappedMessage, options?: MockSendOptions) {
+    this.sentSingles.push({ wrapped, options });
+  }
+
+  sendBatch(batch: MockMessageSendRequest[], options?: MockSendBatchOptions) {
+    this.sentBatches.push({ batch, options });
+  }
+}
+
+describe("WorkersMessageQueue.enqueueMany() - wrapped message shape", () => {
+  it("enqueueMany() - wraps each message with body{} and contentType", async () => {
+    const sendingMockQueue = new MockQueue();
+    const queue = new WorkersMessageQueue(sendingMockQueue as unknown as Queue);
+
+    await queue.enqueueMany(["msg-1", "msg-2"], { orderingKey: "ferer" });
+
+    expect(sendingMockQueue.sentBatches).toHaveLength(1);
+    expect(sendingMockQueue.sentBatches[0].batch).toEqual([
+      {
+        body: {
+          __fedify_ordering_key__: "ferer",
+          __fedify_payload__: "msg-1",
+        },
+        contentType: "json",
+      },
+      {
+        body: {
+          __fedify_ordering_key__: "ferer",
+          __fedify_payload__: "msg-2",
+        },
+        contentType: "json",
+      },
+    ]);
+  });
+
+  it("enqueue() and enqueueMany() - produce the same wrapped shape", async () => {
+    const sendingMockQueue = new MockQueue();
+    const queue = new WorkersMessageQueue(sendingMockQueue as unknown as Queue);
+
+    await queue.enqueue("msg-1", { orderingKey: "ferer" });
+    await queue.enqueueMany(["msg-1"], { orderingKey: "ferer" });
+
+    // enqueueMany() wraps each body in a request ({ body, contentType }), so
+    // unwrap it before comparing against enqueue()'s bare wrapped message.
+    const singleWrapped = sendingMockQueue.sentSingles[0].wrapped;
+    const batchWrapped = sendingMockQueue.sentBatches[0].batch[0].body;
+
+    expect(batchWrapped).toEqual(singleWrapped);
+  });
+
+  it("enqueueMany() - omits ordering key when not provided", async () => {
+    const sendingMockQueue = new MockQueue();
+    const queue = new WorkersMessageQueue(sendingMockQueue as unknown as Queue);
+
+    await queue.enqueueMany(["msg-1"]);
+
+    expect(sendingMockQueue.sentBatches[0].batch[0].body).toEqual(
+      {
+        __fedify_ordering_key__: undefined,
+        __fedify_payload__: "msg-1",
+      },
+    );
   });
 });


### PR DESCRIPTION
## Summary

`WorkersMessageQueue.enqueueMany()` uses `sendBatch()` while `enqueue()`
uses `send()`, so nothing previously caught the two paths drifting apart
in how they wrap a message.

This adds three tests to *packages/cfworkers/src/mod.test.ts*:

1. `enqueueMany() - wraps each message with body{} and contentType`
    checks that each batch item is sent as `{ body, contentType }`.

2. `enqueue() and enqueueMany() - produce the same wrapped shape` calls
     both methods with the same input and compares the wrapped message
     each one produces, to catch shape drift between the two paths.

3. `enqueueMany() - omits ordering key when not provided` confirms the
     ordering key is left `undefined` (not defaulted to some other value)
     when none is given.

Closes #878

## Test plan
- `mise exec -- npx vitest run -t "enqueueMany"` while writing and
  checking each new test
- `deno fmt --check packages/cfworkers`
- `mise exec -- npx vitest run` inside *packages/cfworkers* — all 45
  tests pass (19 in *src/mod.test.ts*, up from 17)
- Confirmed the new tests fail when the behavior they pin is broken:
  renaming `__fedify_ordering_key__` to `__fedify_ordering_keyy__` in
  `enqueueMany()` failed 4 tests — mine, plus existing tests in
  *test/mq.test.ts* that check the same field — then reverted


## AI disclosure

Claude Code (`claude-sonnet-5`) assisted with this change: it explained
the mocking pattern this package already uses (`MockKvNamespace` in the
same file), TypeScript concepts , and pointed out issues in code I had already written (naming conflicts,
a type error from a missing `Queue` property). Allowing AI_POLICY.md, I typed every line of
the test code myself, made every naming and structure decision, and ran
all verification myself.


