### PR TITLE
Fix pnpm build approval so mise install succeeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,5 @@
 {
   "scripts": {
     "prepare": "pnpm -r run build:self"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "esbuild"
-    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,61 +1,71 @@
 packages:
-- packages/amqp
-- packages/astro
-- packages/backfill
-- packages/cfworkers
-- packages/cli
-- packages/debugger
-- packages/create
-- packages/elysia
-- packages/express
-- packages/fastify
-- packages/fedify
-- packages/fixture
-- packages/h3
-- packages/hono
-- packages/init
-- packages/interaction-controls
-- packages/koa
-- packages/lint
-- packages/mysql
-- packages/netlify
-- packages/nestjs
-- packages/next
-- packages/nuxt
-- packages/pglite
-- packages/postgres
-- packages/redis
-- packages/relay
-- packages/solidstart
-- packages/sqlite
-- packages/sveltekit
-- packages/testing
-- packages/uri-template
-- packages/vocab
-- packages/vocab-runtime
-- packages/vocab-tools
-- packages/webfinger
-- docs
-- examples/astro
-- examples/cloudflare-workers
-- examples/elysia
-- examples/express
-- examples/koa
-- examples/lint/oxlint
-- examples/next-integration
-- examples/fastify
-- examples/next14-app-router
-- examples/next15-app-router
-- examples/netlify-astro
-- examples/nuxt
-- examples/solidstart
-- examples/sveltekit-sample
+  - packages/amqp
+  - packages/astro
+  - packages/backfill
+  - packages/cfworkers
+  - packages/cli
+  - packages/debugger
+  - packages/create
+  - packages/elysia
+  - packages/express
+  - packages/fastify
+  - packages/fedify
+  - packages/fixture
+  - packages/h3
+  - packages/hono
+  - packages/init
+  - packages/interaction-controls
+  - packages/koa
+  - packages/lint
+  - packages/mysql
+  - packages/netlify
+  - packages/nestjs
+  - packages/next
+  - packages/nuxt
+  - packages/pglite
+  - packages/postgres
+  - packages/redis
+  - packages/relay
+  - packages/solidstart
+  - packages/sqlite
+  - packages/sveltekit
+  - packages/testing
+  - packages/uri-template
+  - packages/vocab
+  - packages/vocab-runtime
+  - packages/vocab-tools
+  - packages/webfinger
+  - docs
+  - examples/astro
+  - examples/cloudflare-workers
+  - examples/elysia
+  - examples/express
+  - examples/koa
+  - examples/lint/oxlint
+  - examples/next-integration
+  - examples/fastify
+  - examples/next14-app-router
+  - examples/next15-app-router
+  - examples/netlify-astro
+  - examples/nuxt
+  - examples/solidstart
+  - examples/sveltekit-sample
 
 allowBuilds:
+  '@netlify/content-engine': true
+  '@parcel/watcher': true
   '@tailwindcss/oxide': true
+  better-sqlite3: true
+  content-engine: true
+  contentful: true
+  es5-ext: false
   esbuild: true
+  lmdb: true
+  msgpackr-extract: true
+  netlify-cli: true
   protobufjs: true
   sharp: true
+  unix-dgram: false
   unrs-resolver: true
   workerd: true
 


### PR DESCRIPTION
Summary
----------

`mise install` currently fails on a fresh checkout. The `pnpm-install` deps provider aborts with `ERR_PNPM_IGNORED_BUILDS` because every listed dependency's build script is treated as unapproved.

Two things caused this. `package.json` declared `pnpm.onlyBuiltDependencies`, but pnpm 11.25.0 no longer reads that field from `package.json`; it now lives under `allowBuilds` in `pnpm-workspace.yaml`. `pnpm-workspace.yaml` already had an `allowBuilds` section, but most entries were left as the literal placeholder string `"set this to true or false"` instead of an actual boolean, so pnpm did not treat them as approved.

This PR removes the stale `pnpm.onlyBuiltDependencies` field and replaces the placeholder values with explicit `true`/`false` decisions, allowing builds for dependencies already trusted elsewhere in the workspace (`better-sqlite3`, `lmdb`, `msgpackr-extract`, `@parcel/watcher`, `@netlify/content-engine`, `content-engine`, `contentful`, `netlify-cli`) and disabling builds for two that don't need a native/postinstall step in this workspace (`es5-ext`, `unix-dgram`).

Related Links
--------------

- https://pnpm.io/blog/releases/11.0#allowbuilds-replaces-the-old-build-settings

AI disclosure
-------------

Diagnosed and fixed with assistance from Claude Code (Claude Sonnet 5): the tool ran `mise install`, read the pnpm error output, identified both root causes, and proposed the `allowBuilds`/`package.json` edits, which I reviewed before committing.